### PR TITLE
fix: min project access rights modification #933

### DIFF
--- a/frontend/src/components/configure-access-rights/access-rights-manager.vue
+++ b/frontend/src/components/configure-access-rights/access-rights-manager.vue
@@ -90,7 +90,6 @@ import { useSearchAccessGroup } from 'src/hooks/query-hooks';
 import { getAccessRightDescription } from 'src/services/generic';
 import { computed, ref } from 'vue';
 
-
 const accessRights = defineModel<DefaultRightDto[]>({ default: [] });
 
 // State

--- a/frontend/src/components/configure-access-rights/access-rights-manager.vue
+++ b/frontend/src/components/configure-access-rights/access-rights-manager.vue
@@ -74,7 +74,6 @@
 
     <AccessRightsTable
         :access-rights="accessRights || []"
-        :min-access-rights="minAccessRights"
         @update-rights="onUpdateRights"
         @remove="onRemoveGroup"
     />
@@ -91,9 +90,6 @@ import { useSearchAccessGroup } from 'src/hooks/query-hooks';
 import { getAccessRightDescription } from 'src/services/generic';
 import { computed, ref } from 'vue';
 
-defineProps<{
-    minAccessRights: DefaultRightDto[];
-}>();
 
 const accessRights = defineModel<DefaultRightDto[]>({ default: [] });
 

--- a/frontend/src/components/configure-access-rights/access-rights-table.vue
+++ b/frontend/src/components/configure-access-rights/access-rights-table.vue
@@ -1,4 +1,4 @@
-<template>
+xfd<template>
     <q-table
         class="table-white q-mt-xs"
         :columns="columns"
@@ -45,15 +45,11 @@
                             v-for="option in accessGroupRightsList"
                             :key="option"
                             clickable
-                            :disable="isBelowMinRights(props.row, option)"
-                            @click="
-                                () => emit('update-rights', props.row, option)
-                            "
+                            :disable="isDisabledRightOption(props.row, option)"
+                            @click="() => emit('update-rights', props.row, option)"
                         >
-                            <q-tooltip
-                                v-if="isBelowMinRights(props.row, option)"
-                            >
-                                {{ getMinRightsTooltip(props.row) }}
+                            <q-tooltip v-if="isDisabledRightOption(props.row, option)">
+                                Project must have at least one group with Delete rights.
                             </q-tooltip>
                             <q-item-section>
                                 {{ getAccessRightDescription(option) }}
@@ -72,8 +68,13 @@
                     dense
                     icon="sym_o_delete"
                     color="red"
+                    :disable="isDeleteDisabled(props.row)"
                     @click="() => emit('remove', props.row)"
-                />
+                >
+                    <q-tooltip v-if="isDeleteDisabled(props.row)">
+                        Cannot remove the last group with Delete rights.
+                    </q-tooltip>
+                </q-btn>
             </q-td>
         </template>
     </q-table>
@@ -86,10 +87,10 @@ import AccessGroupAvatar from 'components/configure-access-rights/access-group-a
 import { QTableColumn } from 'quasar';
 import { accessGroupRightsList } from 'src/enums/access-group-rights-list';
 import { getAccessRightDescription } from 'src/services/generic';
+import { computed } from 'vue';
 
 const properties = defineProps<{
     accessRights: DefaultRightDto[];
-    minAccessRights: DefaultRightDto[];
 }>();
 
 const emit = defineEmits<{
@@ -134,27 +135,43 @@ const formatMemberCount = (count: number): string =>
     `${count} member${count === 1 ? '' : 's'}`;
 
 /**
- * Checks if a specific option is strictly lower than the user's minimum rights.
- * This enforces the constraint logic inside the dropdown.
+ * There is only one global rule for the access rights of a project: 
+ * **There must always be at least one group with DELETE rights.**
+ * 
+ * The same global rule is enforced in the backend (see access.service.ts). We implement it here as well to provide immediate feedback to the user and prevent unnecessary API calls that would be rejected by the backend.
  */
-const isBelowMinRights = (
+
+// Count how many groups currently have DELETE rights
+const deleteGroupCount = computed(() => {
+    console.log('Recomputing deleteGroupCount');
+    console.log('Current num delete rights:', properties.accessRights.filter(
+        (g) => g.rights === AccessGroupRights.DELETE
+    ).length);
+    return properties.accessRights.filter(
+        (g) => g.rights === AccessGroupRights.DELETE
+    ).length;
+});
+
+
+//Prevent downgrading the last group with DELETE rights
+const isDisabledRightOption = (
     group: DefaultRightDto,
     rightOption: AccessGroupRights,
 ): boolean => {
-    const minAccess = properties.minAccessRights.find(
-        (r) => r.uuid === group.uuid,
-    );
-    // If minAccess exists, the option is disabled if it is STRICTLY LESS than minAccess
-    return minAccess ? minAccess.rights > rightOption : false;
+    // If they are trying to select a right lower than DELETE...
+    if (group.rights === AccessGroupRights.DELETE && rightOption < AccessGroupRights.DELETE) {
+        // ...disable it if this is the ONLY group with DELETE rights
+        return deleteGroupCount.value <= 1;
+    }
+    return false;
 };
 
-const getMinRightsTooltip = (group: DefaultRightDto): string => {
-    const minAccess = properties.minAccessRights.find(
-        (r) => r.uuid === group.uuid,
-    );
-    if (!minAccess) return 'Option unavailable';
-    return `Minimum access required: ${getAccessRightDescription(
-        minAccess.rights,
-    )}`;
+//Prevent removing the last group with DELETE rights
+const isDeleteDisabled = (group: DefaultRightDto): boolean => {
+    if (group.rights === AccessGroupRights.DELETE) {
+        return deleteGroupCount.value <= 1;
+    }
+    return false;
 };
+
 </script>

--- a/frontend/src/components/configure-access-rights/access-rights-table.vue
+++ b/frontend/src/components/configure-access-rights/access-rights-table.vue
@@ -1,4 +1,4 @@
-xfd<template>
+<template>
     <q-table
         class="table-white q-mt-xs"
         :columns="columns"
@@ -46,10 +46,15 @@ xfd<template>
                             :key="option"
                             clickable
                             :disable="isDisabledRightOption(props.row, option)"
-                            @click="() => emit('update-rights', props.row, option)"
+                            @click="
+                                () => emit('update-rights', props.row, option)
+                            "
                         >
-                            <q-tooltip v-if="isDisabledRightOption(props.row, option)">
-                                Project must have at least one group with Delete rights.
+                            <q-tooltip
+                                v-if="isDisabledRightOption(props.row, option)"
+                            >
+                                Project must have at least one group with Delete
+                                rights.
                             </q-tooltip>
                             <q-item-section>
                                 {{ getAccessRightDescription(option) }}
@@ -135,23 +140,18 @@ const formatMemberCount = (count: number): string =>
     `${count} member${count === 1 ? '' : 's'}`;
 
 /**
- * There is only one global rule for the access rights of a project: 
+ * There is only one global rule for the access rights of a project:
  * **There must always be at least one group with DELETE rights.**
- * 
+ *
  * The same global rule is enforced in the backend (see access.service.ts). We implement it here as well to provide immediate feedback to the user and prevent unnecessary API calls that would be rejected by the backend.
  */
 
 // Count how many groups currently have DELETE rights
 const deleteGroupCount = computed(() => {
-    console.log('Recomputing deleteGroupCount');
-    console.log('Current num delete rights:', properties.accessRights.filter(
-        (g) => g.rights === AccessGroupRights.DELETE
-    ).length);
     return properties.accessRights.filter(
-        (g) => g.rights === AccessGroupRights.DELETE
+        (g) => g.rights === AccessGroupRights.DELETE,
     ).length;
 });
-
 
 //Prevent downgrading the last group with DELETE rights
 const isDisabledRightOption = (
@@ -159,7 +159,10 @@ const isDisabledRightOption = (
     rightOption: AccessGroupRights,
 ): boolean => {
     // If they are trying to select a right lower than DELETE...
-    if (group.rights === AccessGroupRights.DELETE && rightOption < AccessGroupRights.DELETE) {
+    if (
+        group.rights === AccessGroupRights.DELETE &&
+        rightOption < AccessGroupRights.DELETE
+    ) {
         // ...disable it if this is the ONLY group with DELETE rights
         return deleteGroupCount.value <= 1;
     }
@@ -173,5 +176,4 @@ const isDeleteDisabled = (group: DefaultRightDto): boolean => {
     }
     return false;
 };
-
 </script>

--- a/frontend/src/dialogs/create-project-dialog.vue
+++ b/frontend/src/dialogs/create-project-dialog.vue
@@ -84,9 +84,7 @@
                 </q-tab-panel>
 
                 <q-tab-panel name="manage_access">
-                    <access-rights-manager
-                        v-model="accessGroups"
-                    />
+                    <access-rights-manager v-model="accessGroups" />
                 </q-tab-panel>
             </q-tab-panels>
         </template>
@@ -116,14 +114,13 @@ import BaseDialog from 'src/dialogs/base-dialog.vue';
 
 import type { DefaultRightDto } from '@kleinkram/api-dto/types/access-control/default-right.dto';
 import type { TagTypeDto } from '@kleinkram/api-dto/types/tags/tags.dto';
-import { AccessGroupType } from '@kleinkram/shared';
 import { useQueryClient } from '@tanstack/vue-query';
 import AccessRightsManager from 'components/configure-access-rights/access-rights-manager.vue';
 import ConfigureMetadata from 'components/configure-metadata.vue';
 import { QInput, useDialogPluginComponent, useQuasar } from 'quasar';
 import { useProjectDefaultAccess } from 'src/hooks/query-hooks';
 import { createProject } from 'src/services/mutations/project';
-import { computed, Ref, ref, watch } from 'vue';
+import { Ref, ref, watch } from 'vue';
 
 const formIsValid = ref(false);
 const isInErrorStateProjectName = ref(false);

--- a/frontend/src/dialogs/create-project-dialog.vue
+++ b/frontend/src/dialogs/create-project-dialog.vue
@@ -86,7 +86,6 @@
                 <q-tab-panel name="manage_access">
                     <access-rights-manager
                         v-model="accessGroups"
-                        :min-access-rights="minAccessRights"
                     />
                 </q-tab-panel>
             </q-tab-panels>
@@ -146,14 +145,6 @@ const selected: Ref<TagTypeDto[]> = ref([]);
 const $q = useQuasar();
 
 const { data: defaultRights } = useProjectDefaultAccess();
-
-const minAccessRights = computed(() =>
-    defaultRights.value
-        ? defaultRights.value.data.filter(
-              (r) => r.type === AccessGroupType.PRIMARY,
-          )
-        : [],
-);
 
 const accessGroups = ref<DefaultRightDto[]>(defaultRights.value?.data ?? []);
 watch(defaultRights, () => {

--- a/frontend/src/dialogs/modify-access-rights-dialog.vue
+++ b/frontend/src/dialogs/modify-access-rights-dialog.vue
@@ -3,9 +3,7 @@
         <template #title>Change Access Rights</template>
 
         <template #content>
-            <access-rights-manager
-                v-model="modifiableAccessRights"
-            />
+            <access-rights-manager v-model="modifiableAccessRights" />
         </template>
 
         <template #actions>
@@ -20,20 +18,20 @@
 </template>
 
 <script setup lang="ts">
+import { AccessGroupRights, UserRole } from '@kleinkram/shared';
 import AccessRightsManager from 'components/configure-access-rights/access-rights-manager.vue';
-import { useDialogPluginComponent } from 'quasar';
+import { useDialogPluginComponent, useQuasar } from 'quasar';
 import BaseDialog from 'src/dialogs/base-dialog.vue';
 import { useUpdateAccessRightsMutation } from 'src/hooks/mutation-hooks';
-import {
-    useProjectAccessRights,
-} from 'src/hooks/query-hooks';
+import { useProjectAccessRights, useUser } from 'src/hooks/query-hooks';
 import { useEditablePaginatedResponse } from 'src/hooks/utility-hooks';
 
 const { projectUuid: projectUuid } = defineProps<{ projectUuid: string }>();
 
 const { dialogRef, onDialogOK } = useDialogPluginComponent();
+const $q = useQuasar();
 
-
+const { data: user } = useUser();
 const { data: projectAccess } = useProjectAccessRights(projectUuid);
 const modifiableAccessRights = useEditablePaginatedResponse(projectAccess);
 
@@ -43,7 +41,48 @@ const { mutate: changeAccessRights } = useUpdateAccessRightsMutation(
 );
 
 const confirmAccessRightsModification: () => void = () => {
-    changeAccessRights();
-    onDialogOK();
+    if (!user.value) return;
+
+    const userAccessGroupUuids = new Set(
+        user.value.memberships
+            .map((m) => m.accessGroup?.uuid)
+            .filter((uuid): uuid is string => !!uuid),
+    );
+
+    const hadDelete = (projectAccess.value?.data ?? []).some(
+        (access) =>
+            access.rights >= AccessGroupRights.DELETE &&
+            userAccessGroupUuids.has(access.uuid),
+    );
+
+    const hasDelete = modifiableAccessRights.value.some(
+        (access) =>
+            access.rights >= AccessGroupRights.DELETE &&
+            userAccessGroupUuids.has(access.uuid),
+    );
+
+    if (hadDelete && !hasDelete && user.value.role !== UserRole.ADMIN) {
+        $q.dialog({
+            title: 'Warning: Loss of Delete Rights',
+            message:
+                'You are transferring DELETE rights away from yourself. Once confirmed, you may no longer be able to delete this project, or manage its access rights. Are you sure you want to continue?',
+            cancel: {
+                label: 'Cancel',
+                flat: true,
+            },
+            ok: {
+                label: 'Confirm Transfer',
+                color: 'negative',
+                flat: true,
+            },
+            persistent: true,
+        }).onOk(() => {
+            changeAccessRights();
+            onDialogOK();
+        });
+    } else {
+        changeAccessRights();
+        onDialogOK();
+    }
 };
 </script>

--- a/frontend/src/dialogs/modify-access-rights-dialog.vue
+++ b/frontend/src/dialogs/modify-access-rights-dialog.vue
@@ -5,7 +5,6 @@
         <template #content>
             <access-rights-manager
                 v-model="modifiableAccessRights"
-                :min-access-rights="minAccessRights"
             />
         </template>
 
@@ -26,7 +25,6 @@ import { useDialogPluginComponent } from 'quasar';
 import BaseDialog from 'src/dialogs/base-dialog.vue';
 import { useUpdateAccessRightsMutation } from 'src/hooks/mutation-hooks';
 import {
-    useMinimalAccessRightsForNewProject,
     useProjectAccessRights,
 } from 'src/hooks/query-hooks';
 import { useEditablePaginatedResponse } from 'src/hooks/utility-hooks';
@@ -35,7 +33,7 @@ const { projectUuid: projectUuid } = defineProps<{ projectUuid: string }>();
 
 const { dialogRef, onDialogOK } = useDialogPluginComponent();
 
-const minAccessRights = useMinimalAccessRightsForNewProject();
+
 const { data: projectAccess } = useProjectAccessRights(projectUuid);
 const modifiableAccessRights = useEditablePaginatedResponse(projectAccess);
 

--- a/frontend/src/hooks/query-hooks.ts
+++ b/frontend/src/hooks/query-hooks.ts
@@ -2,7 +2,6 @@ import type { MissionsDto } from '@kleinkram/api-dto';
 import type { AccessGroupAuditLogsDto } from '@kleinkram/api-dto/types/access-control/access-group-audit-logs.dto';
 import type { AccessGroupDto } from '@kleinkram/api-dto/types/access-control/access-group.dto';
 import type { AccessGroupsDto } from '@kleinkram/api-dto/types/access-control/access-groups.dto';
-import type { DefaultRightDto } from '@kleinkram/api-dto/types/access-control/default-right.dto';
 import type { DefaultRights } from '@kleinkram/api-dto/types/access-control/default-rights';
 import type { ProjectAccessListDto } from '@kleinkram/api-dto/types/access-control/project-access.dto';
 import type { ActionWorkersDto } from '@kleinkram/api-dto/types/action-workers.dto';
@@ -397,7 +396,6 @@ export const useProjectDefaultAccess = (): UseQueryReturnType<
         queryFn: getProjectDefaultAccess,
     });
 };
-
 
 export const useProjectAccessRights: (
     projectAccessUuid: string,

--- a/frontend/src/hooks/query-hooks.ts
+++ b/frontend/src/hooks/query-hooks.ts
@@ -398,24 +398,6 @@ export const useProjectDefaultAccess = (): UseQueryReturnType<
     });
 };
 
-/**
- * Fetches the minimal access rights for a new project. The minimal access rights
- * for a new project consists of the following rights:
- *
- * - DELETE access for the creator
- *
- */
-export const useMinimalAccessRightsForNewProject = (): ComputedRef<
-    DefaultRightDto[]
-> => {
-    const { data: defaultRights } = useProjectDefaultAccess();
-    return computed<DefaultRightDto[]>(
-        () =>
-            unref(defaultRights)?.data.filter(
-                (r: DefaultRightDto) => r.type === AccessGroupType.PRIMARY,
-            ) ?? [],
-    );
-};
 
 export const useProjectAccessRights: (
     projectAccessUuid: string,


### PR DESCRIPTION
The logic for what kind of modifications to the project access rights are allowed (on the frontend) was buggy and allowed behavior that is inconsistent with the validations done in the backend. This pull request adjusts the frontend validatgions to access rights modifications to match the backend. Specifically, there is now only one rule: There must always be at least one group with DELETE rights. This PR also adds a warning popup in the case that a user tries to transfer project ownership  (DELETE rights) to another user or a group that they are not part of.