### PR TITLE
Fix header icon hover backgrounds

### DIFF
--- a/frontend/src/components/documentation-icon.vue
+++ b/frontend/src/components/documentation-icon.vue
@@ -3,6 +3,7 @@
         :href="documentationLink"
         round
         flat
+        class="header-icon-button"
         color="grey-8"
         target="_blank"
         icon="sym_o_help"

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -69,6 +69,29 @@ textarea {
     display: none;
 }
 
+.q-header .q-tab .q-focus-helper,
+.q-header .header-icon-button.q-btn--round .q-focus-helper {
+    display: block;
+    width: auto;
+    height: auto;
+    border-radius: $generic-border-radius;
+}
+
+.q-header .header-icon-button.q-btn--round {
+    border-radius: $generic-border-radius;
+}
+
+.q-header .header-icon-button.q-btn--round .q-focus-helper {
+    inset: 4px;
+}
+
+.q-header .q-tab .q-focus-helper {
+    top: 11px;
+    right: -8px;
+    bottom: 11px;
+    left: -8px;
+}
+
 .q-tab,
 .q-tab__content {
     padding: 0;

--- a/frontend/src/layouts/main-layout/header/header-right-menu.vue
+++ b/frontend/src/layouts/main-layout/header/header-right-menu.vue
@@ -8,7 +8,13 @@
             <header-create-menu />
 
             <div style="margin: auto 10px auto 30px" @click="showOverlay">
-                <q-btn round flat color="grey-8" icon="sym_o_export_notes">
+                <q-btn
+                    round
+                    flat
+                    class="header-icon-button"
+                    color="grey-8"
+                    icon="sym_o_export_notes"
+                >
                     <q-tooltip>Processing Uploads</q-tooltip>
                     <q-linear-progress
                         v-if="isUploading"


### PR DESCRIPTION
## Summary
- Restore hover feedback for the responsive header menu tab
- Change Processing Uploads and Support icon hover backgrounds from circular to rounded-square
- Scope the icon-button hover override to header icon buttons so the profile avatar keeps its circular hover

## Screenshots
<img width="129" height="101" alt="image" src="https://github.com/user-attachments/assets/36a0ee96-1e96-42cb-83d2-f7d0e6ddc10a" />
<img width="164" height="99" alt="image" src="https://github.com/user-attachments/assets/ed1f0117-e357-49dd-a02f-fff1b99d528a" />
<img width="266" height="73" alt="image" src="https://github.com/user-attachments/assets/537a140b-a492-4ded-bad0-a2cc7e706909" />


## Validation
- `pnpm exec prettier --check frontend/src/components/documentation-icon.vue frontend/src/css/app.scss frontend/src/layouts/main-layout/header/header-right-menu.vue`
- `pnpm build`

Fixes #381