### PR TITLE
fix: set default timeout for AuthenticatedClient to 60 seconds

### DIFF
--- a/cli/kleinkram/api/client.py
+++ b/cli/kleinkram/api/client.py
@@ -68,6 +68,7 @@ class AuthenticatedClient(httpx.Client):
     _config_lock: Lock
 
     def __init__(self, config_path: Path = CONFIG_PATH, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("timeout", 60.0)
         super().__init__(*args, **kwargs)
 
         self._config = get_config(path=config_path)


### PR DESCRIPTION
This pull request makes a minor improvement to the `AuthenticatedClient` class by setting a default timeout for HTTP requests. This ensures that requests will not hang indefinitely if a timeout is not explicitly specified.

* Set a default timeout of 60 seconds for all requests in the `AuthenticatedClient` class (`cli/kleinkram/api/client.py`).