### PR TITLE
feat(projects): add copy button for project uuid

### DIFF
--- a/frontend/src/pages/missions-explorer-page.vue
+++ b/frontend/src/pages/missions-explorer-page.vue
@@ -66,6 +66,16 @@
                                     </q-item-section>
                                 </q-item>
                             </edit-project-dialog-opener>
+                            <q-item
+                                    v-ripple
+                                    clickable
+                                    @click="copyDataToClipboard(projectUuid)"
+                                >
+                                    <q-item-section avatar>
+                                        <q-icon name="sym_o_fingerprint" />
+                                    </q-item-section>
+                                    <q-item-section> Copy UUID</q-item-section>
+                                </q-item>
                             <DeleteProjectDialogOpener
                                 :project-uuid="projectUuid ?? ''"
                                 :has-missions="(project?.missionCount ?? 0) > 0"
@@ -254,7 +264,7 @@ import KleinDownloadMissions from 'components/cli-links/klein-download-missions.
 import ExplorerPageMissionTable from 'components/explorer-page/explorer-page-mission-table.vue';
 import TitleSection from 'components/title-section.vue';
 import UploadMissionFolder from 'components/upload-mission-folder.vue';
-import { useQuasar } from 'quasar';
+import { copyToClipboard, useQuasar } from 'quasar';
 import DeleteMissionDialog from 'src/dialogs/delete-mission-dialog.vue';
 import {
     registerNoPermissionErrorHandler,
@@ -325,4 +335,8 @@ function deselect(): void {
 function openMultiActions(): void {
     createAction.value = true;
 }
+
+const copyDataToClipboard = async (data: string): Promise<void> => {
+    await copyToClipboard(data);
+};
 </script>


### PR DESCRIPTION
This PR adds a copy button for a projects uuid in the `missions-explorer-page`.

closes #1644