### PR TITLE
feat(cli): add ability for user to cancle file transfer in CLI via CTRL+C

### DIFF
--- a/cli/kleinkram/api/file_transfer.py
+++ b/cli/kleinkram/api/file_transfer.py
@@ -511,6 +511,7 @@ class UploadResult:
     canceled: int = 0
     total_bytes: int = 0
     elapsed_seconds: float = 0.0
+    interrupted: bool = False
 
 
 @dataclass
@@ -519,6 +520,7 @@ class DownloadResult:
     failed: int = 0
     total_bytes: int = 0
     elapsed_seconds: float = 0.0
+    interrupted: bool = False
 
 
 def _download_state_message(state: DownloadState, path: Path, file: File) -> Optional[Tuple[str, bool]]:
@@ -696,6 +698,7 @@ def upload_files(
     result.elapsed_seconds = monotonic() - start
     if interrupted and on_message_cb is not None:
         on_message_cb("Upload interrupted by user", True)
+    result.interrupted = interrupted
     return result
 
 
@@ -820,4 +823,5 @@ def download_files(
     result.elapsed_seconds = monotonic() - start
     if interrupted and on_message_cb is not None:
         on_message_cb("Download interrupted by user", True)
+    result.interrupted = interrupted
     return result

--- a/cli/kleinkram/api/file_transfer.py
+++ b/cli/kleinkram/api/file_transfer.py
@@ -289,7 +289,7 @@ def upload_file(
                 continue
             else:
                 logger.error(f"Cancelling upload for {path} after {attempt + 1} attempts")
-                raise e from e
+                raise
 
         else:
             _confirm_file_upload(client, creds.file_id, b64_md5(path))

--- a/cli/kleinkram/api/file_transfer.py
+++ b/cli/kleinkram/api/file_transfer.py
@@ -457,6 +457,7 @@ def download_file(
         path.parent.mkdir(parents=True, exist_ok=True)
 
     # download the file and check the hash
+    had_prior_bytes = not overwrite and path.exists() and path.stat().st_size > 0
     try:
         _url_download(
             download_url,
@@ -471,7 +472,7 @@ def download_file(
         # If cancel was requested, treat as cancellation regardless of exception type
         if cancel_event is not None and cancel_event.is_set():
             logger.info(f"Download cancelled for {path}")
-            if path.exists():
+            if (not had_prior_bytes or overwrite) and path.exists():
                 try:
                     path.unlink()
                     logger.info(f"Removed potentially incomplete file {path}")
@@ -480,8 +481,8 @@ def download_file(
             return DownloadState.CANCELED, 0
 
         logger.error(f"Error during download of {path}: {e}")
-        # Attempt to clean up potentially partial file
-        if path.exists():
+        # Only clean up files we created; preserve prior bytes for resume
+        if (not had_prior_bytes or overwrite) and path.exists():
             try:
                 path.unlink()
                 logger.info(f"Removed potentially incomplete file {path}")

--- a/cli/kleinkram/api/file_transfer.py
+++ b/cli/kleinkram/api/file_transfer.py
@@ -635,55 +635,62 @@ def upload_files(
     interrupted = False
     processed_futures: set = set()
 
-    with ThreadPoolExecutor(max_workers=n_workers) as executor:
-        try:
-            for name, path in files.items():
-                if not path.is_file():
-                    logger.warning(f"Skipping non-existent file: {path}")
-                    if on_message_cb is not None:
-                        on_message_cb(f"Skipping non-existent file: {path}", False)
-                    result.skipped += 1
-                    if on_overall_progress_cb is not None:
-                        on_overall_progress_cb()
-                    continue
+    executor = ThreadPoolExecutor(max_workers=n_workers)
+    try:
+        for name, path in files.items():
+            if not path.is_file():
+                logger.warning(f"Skipping non-existent file: {path}")
+                if on_message_cb is not None:
+                    on_message_cb(f"Skipping non-existent file: {path}", False)
+                result.skipped += 1
+                if on_overall_progress_cb is not None:
+                    on_overall_progress_cb()
+                continue
 
-                future = executor.submit(
-                    upload_file,
-                    client=client,
-                    mission_id=mission_id,
-                    filename=name,
-                    path=path,
-                    on_file_start_cb=on_file_start_cb,
-                    on_file_progress_cb=on_file_progress_cb,
+            future = executor.submit(
+                upload_file,
+                client=client,
+                mission_id=mission_id,
+                filename=name,
+                path=path,
+                on_file_start_cb=on_file_start_cb,
+                on_file_progress_cb=on_file_progress_cb,
+                cancel_event=cancel_event,
+            )
+            futures[future] = path
+
+        for future in as_completed(futures):
+            try:
+                processed_futures.add(future)
+                _resolve_upload_future(
+                    future=future,
+                    path=futures[future],
+                    result=result,
                     cancel_event=cancel_event,
+                    executor=executor,
+                    on_message_cb=on_message_cb,
+                    on_overall_progress_cb=on_overall_progress_cb,
                 )
-                futures[future] = path
+            except KeyboardInterrupt:
+                processed_futures.discard(future)
+                raise
 
-            for future in as_completed(futures):
-                try:
-                    processed_futures.add(future)
-                    _resolve_upload_future(
-                        future=future,
-                        path=futures[future],
-                        result=result,
-                        cancel_event=cancel_event,
-                        executor=executor,
-                        on_message_cb=on_message_cb,
-                        on_overall_progress_cb=on_overall_progress_cb,
-                    )
-                except KeyboardInterrupt:
-                    processed_futures.discard(future)
-                    raise
-
-        except KeyboardInterrupt:
-            logger.info("Upload interrupted by user, cancelling...")
-            interrupted = True
-            cancel_event.set()
-            executor.shutdown(wait=False, cancel_futures=True)
+    except KeyboardInterrupt:
+        logger.info("Upload interrupted by user, cancelling...")
+        interrupted = True
+        cancel_event.set()
+        executor.shutdown(wait=False, cancel_futures=True)
+    else:
+        executor.shutdown(wait=True)
 
     if interrupted:
         for future, path in futures.items():
             if future in processed_futures:
+                continue
+            if not future.done():
+                result.canceled += 1
+                if on_overall_progress_cb is not None:
+                    on_overall_progress_cb()
                 continue
             _resolve_upload_future(
                 future=future,
@@ -768,48 +775,55 @@ def download_files(
     interrupted = False
     processed_futures: set = set()
 
-    with ThreadPoolExecutor(max_workers=n_workers) as executor:
-        try:
-            for path, file in files.items():
-                future = executor.submit(
-                    download_file,
-                    client=client,
-                    file=file,
+    executor = ThreadPoolExecutor(max_workers=n_workers)
+    try:
+        for path, file in files.items():
+            future = executor.submit(
+                download_file,
+                client=client,
+                file=file,
+                path=path,
+                overwrite=overwrite,
+                allow_corrupt_files=allow_corrupt_files,
+                create_parents=create_parents,
+                on_file_start_cb=on_file_start_cb,
+                on_file_progress_cb=on_file_progress_cb,
+                cancel_event=cancel_event,
+            )
+            futures[future] = (file, path)
+
+        for future in as_completed(futures):
+            try:
+                processed_futures.add(future)
+                file, path = futures[future]
+                _resolve_download_future(
+                    future=future,
                     path=path,
-                    overwrite=overwrite,
-                    allow_corrupt_files=allow_corrupt_files,
-                    create_parents=create_parents,
-                    on_file_start_cb=on_file_start_cb,
-                    on_file_progress_cb=on_file_progress_cb,
-                    cancel_event=cancel_event,
+                    file=file,
+                    result=result,
+                    on_message_cb=on_message_cb,
+                    on_overall_progress_cb=on_overall_progress_cb,
                 )
-                futures[future] = (file, path)
+            except KeyboardInterrupt:
+                processed_futures.discard(future)
+                raise
 
-            for future in as_completed(futures):
-                try:
-                    processed_futures.add(future)
-                    file, path = futures[future]
-                    _resolve_download_future(
-                        future=future,
-                        path=path,
-                        file=file,
-                        result=result,
-                        on_message_cb=on_message_cb,
-                        on_overall_progress_cb=on_overall_progress_cb,
-                    )
-                except KeyboardInterrupt:
-                    processed_futures.discard(future)
-                    raise
-
-        except KeyboardInterrupt:
-            logger.info("Download interrupted by user, cancelling...")
-            interrupted = True
-            cancel_event.set()
-            executor.shutdown(wait=False, cancel_futures=True)
+    except KeyboardInterrupt:
+        logger.info("Download interrupted by user, cancelling...")
+        interrupted = True
+        cancel_event.set()
+        executor.shutdown(wait=False, cancel_futures=True)
+    else:
+        executor.shutdown(wait=True)
 
     if interrupted:
         for future, (file, path) in futures.items():
             if future in processed_futures:
+                continue
+            if not future.done():
+                result.state_counts[DownloadState.CANCELED] = result.state_counts.get(DownloadState.CANCELED, 0) + 1
+                if on_overall_progress_cb is not None:
+                    on_overall_progress_cb()
                 continue
             _resolve_download_future(
                 future=future,

--- a/cli/kleinkram/api/file_transfer.py
+++ b/cli/kleinkram/api/file_transfer.py
@@ -558,6 +558,62 @@ def _download_state_message(state: DownloadState, path: Path, file: File) -> Opt
     return messages.get(state)
 
 
+def _resolve_upload_future(
+    future: Future[Tuple[UploadState, int]],
+    path: Path,
+    result: UploadResult,
+    cancel_event: threading.Event,
+    executor: Optional[ThreadPoolExecutor] = None,
+    on_message_cb: Optional[OnMessageCb] = None,
+    on_overall_progress_cb: Optional[OnOverallProgressCb] = None,
+    is_cleanup: bool = False,
+) -> None:
+    """Resolves an upload future, updates telemetry, and triggers callbacks."""
+    if future.cancelled():
+        result.canceled += 1
+        if on_overall_progress_cb is not None:
+            on_overall_progress_cb()
+        return
+
+    try:
+        state, size_bytes = future.result()
+    except InsufficientStorageError as e:
+        if on_message_cb is not None:
+            on_message_cb("Upload failed: Insufficient storage space on the server", True)
+        cancel_event.set()
+        if executor is not None:
+            executor.shutdown(wait=False, cancel_futures=True)
+        if not is_cleanup:
+            raise e
+        return
+    except Exception as e:
+        logger.error(format_traceback(e))
+        if on_message_cb is not None:
+            on_message_cb(f"Error uploading {path}: {e}", True)
+        result.failed += 1
+        if on_overall_progress_cb is not None:
+            on_overall_progress_cb()
+        return
+
+    result.total_bytes += size_bytes
+
+    if state == UploadState.UPLOADED:
+        result.uploaded += 1
+        if on_message_cb is not None:
+            on_message_cb(f"uploaded {path}", False)
+    elif state == UploadState.EXISTS:
+        result.skipped += 1
+        if on_message_cb is not None:
+            on_message_cb(f"skipped {path} (already uploaded)", False)
+    elif state == UploadState.CANCELED:
+        result.canceled += 1
+        if on_message_cb is not None:
+            on_message_cb(f"canceled {path} upload", False)
+
+    if on_overall_progress_cb is not None:
+        on_overall_progress_cb()
+
+
 def upload_files(
     client: AuthenticatedClient,
     files: Dict[str, Path],
@@ -602,69 +658,91 @@ def upload_files(
                 futures[future] = path
 
             for future in as_completed(futures):
-                processed_futures.add(future)
-                path = futures[future]
-
                 try:
-                    state, size_bytes = future.result()
-                except InsufficientStorageError as e:
-                    if on_message_cb is not None:
-                        on_message_cb("Upload failed: Insufficient storage space on the server", True)
-                    cancel_event.set()
-                    executor.shutdown(wait=False, cancel_futures=True)
-                    raise e
-                except Exception as e:
-                    logger.error(format_traceback(e))
-                    if on_message_cb is not None:
-                        on_message_cb(f"Error uploading {path}: {e}", True)
-                    result.failed += 1
-                    if on_overall_progress_cb is not None:
-                        on_overall_progress_cb()
-                    continue
+                    processed_futures.add(future)
+                    _resolve_upload_future(
+                        future=future,
+                        path=futures[future],
+                        result=result,
+                        cancel_event=cancel_event,
+                        executor=executor,
+                        on_message_cb=on_message_cb,
+                        on_overall_progress_cb=on_overall_progress_cb,
+                    )
+                except KeyboardInterrupt:
+                    processed_futures.discard(future)
+                    raise
 
-                result.total_bytes += size_bytes
-
-                if state == UploadState.UPLOADED:
-                    result.uploaded += 1
-                    if on_message_cb is not None:
-                        on_message_cb(f"uploaded {path}", False)
-                elif state == UploadState.EXISTS:
-                    result.skipped += 1
-                    if on_message_cb is not None:
-                        on_message_cb(f"skipped {path} (already uploaded)", False)
-                elif state == UploadState.CANCELED:
-                    result.canceled += 1
-                    if on_message_cb is not None:
-                        on_message_cb(f"canceled {path} upload", False)
-
-                if on_overall_progress_cb is not None:
-                    on_overall_progress_cb()
         except KeyboardInterrupt:
             logger.info("Upload interrupted by user, cancelling...")
             interrupted = True
             cancel_event.set()
             executor.shutdown(wait=False, cancel_futures=True)
 
-    # After the with-block, all threads have been joined and every future is
-    # guaranteed to be done() or cancelled(). Drain unprocessed futures safely.
     if interrupted:
-        for future in futures:
+        for future, path in futures.items():
             if future in processed_futures:
                 continue
-            if future.cancelled():
-                result.canceled += 1
-                continue
-            try:
-                state, _ = future.result()
-                if state == UploadState.CANCELED:
-                    result.canceled += 1
-            except Exception:
-                result.failed += 1
+            _resolve_upload_future(
+                future=future,
+                path=path,
+                result=result,
+                cancel_event=cancel_event,
+                on_message_cb=on_message_cb,
+                on_overall_progress_cb=on_overall_progress_cb,
+                is_cleanup=True,
+            )
 
     result.elapsed_seconds = monotonic() - start
     if interrupted and on_message_cb is not None:
         on_message_cb("Upload interrupted by user", True)
     return result
+
+
+def _resolve_download_future(
+    future: Future[Tuple[DownloadState, int]],
+    path: Path,
+    file: File,
+    result: DownloadResult,
+    on_message_cb: Optional[OnMessageCb] = None,
+    on_overall_progress_cb: Optional[OnOverallProgressCb] = None,
+) -> None:
+    """Resolves a download future, updates telemetry, and triggers callbacks."""
+    if future.cancelled():
+        result.state_counts[DownloadState.CANCELED] = result.state_counts.get(DownloadState.CANCELED, 0) + 1
+        if on_overall_progress_cb is not None:
+            on_overall_progress_cb()
+        return
+
+    try:
+        state, size_bytes = future.result()
+    except Exception as e:
+        logger.error(format_traceback(e))
+        if on_message_cb is not None:
+            on_message_cb(f"Error downloading {path}: {e}", True)
+        result.failed += 1
+        if on_overall_progress_cb is not None:
+            on_overall_progress_cb()
+        return
+
+    result.state_counts[state] = result.state_counts.get(state, 0) + 1
+
+    if state in (
+        DownloadState.DOWNLOADED_OK,
+        DownloadState.DOWNLOADED_CORRUPTED,
+        DownloadState.SKIPPED_OK,
+        DownloadState.OVERWRITTEN_OK,
+        DownloadState.OVERWRITTEN_CORRUPTED,
+    ):
+        result.total_bytes += size_bytes
+
+    if on_message_cb is not None:
+        msg = _download_state_message(state, path, file)
+        if msg is not None:
+            on_message_cb(*msg)
+
+    if on_overall_progress_cb is not None:
+        on_overall_progress_cb()
 
 
 def download_files(
@@ -705,59 +783,39 @@ def download_files(
                 futures[future] = (file, path)
 
             for future in as_completed(futures):
-                processed_futures.add(future)
-                file, path = futures[future]
-
                 try:
-                    state, size_bytes = future.result()
-                except Exception as e:
-                    logger.error(format_traceback(e))
-                    if on_message_cb is not None:
-                        on_message_cb(f"Error downloading {path}: {e}", True)
-                    result.failed += 1
-                    if on_overall_progress_cb is not None:
-                        on_overall_progress_cb()
-                    continue
+                    processed_futures.add(future)
+                    file, path = futures[future]
+                    _resolve_download_future(
+                        future=future,
+                        path=path,
+                        file=file,
+                        result=result,
+                        on_message_cb=on_message_cb,
+                        on_overall_progress_cb=on_overall_progress_cb,
+                    )
+                except KeyboardInterrupt:
+                    processed_futures.discard(future)
+                    raise
 
-                result.state_counts[state] = result.state_counts.get(state, 0) + 1
-
-                if state in (
-                    DownloadState.DOWNLOADED_OK,
-                    DownloadState.DOWNLOADED_CORRUPTED,
-                    DownloadState.SKIPPED_OK,
-                    DownloadState.OVERWRITTEN_OK,
-                    DownloadState.OVERWRITTEN_CORRUPTED,
-                ):
-                    result.total_bytes += size_bytes
-
-                # Generate per-file status messages
-                if on_message_cb is not None:
-                    msg = _download_state_message(state, path, file)
-                    if msg is not None:
-                        on_message_cb(*msg)
-
-                if on_overall_progress_cb is not None:
-                    on_overall_progress_cb()
         except KeyboardInterrupt:
             logger.info("Download interrupted by user, cancelling...")
             interrupted = True
             cancel_event.set()
             executor.shutdown(wait=False, cancel_futures=True)
 
-    # After the with-block, all threads have been joined and every future is
-    # guaranteed to be done() or cancelled(). Drain unprocessed futures safely.
     if interrupted:
-        for future in futures:
+        for future, (file, path) in futures.items():
             if future in processed_futures:
                 continue
-            if future.cancelled():
-                result.state_counts[DownloadState.CANCELED] = result.state_counts.get(DownloadState.CANCELED, 0) + 1
-                continue
-            try:
-                state, _ = future.result()
-                result.state_counts[state] = result.state_counts.get(state, 0) + 1
-            except Exception:
-                result.failed += 1
+            _resolve_download_future(
+                future=future,
+                path=path,
+                file=file,
+                result=result,
+                on_message_cb=on_message_cb,
+                on_overall_progress_cb=on_overall_progress_cb,
+            )
 
     result.elapsed_seconds = monotonic() - start
     if interrupted and on_message_cb is not None:

--- a/cli/kleinkram/api/file_transfer.py
+++ b/cli/kleinkram/api/file_transfer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
 from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
@@ -27,6 +28,7 @@ from kleinkram.api.client import AuthenticatedClient
 from kleinkram.config import get_config
 from kleinkram.errors import AccessDenied
 from kleinkram.errors import InsufficientStorageError
+from kleinkram.errors import TransferCancelledError
 from kleinkram.models import File
 from kleinkram.models import FileState
 from kleinkram.utils import b64_md5
@@ -203,7 +205,6 @@ class UploadState(Enum):
     CANCELED = 3
 
 
-# TODO: i dont want to handle errors at this level
 def upload_file(
     client: AuthenticatedClient,
     *,
@@ -213,6 +214,7 @@ def upload_file(
     s3_endpoint: Optional[str] = None,
     on_file_start_cb: Optional[OnFileStartCb] = None,
     on_file_progress_cb: Optional[OnFileProgressCb] = None,
+    cancel_event: Optional[threading.Event] = None,
 ) -> Tuple[UploadState, int]:
     """
     returns UploadState and bytes uploaded (0 if not uploaded)
@@ -224,6 +226,9 @@ def upload_file(
     total_size = path.stat().st_size
 
     for attempt in range(MAX_UPLOAD_RETRIES):
+        if cancel_event is not None and cancel_event.is_set():
+            return UploadState.CANCELED, 0
+
         if on_file_start_cb is not None:
             on_file_start_cb(path, total_size)
 
@@ -233,11 +238,14 @@ def upload_file(
         except FileExistsError:
             return UploadState.EXISTS, 0
 
-        # build the boto3 callback from our file progress callback
-        if on_file_progress_cb is not None:
+        # build the boto3 callback that also checks for cancellation
+        if on_file_progress_cb is not None or cancel_event is not None:
 
             def boto3_cb(bytes_amount):
-                on_file_progress_cb(path, bytes_amount)
+                if cancel_event is not None and cancel_event.is_set():
+                    raise TransferCancelledError("Transfer cancelled by user")
+                if on_file_progress_cb is not None:
+                    on_file_progress_cb(path, bytes_amount)
 
         else:
             boto3_cb = None
@@ -245,6 +253,16 @@ def upload_file(
         try:
             _s3_upload(path, endpoint=s3_endpoint, credentials=creds, callback=boto3_cb)
         except Exception as e:
+            # Check cancellation first — TransferCancelledError or any other
+            # exception raised while cancel_event is set means user-requested abort.
+            if cancel_event is not None and cancel_event.is_set():
+                logger.info(f"Upload cancelled for {path}")
+                try:
+                    _cancel_file_upload(client, creds.file_id, mission_id)
+                except Exception as cancel_e:
+                    logger.warning(f"Failed to cancel server-side upload for {creds.file_id}: {cancel_e}")
+                return UploadState.CANCELED, 0
+
             if _is_s3_out_of_space_error(e):
                 logger.error("Upload failed: S3 storage is out of space.")
                 try:
@@ -262,7 +280,12 @@ def upload_file(
 
             if attempt < MAX_UPLOAD_RETRIES - 1:  # Retry if not the last attempt
                 logger.warning(f"Retrying upload for {path} (attempt {attempt + 1}), retrying after backoff...")
-                sleep(RETRY_BACKOFF_BASE**attempt)
+                sleep_time = RETRY_BACKOFF_BASE**attempt
+                if cancel_event is not None:
+                    if cancel_event.wait(sleep_time):
+                        return UploadState.CANCELED, 0
+                else:
+                    sleep(sleep_time)
                 continue
             else:
                 logger.error(f"Cancelling upload for {path} after {attempt + 1} attempts")
@@ -307,6 +330,7 @@ def _url_download(
     overwrite: bool = False,
     on_file_start_cb: Optional[OnFileStartCb] = None,
     on_file_progress_cb: Optional[OnFileProgressCb] = None,
+    cancel_event: Optional[threading.Event] = None,
 ) -> None:
     if path.exists():
         if overwrite:
@@ -335,6 +359,8 @@ def _url_download(
                 mode = "ab" if downloaded > 0 else "wb"
                 with open(path, mode) as f:
                     for chunk in response.iter_bytes(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                        if cancel_event is not None and cancel_event.is_set():
+                            raise TransferCancelledError("Transfer cancelled by user")
                         attempt = 0  # reset attempt counter on successful download of non-empty chunk
                         if not chunk:
                             break
@@ -343,13 +369,20 @@ def _url_download(
                         if on_file_progress_cb is not None:
                             on_file_progress_cb(path, len(chunk))
             break  # download complete
+        except TransferCancelledError:
+            raise
         except Exception as e:
             logger.info(f"Error: {e}, retrying...")
             attempt += 1
             if attempt > MAX_RETRIES:
                 raise RuntimeError(f"Download failed after {MAX_RETRIES} retries due to {e}") from e
             logger.warning(f"{e} on attempt {attempt}/{MAX_RETRIES}, retrying after backoff...")
-            sleep(RETRY_BACKOFF_BASE**attempt)
+            sleep_time = RETRY_BACKOFF_BASE**attempt
+            if cancel_event is not None:
+                if cancel_event.wait(sleep_time):
+                    raise TransferCancelledError("Transfer cancelled by user")
+            else:
+                sleep(sleep_time)
 
 
 class DownloadState(Enum):
@@ -364,6 +397,7 @@ class DownloadState(Enum):
     SKIPPED_CORRUPTED_LOCAL_OK = 9
     OVERWRITTEN_OK = 10
     OVERWRITTEN_CORRUPTED = 11
+    CANCELED = 12
 
 
 def download_file(
@@ -376,10 +410,14 @@ def download_file(
     create_parents: bool = False,
     on_file_start_cb: Optional[OnFileStartCb] = None,
     on_file_progress_cb: Optional[OnFileProgressCb] = None,
+    cancel_event: Optional[threading.Event] = None,
 ) -> Tuple[DownloadState, int]:
     """\
     Returns DownloadState and bytes downloaded (file.size if successful or skipped ok, 0 otherwise)
     """
+    if cancel_event is not None and cancel_event.is_set():
+        return DownloadState.CANCELED, 0
+
     is_corrupted = file.state == FileState.CORRUPTED
 
     if file.state not in (FileState.OK, FileState.CORRUPTED):
@@ -427,8 +465,20 @@ def download_file(
             overwrite=overwrite,
             on_file_start_cb=on_file_start_cb,
             on_file_progress_cb=on_file_progress_cb,
+            cancel_event=cancel_event,
         )
     except Exception as e:
+        # If cancel was requested, treat as cancellation regardless of exception type
+        if cancel_event is not None and cancel_event.is_set():
+            logger.info(f"Download cancelled for {path}")
+            if path.exists():
+                try:
+                    path.unlink()
+                    logger.info(f"Removed potentially incomplete file {path}")
+                except OSError as unlink_e:
+                    logger.error(f"Could not remove partial file {path}: {unlink_e}")
+            return DownloadState.CANCELED, 0
+
         logger.error(f"Error during download of {path}: {e}")
         # Attempt to clean up potentially partial file
         if path.exists():
@@ -458,6 +508,7 @@ class UploadResult:
     uploaded: int = 0
     skipped: int = 0
     failed: int = 0
+    canceled: int = 0
     total_bytes: int = 0
     elapsed_seconds: float = 0.0
 
@@ -502,6 +553,7 @@ def _download_state_message(state: DownloadState, path: Path, file: File) -> Opt
             f"skipped {path}, already present locally (hash ok) but remote file is CORRUPTED; " "treat as potentially harmful",
             True,
         ),
+        DownloadState.CANCELED: (f"canceled {path} download", False),
     }
     return messages.get(state)
 
@@ -521,67 +573,97 @@ def upload_files(
     futures: Dict[Future[Tuple[UploadState, int]], Path] = {}
 
     result = UploadResult()
+    cancel_event = threading.Event()
+    interrupted = False
+    processed_futures: set = set()
 
     with ThreadPoolExecutor(max_workers=n_workers) as executor:
-        for name, path in files.items():
-            if not path.is_file():
-                logger.warning(f"Skipping non-existent file: {path}")
-                if on_message_cb is not None:
-                    on_message_cb(f"Skipping non-existent file: {path}", False)
-                result.skipped += 1
+        try:
+            for name, path in files.items():
+                if not path.is_file():
+                    logger.warning(f"Skipping non-existent file: {path}")
+                    if on_message_cb is not None:
+                        on_message_cb(f"Skipping non-existent file: {path}", False)
+                    result.skipped += 1
+                    if on_overall_progress_cb is not None:
+                        on_overall_progress_cb()
+                    continue
+
+                future = executor.submit(
+                    upload_file,
+                    client=client,
+                    mission_id=mission_id,
+                    filename=name,
+                    path=path,
+                    on_file_start_cb=on_file_start_cb,
+                    on_file_progress_cb=on_file_progress_cb,
+                    cancel_event=cancel_event,
+                )
+                futures[future] = path
+
+            for future in as_completed(futures):
+                processed_futures.add(future)
+                path = futures[future]
+
+                try:
+                    state, size_bytes = future.result()
+                except InsufficientStorageError as e:
+                    if on_message_cb is not None:
+                        on_message_cb("Upload failed: Insufficient storage space on the server", True)
+                    cancel_event.set()
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    raise e
+                except Exception as e:
+                    logger.error(format_traceback(e))
+                    if on_message_cb is not None:
+                        on_message_cb(f"Error uploading {path}: {e}", True)
+                    result.failed += 1
+                    if on_overall_progress_cb is not None:
+                        on_overall_progress_cb()
+                    continue
+
+                result.total_bytes += size_bytes
+
+                if state == UploadState.UPLOADED:
+                    result.uploaded += 1
+                    if on_message_cb is not None:
+                        on_message_cb(f"uploaded {path}", False)
+                elif state == UploadState.EXISTS:
+                    result.skipped += 1
+                    if on_message_cb is not None:
+                        on_message_cb(f"skipped {path} (already uploaded)", False)
+                elif state == UploadState.CANCELED:
+                    result.canceled += 1
+                    if on_message_cb is not None:
+                        on_message_cb(f"canceled {path} upload", False)
+
                 if on_overall_progress_cb is not None:
                     on_overall_progress_cb()
+        except KeyboardInterrupt:
+            logger.info("Upload interrupted by user, cancelling...")
+            interrupted = True
+            cancel_event.set()
+            executor.shutdown(wait=False, cancel_futures=True)
+
+    # After the with-block, all threads have been joined and every future is
+    # guaranteed to be done() or cancelled(). Drain unprocessed futures safely.
+    if interrupted:
+        for future in futures:
+            if future in processed_futures:
                 continue
-
-            future = executor.submit(
-                upload_file,
-                client=client,
-                mission_id=mission_id,
-                filename=name,
-                path=path,
-                on_file_start_cb=on_file_start_cb,
-                on_file_progress_cb=on_file_progress_cb,
-            )
-            futures[future] = path
-
-        for future in as_completed(futures):
-            path = futures[future]
-
+            if future.cancelled():
+                result.canceled += 1
+                continue
             try:
-                state, size_bytes = future.result()
-            except InsufficientStorageError as e:
-                if on_message_cb is not None:
-                    on_message_cb("Upload failed: Insufficient storage space on the server", True)
-                executor.shutdown(wait=False, cancel_futures=True)
-                raise e
-            except Exception as e:
-                logger.error(format_traceback(e))
-                if on_message_cb is not None:
-                    on_message_cb(f"Error uploading {path}: {e}", True)
+                state, _ = future.result()
+                if state == UploadState.CANCELED:
+                    result.canceled += 1
+            except Exception:
                 result.failed += 1
-                if on_overall_progress_cb is not None:
-                    on_overall_progress_cb()
-                continue
-
-            result.total_bytes += size_bytes
-
-            if state == UploadState.UPLOADED:
-                result.uploaded += 1
-                if on_message_cb is not None:
-                    on_message_cb(f"uploaded {path}", False)
-            elif state == UploadState.EXISTS:
-                result.skipped += 1
-                if on_message_cb is not None:
-                    on_message_cb(f"skipped {path} (already uploaded)", False)
-            else:
-                result.failed += 1
-                if on_message_cb is not None:
-                    on_message_cb(f"canceled {path} upload", True)
-
-            if on_overall_progress_cb is not None:
-                on_overall_progress_cb()
 
     result.elapsed_seconds = monotonic() - start
+    if interrupted and on_message_cb is not None:
+        on_message_cb("Upload interrupted by user", True)
     return result
 
 
@@ -601,55 +683,83 @@ def download_files(
     start = monotonic()
     futures: Dict[Future[Tuple[DownloadState, int]], Tuple[File, Path]] = {}
     result = DownloadResult()
+    cancel_event = threading.Event()
+    interrupted = False
+    processed_futures: set = set()
 
     with ThreadPoolExecutor(max_workers=n_workers) as executor:
-        for path, file in files.items():
-            future = executor.submit(
-                download_file,
-                client=client,
-                file=file,
-                path=path,
-                overwrite=overwrite,
-                allow_corrupt_files=allow_corrupt_files,
-                create_parents=create_parents,
-                on_file_start_cb=on_file_start_cb,
-                on_file_progress_cb=on_file_progress_cb,
-            )
-            futures[future] = (file, path)
+        try:
+            for path, file in files.items():
+                future = executor.submit(
+                    download_file,
+                    client=client,
+                    file=file,
+                    path=path,
+                    overwrite=overwrite,
+                    allow_corrupt_files=allow_corrupt_files,
+                    create_parents=create_parents,
+                    on_file_start_cb=on_file_start_cb,
+                    on_file_progress_cb=on_file_progress_cb,
+                    cancel_event=cancel_event,
+                )
+                futures[future] = (file, path)
 
-        for future in as_completed(futures):
-            file, path = futures[future]
+            for future in as_completed(futures):
+                processed_futures.add(future)
+                file, path = futures[future]
 
-            try:
-                state, size_bytes = future.result()
-            except Exception as e:
-                logger.error(format_traceback(e))
+                try:
+                    state, size_bytes = future.result()
+                except Exception as e:
+                    logger.error(format_traceback(e))
+                    if on_message_cb is not None:
+                        on_message_cb(f"Error downloading {path}: {e}", True)
+                    result.failed += 1
+                    if on_overall_progress_cb is not None:
+                        on_overall_progress_cb()
+                    continue
+
+                result.state_counts[state] = result.state_counts.get(state, 0) + 1
+
+                if state in (
+                    DownloadState.DOWNLOADED_OK,
+                    DownloadState.DOWNLOADED_CORRUPTED,
+                    DownloadState.SKIPPED_OK,
+                    DownloadState.OVERWRITTEN_OK,
+                    DownloadState.OVERWRITTEN_CORRUPTED,
+                ):
+                    result.total_bytes += size_bytes
+
+                # Generate per-file status messages
                 if on_message_cb is not None:
-                    on_message_cb(f"Error downloading {path}: {e}", True)
-                result.failed += 1
+                    msg = _download_state_message(state, path, file)
+                    if msg is not None:
+                        on_message_cb(*msg)
+
                 if on_overall_progress_cb is not None:
                     on_overall_progress_cb()
+        except KeyboardInterrupt:
+            logger.info("Download interrupted by user, cancelling...")
+            interrupted = True
+            cancel_event.set()
+            executor.shutdown(wait=False, cancel_futures=True)
+
+    # After the with-block, all threads have been joined and every future is
+    # guaranteed to be done() or cancelled(). Drain unprocessed futures safely.
+    if interrupted:
+        for future in futures:
+            if future in processed_futures:
                 continue
-
-            result.state_counts[state] = result.state_counts.get(state, 0) + 1
-
-            if state in (
-                DownloadState.DOWNLOADED_OK,
-                DownloadState.DOWNLOADED_CORRUPTED,
-                DownloadState.SKIPPED_OK,
-                DownloadState.OVERWRITTEN_OK,
-                DownloadState.OVERWRITTEN_CORRUPTED,
-            ):
-                result.total_bytes += size_bytes
-
-            # Generate per-file status messages
-            if on_message_cb is not None:
-                msg = _download_state_message(state, path, file)
-                if msg is not None:
-                    on_message_cb(*msg)
-
-            if on_overall_progress_cb is not None:
-                on_overall_progress_cb()
+            if future.cancelled():
+                result.state_counts[DownloadState.CANCELED] = result.state_counts.get(DownloadState.CANCELED, 0) + 1
+                continue
+            try:
+                state, _ = future.result()
+                result.state_counts[state] = result.state_counts.get(state, 0) + 1
+            except Exception:
+                result.failed += 1
 
     result.elapsed_seconds = monotonic() - start
+    if interrupted and on_message_cb is not None:
+        on_message_cb("Download interrupted by user", True)
     return result

--- a/cli/kleinkram/cli/_download.py
+++ b/cli/kleinkram/cli/_download.py
@@ -173,5 +173,5 @@ def download(
             )
 
     canceled = result.state_counts.get(DownloadState.CANCELED, 0)
-    if canceled > 0:
+    if result.interrupted or canceled > 0:
         raise typer.Exit(code=130)

--- a/cli/kleinkram/cli/_download.py
+++ b/cli/kleinkram/cli/_download.py
@@ -130,6 +130,7 @@ def download(
             f"{result.state_counts.get(DownloadState.SKIPPED_FILE_SIZE_MISMATCH, 0)} skipped size mismatch, "
             f"{result.state_counts.get(DownloadState.SKIPPED_INVALID_REMOTE_STATE, 0)} skipped invalid remote state, "
             f"{result.state_counts.get(DownloadState.DOWNLOADED_INVALID_HASH, 0)} downloaded with invalid hash, "
+            f"{result.state_counts.get(DownloadState.CANCELED, 0)} canceled, "
             f"{result.failed} failed"
         )
     else:
@@ -149,11 +150,17 @@ def download(
             + result.state_counts.get(DownloadState.OVERWRITTEN_OK, 0)
             + result.state_counts.get(DownloadState.OVERWRITTEN_CORRUPTED, 0)
         )
-        if result.failed > 0:
+        canceled = result.state_counts.get(DownloadState.CANCELED, 0)
+        if result.failed > 0 or canceled > 0:
+            parts = [f"Downloaded {downloaded} file(s)"]
+            if canceled > 0:
+                parts.append(f"{canceled} canceled")
+            if result.failed > 0:
+                parts.append(f"{result.failed} failed")
             typer.echo(
                 typer.style(
-                    f"\nDownloaded {downloaded} file(s), {result.failed} failed.",
-                    fg=typer.colors.RED,
+                    f"\n{', '.join(parts)}.",
+                    fg=typer.colors.YELLOW if result.failed == 0 else typer.colors.RED,
                 ),
                 err=True,
             )
@@ -164,3 +171,7 @@ def download(
                     fg=typer.colors.GREEN,
                 )
             )
+
+    canceled = result.state_counts.get(DownloadState.CANCELED, 0)
+    if canceled > 0:
+        raise typer.Exit(code=130)

--- a/cli/kleinkram/cli/_upload.py
+++ b/cli/kleinkram/cli/_upload.py
@@ -119,7 +119,9 @@ def upload(
             typer.echo(f"Total uploaded: {format_bytes(result.total_bytes)}")
             typer.echo(f"Average speed: {format_bytes(avg_speed, speed=True)}")
             if result.failed > 0 or result.canceled > 0:
-                parts = [f"Uploaded {result.uploaded} files", f"{result.skipped} skipped"]
+                parts = [f"Uploaded {result.uploaded} files"]
+                if result.skipped > 0:
+                    parts.append(f"{result.skipped} skipped")
                 if result.canceled > 0:
                     parts.append(f"{result.canceled} canceled")
                 if result.failed > 0:
@@ -132,7 +134,10 @@ def upload(
                     err=True,
                 )
             else:
-                typer.echo(f"\nUploaded {result.uploaded} files, {result.skipped} skipped")
+                parts = [f"Uploaded {result.uploaded} files"]
+                if result.skipped > 0:
+                    parts.append(f"{result.skipped} skipped")
+                typer.echo(f"\n{', '.join(parts)}")
         else:
             # No verbose: no progress bars, no callbacks
             result = kleinkram.core.upload(
@@ -159,9 +164,12 @@ def upload(
                     err=True,
                 )
             else:
+                parts = [f"Uploaded {result.uploaded} file(s)"]
+                if result.skipped > 0:
+                    parts.append(f"{result.skipped} skipped")
                 typer.echo(
                     typer.style(
-                        f"\nSuccessfully uploaded {result.uploaded} file(s).",
+                        f"\n{', '.join(parts)}.",
                         fg=typer.colors.GREEN,
                     )
                 )

--- a/cli/kleinkram/cli/_upload.py
+++ b/cli/kleinkram/cli/_upload.py
@@ -118,11 +118,16 @@ def upload(
             typer.echo(f"\nUpload took {result.elapsed_seconds:.2f} seconds")
             typer.echo(f"Total uploaded: {format_bytes(result.total_bytes)}")
             typer.echo(f"Average speed: {format_bytes(avg_speed, speed=True)}")
-            if result.failed > 0:
+            if result.failed > 0 or result.canceled > 0:
+                parts = [f"Uploaded {result.uploaded} files", f"{result.skipped} skipped"]
+                if result.canceled > 0:
+                    parts.append(f"{result.canceled} canceled")
+                if result.failed > 0:
+                    parts.append(f"{result.failed} failed")
                 typer.echo(
                     typer.style(
-                        f"\nUploaded {result.uploaded} files, {result.skipped} skipped, {result.failed} failed",
-                        fg=typer.colors.RED,
+                        f"\n{', '.join(parts)}",
+                        fg=typer.colors.YELLOW if result.failed == 0 else typer.colors.RED,
                     ),
                     err=True,
                 )
@@ -138,11 +143,18 @@ def upload(
                 metadata=load_metadata(Path(metadata)) if metadata else None,
                 ignore_missing_metadata=ignore_missing_tags,
             )
-            if result.failed > 0:
+            if result.failed > 0 or result.canceled > 0:
+                parts = [f"Uploaded {result.uploaded} file(s)"]
+                if result.skipped > 0:
+                    parts.append(f"{result.skipped} skipped")
+                if result.canceled > 0:
+                    parts.append(f"{result.canceled} canceled")
+                if result.failed > 0:
+                    parts.append(f"{result.failed} failed")
                 typer.echo(
                     typer.style(
-                        f"\nUploaded {result.uploaded} file(s), {result.skipped} skipped, {result.failed} failed.",
-                        fg=typer.colors.RED,
+                        f"\n{', '.join(parts)}.",
+                        fg=typer.colors.YELLOW if result.failed == 0 else typer.colors.RED,
                     ),
                     err=True,
                 )
@@ -158,3 +170,6 @@ def upload(
         if create:
             raise  # dont change the error message
         raise MissionNotFound("Mission not found. Use `--create` to create it.")
+
+    if result.canceled > 0:
+        raise typer.Exit(code=130)

--- a/cli/kleinkram/cli/_upload.py
+++ b/cli/kleinkram/cli/_upload.py
@@ -178,6 +178,7 @@ def upload(
         if create:
             raise  # dont change the error message
         raise MissionNotFound("Mission not found. Use `--create` to create it.")
-
-    if result.interrupted or result.canceled > 0:
-        raise typer.Exit(code=130)
+    
+    else:
+        if result.interrupted or result.canceled > 0:
+            raise typer.Exit(code=130)

--- a/cli/kleinkram/cli/_upload.py
+++ b/cli/kleinkram/cli/_upload.py
@@ -178,7 +178,7 @@ def upload(
         if create:
             raise  # dont change the error message
         raise MissionNotFound("Mission not found. Use `--create` to create it.")
-    
+
     else:
         if result.interrupted or result.canceled > 0:
             raise typer.Exit(code=130)

--- a/cli/kleinkram/cli/_upload.py
+++ b/cli/kleinkram/cli/_upload.py
@@ -179,5 +179,5 @@ def upload(
             raise  # dont change the error message
         raise MissionNotFound("Mission not found. Use `--create` to create it.")
 
-    if result.canceled > 0:
+    if result.interrupted or result.canceled > 0:
         raise typer.Exit(code=130)

--- a/cli/kleinkram/errors.py
+++ b/cli/kleinkram/errors.py
@@ -90,3 +90,9 @@ class TriggerNotFound(Exception): ...
 
 
 class InsufficientStorageError(Exception): ...
+
+
+class TransferCancelledError(Exception):
+    """Raised inside worker threads when the cancel_event is set."""
+
+    pass


### PR DESCRIPTION
This PR implements robust cancelation logic for file transfers via the CLI. With these changes, the user can interrupt file uploads and downloads using CTRL+C (KeyboardInterrupt) and the CLI will gracefully cancel the transfers and still create a summary.