### PR TITLE
added support for specifying files by pattern

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,5 +1,6 @@
 # python
 .venv/
+.mypy_cache/
 __pycache__/
 
 # build and dist

--- a/cli/kleinkram/api/routes.py
+++ b/cli/kleinkram/api/routes.py
@@ -25,11 +25,11 @@ from kleinkram.models import MissionById
 from kleinkram.models import MissionByName
 from kleinkram.models import Project
 from kleinkram.models import TagType
+from kleinkram.utils import filtered_by_patterns
 from kleinkram.utils import is_valid_uuid4
 
 
-# TODO: change to 10000
-MAX_PAGINATION = 1_000
+MAX_PAGINATION = 10_000
 
 TEMP_CREDS = "/file/temporaryAccess"
 CLAIM_ADMIN = "/user/claimAdmin"
@@ -384,10 +384,16 @@ def get_files_by_file_spec(
         raise ValueError("mission not found")
 
     if spec.files:
+        file_ids = [id for id_ in spec.files if isinstance(id_, UUID)]
+        file_names = filtered_by_patterns(
+            [file.name for file in parsed_mission.files],
+            [name for name in spec.files if isinstance(name, str)],
+        )
+
         filtered = [
-            f
-            for f in parsed_mission.files
-            if f.id in spec.files or f.name in spec.files
+            file
+            for file in parsed_mission.files
+            if file.id in file_ids or file.name in file_names
         ]
         return filtered
 

--- a/cli/kleinkram/utils.py
+++ b/cli/kleinkram/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-import glob
+import fnmatch
 import hashlib
 import os
 import string
@@ -42,6 +42,14 @@ def check_file_paths(files: Sequence[Path]) -> None:
             raise FileTypeNotSupported(
                 f"only `.bag` or `.mcap` files are supported: {file}"
             )
+
+
+def filtered_by_patterns(names: Sequence[str], patterns: List[str]) -> List[str]:
+    filtered = []
+    for name in names:
+        if any(fnmatch.fnmatch(name, p) for p in patterns):
+            filtered.append(name)
+    return filtered
 
 
 def raw_rich(*objects: Any, **kwargs: Any) -> str:

--- a/cli/tests/test_utils.py
+++ b/cli/tests/test_utils.py
@@ -14,6 +14,7 @@ from kleinkram.models import MissionById
 from kleinkram.models import MissionByName
 from kleinkram.utils import b64_md5
 from kleinkram.utils import check_file_paths
+from kleinkram.utils import filtered_by_patterns
 from kleinkram.utils import get_filename
 from kleinkram.utils import get_filename_map
 from kleinkram.utils import get_valid_file_spec
@@ -45,6 +46,25 @@ def test_check_file_paths():
             check_file_paths([is_dir])
 
         assert check_file_paths([exists_bag, exits_mcap]) is None
+
+
+@pytest.mark.parametrize(
+    "names, patterns, expected",
+    [
+        pytest.param(["a.bag", "b.mcap"], ["*.bag"], ["a.bag"], id="one pattern"),
+        pytest.param(["a", "b", "c"], ["*"], ["a", "b", "c"], id="match all"),
+        pytest.param(["a", "b", "c"], ["*.bag"], [], id="no match"),
+        pytest.param(
+            ["a.bag", "b.mcap"],
+            ["*.bag", "*.mcap"],
+            ["a.bag", "b.mcap"],
+            id="all match",
+        ),
+        pytest.param(["a", "b", "c"], ["a", "b"], ["a", "b"], id="full name match"),
+    ],
+)
+def test_filtered_by_patterns(names, patterns, expected):
+    assert filtered_by_patterns(names, patterns) == expected
 
 
 def test_is_valid_uuid4():


### PR DESCRIPTION
changed the behaviour of `klein list files` to be equivalent to `klein download` the argument `files` now accepts uuid, filenames or filename patters. You can now do the following:
```bash
klein list files -p my-project -m my-mission "*.bag"
klein download -p my-project -m my-mission "*.bag"
```