### PR TITLE
fix: metadata update mapping & tag deletion (issue #2238)

### DIFF
--- a/backend/src/services/queue.service.ts
+++ b/backend/src/services/queue.service.ts
@@ -343,7 +343,7 @@ export class QueueService implements OnModuleInit {
                 }
             }
         }
-        return {};
+        return { success: true };
     }
 
     async cancelProcessing(

--- a/backend/src/services/tag.service.ts
+++ b/backend/src/services/tag.service.ts
@@ -195,7 +195,6 @@ export class TagService {
                         value = Number.parseInt(value as string);
                     }
 
-
                     exsitingTag.value_number = value as number;
                     break;
                 }

--- a/backend/src/services/tag.service.ts
+++ b/backend/src/services/tag.service.ts
@@ -195,8 +195,8 @@ export class TagService {
                         value = Number.parseInt(value as string);
                     }
 
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-                    (exsitingTag as any)[tagType.datatype] = value as number;
+
+                    exsitingTag.value_number = value as number;
                     break;
                 }
                 throw new UnprocessableEntityException(
@@ -212,8 +212,7 @@ export class TagService {
                     );
                 }
 
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-                (exsitingTag as any)[tagType.datatype] = value;
+                exsitingTag.value_string = value;
                 break;
             }
 
@@ -223,8 +222,7 @@ export class TagService {
                         value = value === 'true';
                     }
 
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-                    (exsitingTag as any)[tagType.datatype] = value as boolean;
+                    exsitingTag.value_boolean = value as boolean;
                     break;
                 }
 
@@ -239,8 +237,17 @@ export class TagService {
                     );
                 }
 
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-                (exsitingTag as any)[tagType.datatype] = new Date(value);
+                exsitingTag.value_date = new Date(value);
+                break;
+            }
+            case DataType.LOCATION: {
+                if (typeof value !== 'string') {
+                    throw new UnprocessableEntityException(
+                        'Value must be a string',
+                    );
+                }
+
+                exsitingTag.value_location = value;
                 break;
             }
 
@@ -264,7 +271,7 @@ export class TagService {
 
     async deleteTag(uuid: string): Promise<DeleteTagDto> {
         await this.tagRepository.delete({ uuid });
-        return {};
+        return { success: true };
     }
 
     async getAll(skip: number, take: number): Promise<TagTypesDto> {

--- a/frontend/src/services/mutations/tag.ts
+++ b/frontend/src/services/mutations/tag.ts
@@ -2,9 +2,7 @@ import { DataType } from '@kleinkram/shared';
 import axios from 'src/api/axios';
 
 export const removeTag = async (tagUUID: string) => {
-    const response = await axios.delete('/tag/deleteTag', {
-        params: { uuid: tagUUID },
-    });
+    const response = await axios.delete(`/tag/${tagUUID}`);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return response.data;
 };

--- a/packages/api-dto/src/types/delete-mission-response.dto.ts
+++ b/packages/api-dto/src/types/delete-mission-response.dto.ts
@@ -1,2 +1,12 @@
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
-export class DeleteMissionResponseDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+
+export class DeleteMissionResponseDto {
+    @ApiProperty({
+        description: 'Indicates the deletion was successful',
+        example: true,
+        type: Boolean,
+    })
+    @IsBoolean()
+    success!: boolean;
+}

--- a/packages/api-dto/src/types/project/delete-project-response.dto.ts
+++ b/packages/api-dto/src/types/project/delete-project-response.dto.ts
@@ -1,2 +1,12 @@
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
-export class DeleteProjectResponseDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+
+export class DeleteProjectResponseDto {
+    @ApiProperty({
+        description: 'Indicates the deletion was successful',
+        example: true,
+        type: Boolean,
+    })
+    @IsBoolean()
+    success!: boolean;
+}

--- a/packages/api-dto/src/types/tags/delete-tag.dto.ts
+++ b/packages/api-dto/src/types/tags/delete-tag.dto.ts
@@ -1,2 +1,12 @@
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
-export class DeleteTagDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+
+export class DeleteTagDto {
+    @ApiProperty({
+        description: 'Indicates the deletion was successful',
+        example: true,
+        type: Boolean,
+    })
+    @IsBoolean()
+    success!: boolean;
+}


### PR DESCRIPTION
This PR fixes two metadata issues listed in #2238:

1. **Metadata Update Failure**: The updateTagType backend service was setting values on the MetadataEntity using `(exsitingTag as any)[tagType.datatype] = value`, where `tagType.datatype` was the uppercase enum value (e.g., `STRING`). The actual property name on the database entity is `value_string`, so the updates were silently ignored by TypeORM since it was a non-existent property on the entity.
2. **Metadata Deletion Failure (500 Internal Server Error)**:
   - The frontend was calling `DELETE /tag/deleteTag?uuid=tagUUID`, which matched the `DELETE /tag/:uuid` wildcard route in the backend with the value `'deleteTag'`. This has been corrected to use the proper REST path `/tag/${tagUUID}`.
   - The backend's validation interceptor (`GlobalResponseValidationInterceptor`) rejected empty response DTOs (like `DeleteTagDto`) with no validation decorators, causing 500 errors. We've added a `success: boolean` field and decorators to `DeleteTagDto`, `DeleteMissionResponseDto`, and `DeleteProjectResponseDto` and updated the services to return `{ success: true }`.