### PR TITLE
Fix: Move files via PUT /files/:uuid bypasses mission checks

### DIFF
--- a/backend/src/endpoints/file/file.controller.ts
+++ b/backend/src/endpoints/file/file.controller.ts
@@ -197,6 +197,7 @@ export class FileController {
             dto,
             auth.user,
             auth.apiKey?.action,
+            auth.apiKey,
         );
         return plainToInstance(FileDto, file, {
             excludeExtraneousValues: true,

--- a/backend/src/services/file-lifecycle.service.ts
+++ b/backend/src/services/file-lifecycle.service.ts
@@ -1,5 +1,7 @@
+import { MissionGuardService } from '@/endpoints/auth/mission-guard.service';
 import { TriggerService } from '@/services/trigger.service';
 import { TemporaryFileAccessesDto, UpdateFile } from '@kleinkram/api-dto';
+import { ApiKeyEntity } from '@kleinkram/backend-common';
 import { FileAuditService } from '@kleinkram/backend-common/audit/file-audit.service';
 import { redis } from '@kleinkram/backend-common/consts';
 import { ActionEntity } from '@kleinkram/backend-common/entities/action/action.entity';
@@ -14,6 +16,7 @@ import {
     StorageCredentials,
 } from '@kleinkram/backend-common/modules/storage/types';
 import {
+    AccessGroupRights,
     FileEventType,
     FileOrigin,
     FileState,
@@ -23,6 +26,7 @@ import {
 import {
     BadRequestException,
     ConflictException,
+    ForbiddenException,
     Inject,
     Injectable,
     NotFoundException,
@@ -68,6 +72,7 @@ export class FileLifecycleService implements OnModuleInit {
         private readonly dataSource: DataSource,
         private readonly auditService: FileAuditService,
         private readonly triggerService: TriggerService,
+        private readonly missionGuardService: MissionGuardService,
     ) {}
 
     onModuleInit(): void {
@@ -81,6 +86,7 @@ export class FileLifecycleService implements OnModuleInit {
         file: UpdateFile,
         actor?: UserEntity,
         action?: ActionEntity,
+        apiKey?: ApiKeyEntity,
     ): Promise<FileEntity | null> {
         logger.debug(`Updating file with uuid: ${uuid}`);
 
@@ -120,6 +126,35 @@ export class FileLifecycleService implements OnModuleInit {
             file.missionUuid &&
             file.missionUuid !== databaseFile.mission.uuid
         ) {
+            const newMissionUuid = file.missionUuid;
+
+            if (apiKey) {
+                if (newMissionUuid !== apiKey.mission.uuid) {
+                    throw new ForbiddenException(
+                        'API keys cannot move files to a different mission.',
+                    );
+                }
+                if (apiKey.rights < AccessGroupRights.CREATE) {
+                    throw new ForbiddenException(
+                        'API Key does not have CREATE permission on the destination mission.',
+                    );
+                }
+            } else if (actor) {
+                const hasCreateAccess =
+                    await this.missionGuardService.canAccessMission(
+                        actor,
+                        newMissionUuid,
+                        AccessGroupRights.CREATE,
+                    );
+                if (!hasCreateAccess) {
+                    throw new ForbiddenException(
+                        'User does not have CREATE permission on the destination mission.',
+                    );
+                }
+            } else {
+                throw new ForbiddenException('Unauthorized action.');
+            }
+
             oldMissionUuid = databaseFile.mission.uuid;
             const newMission = await this.missionRepository.findOneOrFail({
                 where: { uuid: file.missionUuid },

--- a/backend/src/services/file-lifecycle.service.ts
+++ b/backend/src/services/file-lifecycle.service.ts
@@ -126,34 +126,7 @@ export class FileLifecycleService implements OnModuleInit {
             file.missionUuid &&
             file.missionUuid !== databaseFile.mission.uuid
         ) {
-            const newMissionUuid = file.missionUuid;
-
-            if (apiKey) {
-                if (newMissionUuid !== apiKey.mission.uuid) {
-                    throw new ForbiddenException(
-                        'API keys cannot move files to a different mission.',
-                    );
-                }
-                if (apiKey.rights < AccessGroupRights.CREATE) {
-                    throw new ForbiddenException(
-                        'API Key does not have CREATE permission on the destination mission.',
-                    );
-                }
-            } else if (actor) {
-                const hasCreateAccess =
-                    await this.missionGuardService.canAccessMission(
-                        actor,
-                        newMissionUuid,
-                        AccessGroupRights.CREATE,
-                    );
-                if (!hasCreateAccess) {
-                    throw new ForbiddenException(
-                        'User does not have CREATE permission on the destination mission.',
-                    );
-                }
-            } else {
-                throw new ForbiddenException('Unauthorized action.');
-            }
+            await this.checkMovePermission(file.missionUuid, actor, apiKey);
 
             oldMissionUuid = databaseFile.mission.uuid;
             const newMission = await this.missionRepository.findOneOrFail({
@@ -632,5 +605,38 @@ export class FileLifecycleService implements OnModuleInit {
         }
 
         return filesToFix.length;
+    }
+
+    private async checkMovePermission(
+        newMissionUuid: string,
+        actor?: UserEntity,
+        apiKey?: ApiKeyEntity,
+    ): Promise<void> {
+        if (apiKey) {
+            if (newMissionUuid !== apiKey.mission.uuid) {
+                throw new ForbiddenException(
+                    'API keys cannot move files to a different mission.',
+                );
+            }
+            if (apiKey.rights < AccessGroupRights.CREATE) {
+                throw new ForbiddenException(
+                    'API Key does not have CREATE permission on the destination mission.',
+                );
+            }
+        } else if (actor) {
+            const hasCreateAccess =
+                await this.missionGuardService.canAccessMission(
+                    actor,
+                    newMissionUuid,
+                    AccessGroupRights.CREATE,
+                );
+            if (!hasCreateAccess) {
+                throw new ForbiddenException(
+                    'User does not have CREATE permission on the destination mission.',
+                );
+            }
+        } else {
+            throw new ForbiddenException('Unauthorized action.');
+        }
     }
 }

--- a/backend/tests/actions/api-key-scope.test.ts
+++ b/backend/tests/actions/api-key-scope.test.ts
@@ -8,6 +8,7 @@ import {
     ActionEntity,
     ActionTemplateEntity,
     ApiKeyEntity,
+    FileEntity,
     MissionEntity,
     ProjectEntity,
     UserEntity,
@@ -19,6 +20,7 @@ import {
     createMissionUsingPost,
     createProjectUsingPost,
     HeaderCreator,
+    uploadFile,
 } from '../utils/api-calls';
 import { clearAllData, database } from '../utils/database-utilities';
 
@@ -295,5 +297,159 @@ describe('Verify Action API Key Scope', () => {
         );
 
         expect(projectResponse.status).toBe(403); // Forbidden
+    });
+
+    test('if an action API key CANNOT move a file to another mission (even in the same project)', async () => {
+        // 1. Submit Action in the original mission
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        const headers = new HeaderCreator(globalThis.creator);
+        headers.addHeader('Content-Type', 'application/json');
+        const submitResponse = await fetch(`${DEFAULT_URL}/actions`, {
+            method: 'POST',
+            headers: headers.getHeaders(),
+            body: JSON.stringify({
+                missionUUID: globalThis.missionUuid,
+                templateUUID: globalThis.templateUuid,
+            } as SubmitActionDto),
+        });
+        expect(submitResponse.status).toBe(201);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const { actionUUID: uuid } = await submitResponse.json();
+
+        // 2. Get API Key
+        const actionRepo = database.getRepository(ActionEntity);
+        const action = await actionRepo.findOneOrFail({
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            where: { uuid },
+        });
+
+        const apiKeyRepo = database.getRepository(ApiKeyEntity);
+        const apiKeyEntity = apiKeyRepo.create({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            key_type: KeyTypes.ACTION,
+            mission: { uuid: globalThis.missionUuid },
+            action: action,
+            rights: AccessGroupRights.WRITE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            user: globalThis.creator,
+        });
+        await apiKeyRepo.save(apiKeyEntity);
+        const apiKey = apiKeyEntity.apikey;
+
+        // 3. Create another mission in the same project
+        const otherMissionUuid = await createMissionUsingPost(
+            {
+                name: 'other_mission_same_project',
+                projectUUID: globalThis.projectUuid,
+                tags: {},
+                ignoreTags: true,
+            },
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            globalThis.creator,
+        );
+        // 4. Upload a file in the original mission using the helper (so it exists on S3)
+        await uploadFile(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            globalThis.creator,
+            'test.bag',
+            globalThis.missionUuid,
+        );
+        const fileRepo = database.getRepository(FileEntity);
+        const file = await fileRepo.findOneByOrFail({ filename: 'test.bag' });
+
+        // 5. Try to move file to the other mission using PUT /files/:uuid
+        const moveResponse = await fetch(`${DEFAULT_URL}/files/${file.uuid}`, {
+            method: 'PUT',
+            headers: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'Content-Type': 'application/json',
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'x-api-key': apiKey,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'kleinkram-client-version': appVersion,
+            },
+            body: JSON.stringify({
+                uuid: file.uuid,
+                filename: 'test.bag',
+                date: file.date.toISOString(),
+                missionUuid: otherMissionUuid,
+            }),
+        });
+
+        expect(moveResponse.status).toBe(403); // Forbidden
+    });
+
+    test('if an action API key CAN update a file filename within its own mission', async () => {
+        // 1. Submit Action in the original mission
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        const headers = new HeaderCreator(globalThis.creator);
+        headers.addHeader('Content-Type', 'application/json');
+        const submitResponse = await fetch(`${DEFAULT_URL}/actions`, {
+            method: 'POST',
+            headers: headers.getHeaders(),
+            body: JSON.stringify({
+                missionUUID: globalThis.missionUuid,
+                templateUUID: globalThis.templateUuid,
+            } as SubmitActionDto),
+        });
+        expect(submitResponse.status).toBe(201);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const { actionUUID: uuid } = await submitResponse.json();
+
+        // 2. Get API Key
+        const actionRepo = database.getRepository(ActionEntity);
+        const action = await actionRepo.findOneOrFail({
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            where: { uuid },
+        });
+
+        const apiKeyRepo = database.getRepository(ApiKeyEntity);
+        const apiKeyEntity = apiKeyRepo.create({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            key_type: KeyTypes.ACTION,
+            mission: { uuid: globalThis.missionUuid },
+            action: action,
+            rights: AccessGroupRights.WRITE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            user: globalThis.creator,
+        });
+        await apiKeyRepo.save(apiKeyEntity);
+        const apiKey = apiKeyEntity.apikey;
+
+        // 3. Upload a file in the original mission using the helper (so it exists on S3)
+        await uploadFile(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            globalThis.creator,
+            'test.bag',
+            globalThis.missionUuid,
+        );
+        const fileRepo = database.getRepository(FileEntity);
+        const file = await fileRepo.findOneByOrFail({ filename: 'test.bag' });
+
+        // 4. Update file filename within the same mission using PUT /files/:uuid
+        const updateResponse = await fetch(
+            `${DEFAULT_URL}/files/${file.uuid}`,
+            {
+                method: 'PUT',
+                headers: {
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    'Content-Type': 'application/json',
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    'x-api-key': apiKey,
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    'kleinkram-client-version': appVersion,
+                },
+                body: JSON.stringify({
+                    uuid: file.uuid,
+                    filename: 'updated.bag',
+                    date: file.date.toISOString(),
+                    missionUuid: globalThis.missionUuid,
+                }),
+            },
+        );
+
+        expect(updateResponse.status).toBe(200);
+        const updatedFile = await fileRepo.findOneByOrFail({ uuid: file.uuid });
+        expect(updatedFile.filename).toBe('updated.bag');
     });
 });


### PR DESCRIPTION
Closes #1915. Fixes Vulnerability C where moving files via `PUT /files/:uuid` bypassed mission checks and allowed API keys/users to move files to missions they do not have CREATE access to. Added integration test cases.