### PR TITLE
fix: remove unused symlink command from docs service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -435,7 +435,7 @@ services:
             - ./tsconfig.base.json:/app/tsconfig.base.json
             - ./packages:/app/packages
 
-        command: sh -c "ln -sf /app/docs/scripts /app/scripts && npm run docs:dev /app/docs"
+        command: npm run docs:dev /app/docs
 
     artifact-uploader:
         container_name: kleinkram-artifact-uploader


### PR DESCRIPTION
This pull request makes a minor update to the `docker-compose.yml` file by simplifying the command used to start the documentation development server. The symbolic link creation step has been removed, and the service now directly runs the documentation server command.