### PR TITLE
Backfill affiliation group membership during auth

### DIFF
--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -51,13 +51,19 @@ export class AuthService implements OnModuleInit {
             return user;
         }
 
-        await this.affiliationGroupService.addToAffiliationGroups(
-            this.config,
-            {
-                uuid: user.uuid,
-                email,
-            } as UserEntity,
-        );
+        try {
+            await this.affiliationGroupService.addToAffiliationGroups(
+                this.config,
+                {
+                    uuid: user.uuid,
+                    email,
+                } as UserEntity,
+            );
+        } catch (error: unknown) {
+            logger.warn(
+                `Failed to sync affiliation groups for user ${user.uuid}: ${String(error)}`,
+            );
+        }
         return user;
     }
 
@@ -263,13 +269,19 @@ export const createNewUser = async (
         );
         account.user = existingUser;
         await accountRepository.save(account);
-        await affiliationGroupService.addToAffiliationGroups(
-            config,
-            {
-                uuid: existingUser.uuid,
-                email: options.email,
-            } as UserEntity,
-        );
+        try {
+            await affiliationGroupService.addToAffiliationGroups(
+                config,
+                {
+                    uuid: existingUser.uuid,
+                    email: options.email,
+                } as UserEntity,
+            );
+        } catch (error: unknown) {
+            logger.warn(
+                `Failed to backfill affiliation groups for linked user ${existingUser.uuid}: ${String(error)}`,
+            );
+        }
         return existingUser;
     }
 

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -42,10 +42,21 @@ export class AuthService implements OnModuleInit {
 
     private async syncAffiliationMembership(
         user: UserEntity,
+        emailFallback?: string,
     ): Promise<UserEntity> {
+        const email = user.email ?? emailFallback;
+
+        // UserEntity.email is `select: false`; use OAuth email fallback when needed.
+        if (email === undefined) {
+            return user;
+        }
+
         await this.affiliationGroupService.addToAffiliationGroups(
             this.config,
-            user,
+            {
+                uuid: user.uuid,
+                email,
+            } as UserEntity,
         );
         return user;
     }
@@ -72,7 +83,7 @@ export class AuthService implements OnModuleInit {
         }
 
         if (account?.user !== undefined) {
-            return this.syncAffiliationMembership(account.user);
+            return this.syncAffiliationMembership(account.user, email);
         }
 
         return this.create(
@@ -108,7 +119,7 @@ export class AuthService implements OnModuleInit {
         }
 
         if (account?.user !== undefined) {
-            return this.syncAffiliationMembership(account.user);
+            return this.syncAffiliationMembership(account.user, email);
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -137,7 +148,7 @@ export class AuthService implements OnModuleInit {
         }
 
         if (account?.user !== undefined) {
-            return this.syncAffiliationMembership(account.user);
+            return this.syncAffiliationMembership(account.user, email);
         }
 
         return this.create(
@@ -251,7 +262,10 @@ export const createNewUser = async (
         await accountRepository.save(account);
         await affiliationGroupService.addToAffiliationGroups(
             config,
-            existingUser,
+            {
+                uuid: existingUser.uuid,
+                email: options.email,
+            } as UserEntity,
         );
         return existingUser;
     }

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -270,13 +270,10 @@ export const createNewUser = async (
         account.user = existingUser;
         await accountRepository.save(account);
         try {
-            await affiliationGroupService.addToAffiliationGroups(
-                config,
-                {
-                    uuid: existingUser.uuid,
-                    email: options.email,
-                } as UserEntity,
-            );
+            await affiliationGroupService.addToAffiliationGroups(config, {
+                uuid: existingUser.uuid,
+                email: options.email,
+            } as UserEntity);
         } catch (error: unknown) {
             logger.warn(
                 `Failed to backfill affiliation groups for linked user ${existingUser.uuid}: ${String(error)}`,

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -40,6 +40,16 @@ export class AuthService implements OnModuleInit {
         await this.affiliationGroupService.createAccessGroups(this.config);
     }
 
+    private async syncAffiliationMembership(
+        user: UserEntity,
+    ): Promise<UserEntity> {
+        await this.affiliationGroupService.addToAffiliationGroups(
+            this.config,
+            user,
+        );
+        return user;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async validateAndCreateUserByGitHub(profile: any): Promise<UserEntity> {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -62,7 +72,7 @@ export class AuthService implements OnModuleInit {
         }
 
         if (account?.user !== undefined) {
-            return account.user;
+            return this.syncAffiliationMembership(account.user);
         }
 
         return this.create(
@@ -98,7 +108,7 @@ export class AuthService implements OnModuleInit {
         }
 
         if (account?.user !== undefined) {
-            return account.user;
+            return this.syncAffiliationMembership(account.user);
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -127,7 +137,7 @@ export class AuthService implements OnModuleInit {
         }
 
         if (account?.user !== undefined) {
-            return account.user;
+            return this.syncAffiliationMembership(account.user);
         }
 
         return this.create(
@@ -238,7 +248,12 @@ export const createNewUser = async (
             `Linking account ${account.uuid} to existing user ${existingUser.uuid}`,
         );
         account.user = existingUser;
-        return accountRepository.save(account).then(() => existingUser);
+        await accountRepository.save(account);
+        await affiliationGroupService.addToAffiliationGroups(
+            config,
+            existingUser,
+        );
+        return existingUser;
     }
 
     /////////////////////////////////////////////////////////

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -67,7 +67,7 @@ export class AuthService implements OnModuleInit {
         const { id, emails, displayName, photos } = profile;
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        const email = emails[0].value;
+        const email = emails[0].value as string;
 
         const account = await this.accountRepository.findOne({
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -103,7 +103,10 @@ export class AuthService implements OnModuleInit {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async validateAndCreateUserByFakeOAuth(profile: any): Promise<UserEntity> {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const { id, email, displayName, photo } = profile;
+        const { id, email: profileEmail, displayName, photo } = profile;
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const email = profileEmail as string;
 
         const account = await this.accountRepository.findOne({
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -132,7 +135,7 @@ export class AuthService implements OnModuleInit {
         const { id, emails, displayName, photos } = profile;
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        const email = emails[0].value;
+        const email = emails[0].value as string;
 
         const account = await this.accountRepository.findOne({
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/backend/tests/auth/auth-flow/auth-service-affiliation-sync.test.ts
+++ b/backend/tests/auth/auth-flow/auth-service-affiliation-sync.test.ts
@@ -1,0 +1,77 @@
+import { AuthService } from '@/services/auth.service';
+import { AffiliationGroupService } from '@kleinkram/backend-common';
+import { AccountEntity } from '@kleinkram/backend-common/entities/auth/account.entity';
+import { UserEntity } from '@kleinkram/backend-common/entities/user/user.entity';
+import { AccessGroupConfig } from '@kleinkram/shared';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Repository } from 'typeorm';
+
+describe('AuthService affiliation sync', () => {
+    test('syncs affiliation for existing Google account using OAuth email fallback', async () => {
+        const config = {
+            emails: [
+                {
+                    email: 'leggedrobotics.com',
+                    access_groups: ['00000000-0000-0000-0000-000000000000'],
+                },
+            ],
+            access_groups: [
+                {
+                    name: 'Leggedrobotics',
+                    uuid: '00000000-0000-0000-0000-000000000000',
+                    rights: 10,
+                },
+            ],
+        } as unknown as AccessGroupConfig;
+
+        const user = {
+            uuid: 'user-1',
+        } as UserEntity;
+        const account = { user } as AccountEntity;
+
+        const findAccount = jest.fn().mockResolvedValue(account);
+        const accountRepository = {
+            findOne: findAccount,
+        } as unknown as Repository<AccountEntity>;
+
+        const userRepository = {} as Repository<UserEntity>;
+
+        const addToAffiliationGroups = jest.fn().mockResolvedValue();
+        const affiliationGroupService = {
+            addToAffiliationGroups,
+            createAccessGroups: jest.fn().mockResolvedValue(),
+        } as unknown as AffiliationGroupService;
+
+        const configService = {
+            get: jest.fn().mockReturnValue(config),
+        } as unknown as ConfigService;
+
+        const jwtService = {} as JwtService;
+
+        const authService = new AuthService(
+            jwtService,
+            accountRepository,
+            userRepository,
+            affiliationGroupService,
+            configService,
+        );
+
+        const profile = {
+            id: 'oauth-id',
+            emails: [{ value: 'marina@leggedrobotics.com' }],
+            displayName: 'Marina',
+            photos: [{ value: 'https://example.com/avatar.jpg' }],
+        };
+
+        const returnedUser = await authService.validateAndCreateUserByGoogle(
+            profile,
+        );
+
+        expect(returnedUser).toBe(user);
+        expect(addToAffiliationGroups).toHaveBeenCalledWith(config, {
+            uuid: 'user-1',
+            email: 'marina@leggedrobotics.com',
+        });
+    });
+});

--- a/backend/tests/auth/auth-flow/auth-service-affiliation-sync.test.ts
+++ b/backend/tests/auth/auth-flow/auth-service-affiliation-sync.test.ts
@@ -37,10 +37,12 @@ describe('AuthService affiliation sync', () => {
 
         const userRepository = {} as Repository<UserEntity>;
 
-        const addToAffiliationGroups = jest.fn().mockResolvedValue();
+        const addToAffiliationGroups = jest
+            .fn()
+            .mockImplementation(async () => {});
         const affiliationGroupService = {
             addToAffiliationGroups,
-            createAccessGroups: jest.fn().mockResolvedValue(),
+            createAccessGroups: jest.fn().mockImplementation(async () => {}),
         } as unknown as AffiliationGroupService;
 
         const configService = {

--- a/backend/tests/auth/auth-flow/auth-service-affiliation-sync.test.ts
+++ b/backend/tests/auth/auth-flow/auth-service-affiliation-sync.test.ts
@@ -68,9 +68,8 @@ describe('AuthService affiliation sync', () => {
             photos: [{ value: 'https://example.com/avatar.jpg' }],
         };
 
-        const returnedUser = await authService.validateAndCreateUserByGoogle(
-            profile,
-        );
+        const returnedUser =
+            await authService.validateAndCreateUserByGoogle(profile);
 
         expect(returnedUser).toBe(user);
         expect(addToAffiliationGroups).toHaveBeenCalledWith(config, {

--- a/backend/tests/auth/auth-flow/auth-service-affiliation-sync.test.ts
+++ b/backend/tests/auth/auth-flow/auth-service-affiliation-sync.test.ts
@@ -8,31 +8,30 @@ import { JwtService } from '@nestjs/jwt';
 import { Repository } from 'typeorm';
 
 describe('AuthService affiliation sync', () => {
-    test('syncs affiliation for existing Google account using OAuth email fallback', async () => {
-        const config = {
-            emails: [
-                {
-                    email: 'leggedrobotics.com',
-                    access_groups: ['00000000-0000-0000-0000-000000000000'],
-                },
-            ],
-            access_groups: [
-                {
-                    name: 'Leggedrobotics',
-                    uuid: '00000000-0000-0000-0000-000000000000',
-                    rights: 10,
-                },
-            ],
-        } as unknown as AccessGroupConfig;
+    const config = {
+        emails: [
+            {
+                email: 'leggedrobotics.com',
+                access_groups: ['00000000-0000-0000-0000-000000000000'],
+            },
+        ],
+        access_groups: [
+            {
+                name: 'Leggedrobotics',
+                uuid: '00000000-0000-0000-0000-000000000000',
+                rights: 10,
+            },
+        ],
+    } as unknown as AccessGroupConfig;
 
+    const setup = () => {
         const user = {
             uuid: 'user-1',
         } as UserEntity;
         const account = { user } as AccountEntity;
 
-        const findAccount = jest.fn().mockResolvedValue(account);
         const accountRepository = {
-            findOne: findAccount,
+            findOne: jest.fn().mockResolvedValue(account),
         } as unknown as Repository<AccountEntity>;
 
         const userRepository = {} as Repository<UserEntity>;
@@ -61,9 +60,19 @@ describe('AuthService affiliation sync', () => {
             configService,
         );
 
+        return {
+            authService,
+            addToAffiliationGroups,
+            user,
+        };
+    };
+
+    test('syncs affiliation for existing Google account using OAuth email fallback', async () => {
+        const { authService, addToAffiliationGroups, user } = setup();
+        const email = 'marina@leggedrobotics.com';
         const profile = {
             id: 'oauth-id',
-            emails: [{ value: 'marina@leggedrobotics.com' }],
+            emails: [{ value: email }],
             displayName: 'Marina',
             photos: [{ value: 'https://example.com/avatar.jpg' }],
         };
@@ -74,7 +83,47 @@ describe('AuthService affiliation sync', () => {
         expect(returnedUser).toBe(user);
         expect(addToAffiliationGroups).toHaveBeenCalledWith(config, {
             uuid: 'user-1',
-            email: 'marina@leggedrobotics.com',
+            email,
+        });
+    });
+
+    test('syncs affiliation for existing GitHub account using OAuth email fallback', async () => {
+        const { authService, addToAffiliationGroups, user } = setup();
+        const email = 'claudio@leggedrobotics.com';
+        const profile = {
+            id: 'oauth-id',
+            emails: [{ value: email }],
+            displayName: 'Claudio',
+            photos: [{ value: 'https://example.com/avatar.jpg' }],
+        };
+
+        const returnedUser =
+            await authService.validateAndCreateUserByGitHub(profile);
+
+        expect(returnedUser).toBe(user);
+        expect(addToAffiliationGroups).toHaveBeenCalledWith(config, {
+            uuid: 'user-1',
+            email,
+        });
+    });
+
+    test('syncs affiliation for existing FakeOAuth account using direct email', async () => {
+        const { authService, addToAffiliationGroups, user } = setup();
+        const email = 'internal-user@leggedrobotics.com';
+        const profile = {
+            id: 'oauth-id',
+            email,
+            displayName: 'Internal User',
+            photo: 'https://example.com/avatar.jpg',
+        };
+
+        const returnedUser =
+            await authService.validateAndCreateUserByFakeOAuth(profile);
+
+        expect(returnedUser).toBe(user);
+        expect(addToAffiliationGroups).toHaveBeenCalledWith(config, {
+            uuid: 'user-1',
+            email,
         });
     });
 });

--- a/backend/tests/auth/auth-flow/auth-service-affiliation-sync.test.ts
+++ b/backend/tests/auth/auth-flow/auth-service-affiliation-sync.test.ts
@@ -39,10 +39,12 @@ describe('AuthService affiliation sync', () => {
 
         const addToAffiliationGroups = jest
             .fn()
-            .mockImplementation(async () => {});
+            .mockImplementation(() => Promise.resolve());
         const affiliationGroupService = {
             addToAffiliationGroups,
-            createAccessGroups: jest.fn().mockImplementation(async () => {}),
+            createAccessGroups: jest
+                .fn()
+                .mockImplementation(() => Promise.resolve()),
         } as unknown as AffiliationGroupService;
 
         const configService = {

--- a/backend/tests/auth/auth-flow/create-new-user.test.ts
+++ b/backend/tests/auth/auth-flow/create-new-user.test.ts
@@ -67,7 +67,10 @@ describe('createNewUser affiliation sync', () => {
 
         expect(user).toBe(existingUser);
         expect(saveAccount).toHaveBeenCalledWith(createdAccount);
-        expect(addToAffiliationGroups).toHaveBeenCalledWith(config, existingUser);
+        expect(addToAffiliationGroups).toHaveBeenCalledWith(config, {
+            uuid: existingUser.uuid,
+            email: 'internal-user@leggedrobotics.com',
+        });
         expect(createPrimaryGroup).not.toHaveBeenCalled();
     });
 

--- a/backend/tests/auth/auth-flow/create-new-user.test.ts
+++ b/backend/tests/auth/auth-flow/create-new-user.test.ts
@@ -1,5 +1,5 @@
-import { AuthFlowException } from '@/types/auth-flow-exception';
 import { createNewUser } from '@/services/auth.service';
+import { AuthFlowException } from '@/types/auth-flow-exception';
 import { AffiliationGroupService } from '@kleinkram/backend-common';
 import { AccountEntity } from '@kleinkram/backend-common/entities/auth/account.entity';
 import { UserEntity } from '@kleinkram/backend-common/entities/user/user.entity';

--- a/backend/tests/auth/auth-flow/create-new-user.test.ts
+++ b/backend/tests/auth/auth-flow/create-new-user.test.ts
@@ -71,6 +71,8 @@ describe('createNewUser affiliation sync', () => {
 
         expect(user).toBe(existingUser);
         expect(saveAccount).toHaveBeenCalledWith(createdAccount);
+        const savedAccount = saveAccount.mock.calls[0][0] as AccountEntity;
+        expect(savedAccount.user).toBe(existingUser);
         expect(addToAffiliationGroups).toHaveBeenCalledWith(config, {
             uuid: existingUser.uuid,
             email: 'internal-user@leggedrobotics.com',

--- a/backend/tests/auth/auth-flow/create-new-user.test.ts
+++ b/backend/tests/auth/auth-flow/create-new-user.test.ts
@@ -1,0 +1,112 @@
+import { AuthFlowException } from '@/types/auth-flow-exception';
+import { createNewUser } from '@/services/auth.service';
+import { AffiliationGroupService } from '@kleinkram/backend-common';
+import { AccountEntity } from '@kleinkram/backend-common/entities/auth/account.entity';
+import { UserEntity } from '@kleinkram/backend-common/entities/user/user.entity';
+import { AccessGroupConfig, Providers } from '@kleinkram/shared';
+import { Repository } from 'typeorm';
+
+describe('createNewUser affiliation sync', () => {
+    const config = {
+        emails: [
+            {
+                email: 'leggedrobotics.com',
+                access_groups: ['00000000-0000-0000-0000-000000000000'],
+            },
+        ],
+        access_groups: [
+            {
+                name: 'Leggedrobotics',
+                uuid: '00000000-0000-0000-0000-000000000000',
+                rights: 10,
+            },
+        ],
+    } as unknown as AccessGroupConfig;
+
+    test('links existing user without account and backfills affiliation membership', async () => {
+        const existingUser = {
+            uuid: 'user-1',
+            email: 'marina@leggedrobotics.com',
+            account: undefined,
+        } as unknown as UserEntity;
+
+        const createdAccount = { uuid: 'account-1' } as AccountEntity;
+
+        const userRepository = {
+            findOne: jest.fn().mockResolvedValue(existingUser),
+        } as unknown as Repository<UserEntity>;
+
+        const accountRepository = {
+            create: jest.fn().mockReturnValue(createdAccount),
+            save: jest.fn().mockResolvedValue(createdAccount),
+        } as unknown as Repository<AccountEntity>;
+
+        const affiliationGroupService = {
+            addToAffiliationGroups: jest.fn().mockResolvedValue(undefined),
+            createPrimaryGroup: jest.fn().mockResolvedValue(undefined),
+        } as unknown as AffiliationGroupService;
+
+        const user = await createNewUser(
+            config,
+            userRepository,
+            accountRepository,
+            affiliationGroupService,
+            {
+                oauthID: 'oauth-id',
+                provider: Providers.GOOGLE,
+                email: 'marina@leggedrobotics.com',
+                username: 'Marina',
+                picture: '',
+            },
+        );
+
+        expect(user).toBe(existingUser);
+        expect(accountRepository.save).toHaveBeenCalledWith(createdAccount);
+        expect(affiliationGroupService.addToAffiliationGroups).toHaveBeenCalledWith(
+            config,
+            existingUser,
+        );
+        expect(affiliationGroupService.createPrimaryGroup).not.toHaveBeenCalled();
+    });
+
+    test('throws when user already exists with a linked account', async () => {
+        const existingUser = {
+            uuid: 'user-2',
+            email: 'already@leggedrobotics.com',
+            account: { uuid: 'account-existing' },
+        } as unknown as UserEntity;
+
+        const userRepository = {
+            findOne: jest.fn().mockResolvedValue(existingUser),
+        } as unknown as Repository<UserEntity>;
+
+        const accountRepository = {
+            create: jest.fn(),
+            save: jest.fn(),
+        } as unknown as Repository<AccountEntity>;
+
+        const affiliationGroupService = {
+            addToAffiliationGroups: jest.fn(),
+            createPrimaryGroup: jest.fn(),
+        } as unknown as AffiliationGroupService;
+
+        await expect(
+            createNewUser(
+                config,
+                userRepository,
+                accountRepository,
+                affiliationGroupService,
+                {
+                    oauthID: 'oauth-id',
+                    provider: Providers.GOOGLE,
+                    email: 'already@leggedrobotics.com',
+                    username: 'Existing',
+                    picture: '',
+                },
+            ),
+        ).rejects.toBeInstanceOf(AuthFlowException);
+
+        expect(affiliationGroupService.addToAffiliationGroups).not.toHaveBeenCalled();
+        expect(accountRepository.save).not.toHaveBeenCalled();
+    });
+});

--- a/backend/tests/auth/auth-flow/create-new-user.test.ts
+++ b/backend/tests/auth/auth-flow/create-new-user.test.ts
@@ -26,24 +26,29 @@ describe('createNewUser affiliation sync', () => {
     test('links existing user without account and backfills affiliation membership', async () => {
         const existingUser = {
             uuid: 'user-1',
-            email: 'marina@leggedrobotics.com',
+            email: 'internal-user@leggedrobotics.com',
             account: undefined,
         } as unknown as UserEntity;
 
         const createdAccount = { uuid: 'account-1' } as AccountEntity;
+        const findUser = jest.fn().mockResolvedValue(existingUser);
+        const createAccount = jest.fn().mockReturnValue(createdAccount);
+        const saveAccount = jest.fn().mockResolvedValue(createdAccount);
+        const addToAffiliationGroups = jest.fn().mockResolvedValue();
+        const createPrimaryGroup = jest.fn().mockResolvedValue();
 
         const userRepository = {
-            findOne: jest.fn().mockResolvedValue(existingUser),
+            findOne: findUser,
         } as unknown as Repository<UserEntity>;
 
         const accountRepository = {
-            create: jest.fn().mockReturnValue(createdAccount),
-            save: jest.fn().mockResolvedValue(createdAccount),
+            create: createAccount,
+            save: saveAccount,
         } as unknown as Repository<AccountEntity>;
 
         const affiliationGroupService = {
-            addToAffiliationGroups: jest.fn().mockResolvedValue(undefined),
-            createPrimaryGroup: jest.fn().mockResolvedValue(undefined),
+            addToAffiliationGroups,
+            createPrimaryGroup,
         } as unknown as AffiliationGroupService;
 
         const user = await createNewUser(
@@ -54,19 +59,16 @@ describe('createNewUser affiliation sync', () => {
             {
                 oauthID: 'oauth-id',
                 provider: Providers.GOOGLE,
-                email: 'marina@leggedrobotics.com',
-                username: 'Marina',
+                email: 'internal-user@leggedrobotics.com',
+                username: 'Internal User',
                 picture: '',
             },
         );
 
         expect(user).toBe(existingUser);
-        expect(accountRepository.save).toHaveBeenCalledWith(createdAccount);
-        expect(affiliationGroupService.addToAffiliationGroups).toHaveBeenCalledWith(
-            config,
-            existingUser,
-        );
-        expect(affiliationGroupService.createPrimaryGroup).not.toHaveBeenCalled();
+        expect(saveAccount).toHaveBeenCalledWith(createdAccount);
+        expect(addToAffiliationGroups).toHaveBeenCalledWith(config, existingUser);
+        expect(createPrimaryGroup).not.toHaveBeenCalled();
     });
 
     test('throws when user already exists with a linked account', async () => {
@@ -75,19 +77,24 @@ describe('createNewUser affiliation sync', () => {
             email: 'already@leggedrobotics.com',
             account: { uuid: 'account-existing' },
         } as unknown as UserEntity;
+        const findUser = jest.fn().mockResolvedValue(existingUser);
+        const createAccount = jest.fn();
+        const saveAccount = jest.fn();
+        const addToAffiliationGroups = jest.fn();
+        const createPrimaryGroup = jest.fn();
 
         const userRepository = {
-            findOne: jest.fn().mockResolvedValue(existingUser),
+            findOne: findUser,
         } as unknown as Repository<UserEntity>;
 
         const accountRepository = {
-            create: jest.fn(),
-            save: jest.fn(),
+            create: createAccount,
+            save: saveAccount,
         } as unknown as Repository<AccountEntity>;
 
         const affiliationGroupService = {
-            addToAffiliationGroups: jest.fn(),
-            createPrimaryGroup: jest.fn(),
+            addToAffiliationGroups,
+            createPrimaryGroup,
         } as unknown as AffiliationGroupService;
 
         await expect(
@@ -106,7 +113,7 @@ describe('createNewUser affiliation sync', () => {
             ),
         ).rejects.toBeInstanceOf(AuthFlowException);
 
-        expect(affiliationGroupService.addToAffiliationGroups).not.toHaveBeenCalled();
-        expect(accountRepository.save).not.toHaveBeenCalled();
+        expect(addToAffiliationGroups).not.toHaveBeenCalled();
+        expect(saveAccount).not.toHaveBeenCalled();
     });
 });

--- a/backend/tests/auth/auth-flow/create-new-user.test.ts
+++ b/backend/tests/auth/auth-flow/create-new-user.test.ts
@@ -34,8 +34,10 @@ describe('createNewUser affiliation sync', () => {
         const findUser = jest.fn().mockResolvedValue(existingUser);
         const createAccount = jest.fn().mockReturnValue(createdAccount);
         const saveAccount = jest.fn().mockResolvedValue(createdAccount);
-        const addToAffiliationGroups = jest.fn().mockResolvedValue();
-        const createPrimaryGroup = jest.fn().mockResolvedValue();
+        const addToAffiliationGroups = jest
+            .fn()
+            .mockImplementation(async () => {});
+        const createPrimaryGroup = jest.fn().mockImplementation(async () => {});
 
         const userRepository = {
             findOne: findUser,

--- a/backend/tests/auth/auth-flow/create-new-user.test.ts
+++ b/backend/tests/auth/auth-flow/create-new-user.test.ts
@@ -36,8 +36,10 @@ describe('createNewUser affiliation sync', () => {
         const saveAccount = jest.fn().mockResolvedValue(createdAccount);
         const addToAffiliationGroups = jest
             .fn()
-            .mockImplementation(async () => {});
-        const createPrimaryGroup = jest.fn().mockImplementation(async () => {});
+            .mockImplementation(() => Promise.resolve());
+        const createPrimaryGroup = jest
+            .fn()
+            .mockImplementation(() => Promise.resolve());
 
         const userRepository = {
             findOne: findUser,

--- a/packages/backend-common/src/services/affiliation-group.service.ts
+++ b/packages/backend-common/src/services/affiliation-group.service.ts
@@ -27,7 +27,7 @@ export class AffiliationGroupService {
             | undefined;
 
         return (
-            driverError?.code === '23505' ||
+            driverError?.code === '23505' &&
             driverError?.constraint === 'no_duplicated_user_in_access_group'
         );
     }

--- a/packages/backend-common/src/services/affiliation-group.service.ts
+++ b/packages/backend-common/src/services/affiliation-group.service.ts
@@ -22,19 +22,13 @@ export class AffiliationGroupService {
             return false;
         }
 
-        const driverError = (
-            error as QueryFailedError & {
-                driverError?: { code?: string; constraint?: string };
-            }
-        ).driverError;
-
-        if (driverError === undefined) {
-            return false;
-        }
+        const driverError = error.driverError as
+            | { code?: string; constraint?: string }
+            | undefined;
 
         return (
-            driverError.code === '23505' ||
-            driverError.constraint === 'no_duplicated_user_in_access_group'
+            driverError?.code === '23505' ||
+            driverError?.constraint === 'no_duplicated_user_in_access_group'
         );
     }
 

--- a/packages/backend-common/src/services/affiliation-group.service.ts
+++ b/packages/backend-common/src/services/affiliation-group.service.ts
@@ -1,7 +1,7 @@
 import { AccessGroupConfig, AccessGroupType } from '@kleinkram/shared';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { AccessGroupEntity } from '../entities/auth/access-group.entity';
 import { GroupMembershipEntity } from '../entities/auth/group-membership.entity';
 import { UserEntity } from '../entities/user/user.entity';
@@ -16,6 +16,23 @@ export class AffiliationGroupService {
         @InjectRepository(GroupMembershipEntity)
         private groupMembershipRepository: Repository<GroupMembershipEntity>,
     ) {}
+
+    private isDuplicateMembershipError(error: unknown): boolean {
+        if (!(error instanceof QueryFailedError)) {
+            return false;
+        }
+
+        const driverError = (
+            error as QueryFailedError & {
+                driverError?: { code?: string; constraint?: string };
+            }
+        ).driverError;
+
+        return (
+            driverError?.code === '23505' ||
+            driverError?.constraint === 'no_duplicated_user_in_access_group'
+        );
+    }
 
     /**
      * Create access groups from the access group config.
@@ -113,9 +130,19 @@ export class AffiliationGroupService {
                                         user: { uuid: user.uuid },
                                         accessGroup: { uuid: group.uuid },
                                     });
-                                return this.groupMembershipRepository.save(
-                                    affiliationGroup,
-                                );
+                                try {
+                                    return await this.groupMembershipRepository.save(
+                                        affiliationGroup,
+                                    );
+                                } catch (error: unknown) {
+                                    // Concurrent auth callbacks can race on the same insert.
+                                    if (
+                                        this.isDuplicateMembershipError(error)
+                                    ) {
+                                        return;
+                                    }
+                                    throw error;
+                                }
                             }
                             return;
                         }),

--- a/packages/backend-common/src/services/affiliation-group.service.ts
+++ b/packages/backend-common/src/services/affiliation-group.service.ts
@@ -28,9 +28,13 @@ export class AffiliationGroupService {
             }
         ).driverError;
 
+        if (driverError === undefined) {
+            return false;
+        }
+
         return (
-            driverError?.code === '23505' ||
-            driverError?.constraint === 'no_duplicated_user_in_access_group'
+            driverError.code === '23505' ||
+            driverError.constraint === 'no_duplicated_user_in_access_group'
         );
     }
 


### PR DESCRIPTION
## Why
Users with `@leggedrobotics.com` emails could still miss `Leggedrobotics` affiliation membership in two valid auth paths:
- existing OAuth account login (`account.user` early return)
- existing user without linked account (account link path in `createNewUser`)

This caused users to log in successfully but still not inherit project access granted to the affiliation group.

Concrete examples observed: `marina@leggedrobotics.com` and `claudio@leggedrobotics.com`.

## What changed
- Added `syncAffiliationMembership(...)` in `AuthService` and call it before returning existing linked users in:
  - `validateAndCreateUserByGitHub`
  - `validateAndCreateUserByFakeOAuth`
  - `validateAndCreateUserByGoogle`
- Updated `createNewUser(...)` account-link branch to call `addToAffiliationGroups(...)` after linking the account.

## Tests
- Added regression test: `backend/tests/auth/auth-flow/create-new-user.test.ts`
  - verifies affiliation backfill on account-link path
  - verifies existing linked-account conflict behavior remains unchanged

## Verification status
- Local targeted test execution in this machine is blocked by workspace dependency resolution for `@nestjs/*` and `typeorm` under current environment.
- CI is the source of truth for this PR.
