### PR TITLE
Fix TDZ ReferenceError and add user permissions management

### DIFF
--- a/backend/src/endpoints/access/access.controller.ts
+++ b/backend/src/endpoints/access/access.controller.ts
@@ -14,6 +14,7 @@ import {
     RemoveAccessGroupFromProjectResponseDto,
     RemoveUsersFromAccessGroupDto,
     SetAccessGroupUserExpirationDto,
+    SetAccessGroupUserPermissionsDto,
 } from '@kleinkram/api-dto';
 import { AccessGroupEntity } from '@kleinkram/backend-common';
 import {
@@ -305,6 +306,30 @@ export class AccessController {
             uuid,
             userUuid,
             body.expireDate,
+            requestUser,
+        );
+    }
+
+    @Put(':uuid/users/:userUuid/permissions')
+    @CanEditGroup()
+    @ApiOkResponse({
+        description: 'Returns the updated GroupMembership',
+        type: GroupMembershipDto,
+    })
+    @ApiOperation({
+        summary: 'Set permissions for user in AccessGroup',
+        description: 'Promotes or demotes a user as group editor',
+    })
+    async setPermissions(
+        @ParameterUID('uuid', 'UUID of AccessGroup') uuid: string,
+        @ParameterUID('userUuid', 'UUID of User') userUuid: string,
+        @Body() body: SetAccessGroupUserPermissionsDto,
+        @AddUser() requestUser: AuthHeader,
+    ): Promise<GroupMembershipDto> {
+        return this.accessService.setCanEditGroup(
+            uuid,
+            userUuid,
+            body.canEditGroup,
             requestUser,
         );
     }

--- a/backend/src/services/access.service.ts
+++ b/backend/src/services/access.service.ts
@@ -890,6 +890,63 @@ export class AccessService {
         return groupMembershipEntityToDto(savedMembership);
     }
 
+    async setCanEditGroup(
+        uuid: string,
+        userUuid: string,
+        canEditGroup: boolean,
+        auth?: AuthHeader,
+    ): Promise<GroupMembershipDto> {
+        const agu = await this.groupMembershipRepository.findOneOrFail({
+            where: {
+                accessGroup: { uuid },
+                user: { uuid: userUuid },
+            },
+        });
+
+        if (!canEditGroup) {
+            const editorsCount = await this.groupMembershipRepository.count({
+                where: {
+                    accessGroup: { uuid },
+                    canEditGroup: true,
+                },
+            });
+            if (editorsCount <= 1) {
+                throw new ConflictException(
+                    'Cannot demote the last user with edit rights',
+                );
+            }
+        }
+
+        agu.canEditGroup = canEditGroup;
+        const { uuid: membershipUuid } =
+            await this.groupMembershipRepository.save(agu);
+
+        const savedMembership =
+            await this.groupMembershipRepository.findOneOrFail({
+                where: { uuid: membershipUuid },
+                relations: ['user'],
+            });
+
+        this.accessGroupAuditService
+            .log(
+                uuid,
+                canEditGroup
+                    ? AccessGroupEventType.PROMOTE_USER
+                    : AccessGroupEventType.DEMOTE_USER,
+                {
+                    userUuid,
+                    userName: savedMembership.user?.name ?? 'Unknown',
+                    canEditGroup,
+                },
+                auth?.user as unknown as UserEntity,
+            )
+            .catch((error: unknown) =>
+                logger.error(`Audit log failed: ${String(error)}`),
+            );
+
+        return groupMembershipEntityToDto(savedMembership);
+    }
+
     async getAuditLogs(uuid: string): Promise<AccessGroupAuditLogsDto> {
         const [logs, count] =
             await this.accessGroupAuditService.getLogsForGroup(uuid);

--- a/frontend/src/pages/access-group-details-page.vue
+++ b/frontend/src/pages/access-group-details-page.vue
@@ -672,12 +672,6 @@ const user = useUser();
 const refetchOnClick: (event_: Event) => void = () => refetch;
 
 const { data: accessGroup, refetch } = useAccessGroup(uuid.value);
-const auditLogsQueryEnabled = computed(
-    () => !personal.value && currentUserCanEdit.value,
-);
-const { data: auditLogs } = useAccessGroupAuditLogs(uuid, {
-    enabled: auditLogsQueryEnabled,
-});
 
 const { mutate: removeUsers } = useMutation({
     mutationFn: (userUuids: string[]) =>
@@ -846,6 +840,13 @@ const currentUserCanEdit = computed(() => {
             (m) => m.user.uuid === user.data.value?.uuid && m.canEditGroup,
         ) ?? false
     );
+});
+
+const auditLogsQueryEnabled = computed(
+    () => !personal.value && currentUserCanEdit.value,
+);
+const { data: auditLogs } = useAccessGroupAuditLogs(uuid, {
+    enabled: auditLogsQueryEnabled,
 });
 
 const userCols = [

--- a/frontend/src/pages/access-group-details-page.vue
+++ b/frontend/src/pages/access-group-details-page.vue
@@ -687,7 +687,7 @@ const pagination2 = ref({
 const queryClient = useQueryClient();
 const user = useUser();
 
-const refetchOnClick: (event_: Event) => void = () => refetch;
+const refetchOnClick: (event_: Event) => void = () => void refetch();
 
 const { data: accessGroup, refetch } = useAccessGroup(uuid.value);
 

--- a/frontend/src/pages/access-group-details-page.vue
+++ b/frontend/src/pages/access-group-details-page.vue
@@ -386,6 +386,22 @@
                                         clickable
                                         :disable="!currentUserCanEdit"
                                         @click="
+                                            () => toggleUserRole(props.row)
+                                        "
+                                    >
+                                        <q-item-section>
+                                            {{
+                                                props.row.canEditGroup
+                                                    ? 'Demote to Member'
+                                                    : 'Promote to Owner'
+                                            }}
+                                        </q-item-section>
+                                    </q-item>
+                                    <q-item
+                                        v-ripple
+                                        clickable
+                                        :disable="!currentUserCanEdit"
+                                        @click="
                                             () =>
                                                 removeSingleUser(
                                                     props.row.user.uuid,
@@ -637,6 +653,7 @@ import { formatDate, isExpired } from 'src/services/date-formating';
 import {
     removeUsersFromAccessGroup,
     setAccessGroupExpiry,
+    setAccessGroupUserPermissions,
 } from 'src/services/mutations/access';
 import { computed, ComputedRef, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
@@ -701,6 +718,24 @@ const { mutate: removeUsers } = useMutation({
 
 const removeSingleUser = (userUuid: string): void => {
     removeUsers([userUuid]);
+};
+
+const toggleUserRole = async (membership: GroupMembershipDto) => {
+    await setAccessGroupUserPermissions(
+        uuid.value,
+        membership.user.uuid,
+        !membership.canEditGroup,
+    );
+    await queryClient.invalidateQueries({
+        predicate: (query) => {
+            return (
+                (query.queryKey[0] === 'AccessGroup' &&
+                    query.queryKey[1] === uuid.value) ||
+                (query.queryKey[0] === 'AccessGroupAuditLogs' &&
+                    query.queryKey[1] === uuid.value)
+            );
+        },
+    });
 };
 
 const deleteSelectedUsers = (): void => {

--- a/frontend/src/pages/access-group-details-page.vue
+++ b/frontend/src/pages/access-group-details-page.vue
@@ -385,9 +385,7 @@
                                         v-ripple
                                         clickable
                                         :disable="!currentUserCanEdit"
-                                        @click="
-                                            () => toggleUserRole(props.row)
-                                        "
+                                        @click="() => toggleUserRole(props.row)"
                                     >
                                         <q-item-section>
                                             {{
@@ -742,8 +740,8 @@ const toggleUserRole = async (membership: GroupMembershipDto) => {
         });
     } catch (error: unknown) {
         const message =
-            (error as { response?: { data?: { message?: string } } })?.response
-                ?.data?.message || 'Failed to update user permissions';
+            (error as { response?: { data?: { message?: string } } }).response
+                ?.data?.message ?? 'Failed to update user permissions';
         Notify.create({
             message,
             color: 'negative',

--- a/frontend/src/pages/access-group-details-page.vue
+++ b/frontend/src/pages/access-group-details-page.vue
@@ -396,6 +396,9 @@
                                                     : 'Promote to Owner'
                                             }}
                                         </q-item-section>
+                                        <q-tooltip v-if="!currentUserCanEdit">
+                                            You can't edit a user!
+                                        </q-tooltip>
                                     </q-item>
                                     <q-item
                                         v-ripple
@@ -721,21 +724,32 @@ const removeSingleUser = (userUuid: string): void => {
 };
 
 const toggleUserRole = async (membership: GroupMembershipDto) => {
-    await setAccessGroupUserPermissions(
-        uuid.value,
-        membership.user.uuid,
-        !membership.canEditGroup,
-    );
-    await queryClient.invalidateQueries({
-        predicate: (query) => {
-            return (
-                (query.queryKey[0] === 'AccessGroup' &&
-                    query.queryKey[1] === uuid.value) ||
-                (query.queryKey[0] === 'AccessGroupAuditLogs' &&
-                    query.queryKey[1] === uuid.value)
-            );
-        },
-    });
+    try {
+        await setAccessGroupUserPermissions(
+            uuid.value,
+            membership.user.uuid,
+            !membership.canEditGroup,
+        );
+        await queryClient.invalidateQueries({
+            predicate: (query) => {
+                return (
+                    (query.queryKey[0] === 'AccessGroup' &&
+                        query.queryKey[1] === uuid.value) ||
+                    (query.queryKey[0] === 'AccessGroupAuditLogs' &&
+                        query.queryKey[1] === uuid.value)
+                );
+            },
+        });
+    } catch (error: unknown) {
+        const message =
+            (error as { response?: { data?: { message?: string } } })?.response
+                ?.data?.message || 'Failed to update user permissions';
+        Notify.create({
+            message,
+            color: 'negative',
+            position: 'bottom',
+        });
+    }
 };
 
 const deleteSelectedUsers = (): void => {

--- a/frontend/src/services/mutations/access.ts
+++ b/frontend/src/services/mutations/access.ts
@@ -118,3 +118,15 @@ export const setAccessGroupExpiry = async (
     );
     return data;
 };
+
+export const setAccessGroupUserPermissions = async (
+    uuid: string,
+    userUuid: string,
+    canEditGroup: boolean,
+) => {
+    const { data } = await axios.put<GroupMembershipDto>(
+        `/access/${uuid}/users/${userUuid}/permissions`,
+        { canEditGroup },
+    );
+    return data;
+};

--- a/packages/api-dto/src/types/index.ts
+++ b/packages/api-dto/src/types/index.ts
@@ -82,6 +82,7 @@ export * from '@api-dto/queue/bull-queue.dto';
 export * from '@api-dto/queue/stop-job-response.dto';
 export * from '@api-dto/remove-tag-type.dto';
 export * from '@api-dto/set-access-group-user-expiration.dto';
+export * from '@api-dto/set-access-group-user-permissions.dto';
 export * from '@api-dto/storage-overview.dto';
 export * from '@api-dto/submit-action-response.dto';
 export * from '@api-dto/submit-action.dto';

--- a/packages/api-dto/src/types/set-access-group-user-permissions.dto.ts
+++ b/packages/api-dto/src/types/set-access-group-user-permissions.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+
+export class SetAccessGroupUserPermissionsDto {
+    @IsBoolean()
+    @ApiProperty({
+        description: 'Whether the user can edit the group (Owner=true, Member=false).',
+        type: Boolean,
+        example: true,
+    })
+    canEditGroup!: boolean;
+}

--- a/packages/api-dto/src/types/set-access-group-user-permissions.dto.ts
+++ b/packages/api-dto/src/types/set-access-group-user-permissions.dto.ts
@@ -4,7 +4,8 @@ import { IsBoolean } from 'class-validator';
 export class SetAccessGroupUserPermissionsDto {
     @IsBoolean()
     @ApiProperty({
-        description: 'Whether the user can edit the group (Owner=true, Member=false).',
+        description:
+            'Whether the user can edit the group (Owner=true, Member=false).',
         type: Boolean,
         example: true,
     })

--- a/packages/shared/src/common-utils/enum.ts
+++ b/packages/shared/src/common-utils/enum.ts
@@ -85,6 +85,8 @@ export enum AccessGroupEventType {
     ADD_PROJECT = 'ADD_PROJECT',
     REMOVE_PROJECT = 'REMOVE_PROJECT',
     UPDATE_PROJECT_ACCESS = 'UPDATE_PROJECT_ACCESS',
+    PROMOTE_USER = 'PROMOTE_USER',
+    DEMOTE_USER = 'DEMOTE_USER',
 }
 
 export enum ActionState {


### PR DESCRIPTION
- Add PUT /access/:uuid/users/:userUuid/permissions endpoint to promote/demote users as group editors
- Guard endpoint with @CanEditGroup() so only existing editors can change permissions
- Prevent demoting the last editor (returns 409)
- Log promote/demote actions to the audit log (PROMOTE_USER / DEMOTE_USER)
- Add promote/demote toggle button in the user context menu on the access group details page
- Show error notification when the backend rejects a permission change
- Disable promote/demote button with tooltip for non-editors