### PR TITLE
fix: audit logs TDZ error on access group details page

### DIFF
--- a/frontend/src/pages/access-group-details-page.vue
+++ b/frontend/src/pages/access-group-details-page.vue
@@ -672,12 +672,6 @@ const user = useUser();
 const refetchOnClick: (event_: Event) => void = () => refetch;
 
 const { data: accessGroup, refetch } = useAccessGroup(uuid.value);
-const auditLogsQueryEnabled = computed(
-    () => !personal.value && currentUserCanEdit.value,
-);
-const { data: auditLogs } = useAccessGroupAuditLogs(uuid, {
-    enabled: auditLogsQueryEnabled,
-});
 
 const { mutate: removeUsers } = useMutation({
     mutationFn: (userUuids: string[]) =>
@@ -846,6 +840,13 @@ const currentUserCanEdit = computed(() => {
             (m) => m.user.uuid === user.data.value?.uuid && m.canEditGroup,
         ) ?? false
     );
+});
+
+const auditLogsQueryEnabled = computed(
+    () => !personal.value && currentUserCanEdit.value,
+);
+const { data: auditLogs } = useAccessGroupAuditLogs(uuid, {
+    enabled: auditLogsQueryEnabled,
 });
 
 const userCols = [


### PR DESCRIPTION
## Summary
- Moves `auditLogsQueryEnabled` computed and `useAccessGroupAuditLogs` call after `personal` and `currentUserCanEdit` are defined
- Fixes `ReferenceError: Cannot access 'personal' before initialization` at line 676

🤖 Generated with [Claude Code](https://claude.com/claude-code)