### PR TITLE
chore(db): migration for TypeORM 1 junction-table FK cascade defaults

### DIFF
--- a/backend/migration/migrations/1788703971461-typeorm1-junction-fk-cascade.ts
+++ b/backend/migration/migrations/1788703971461-typeorm1-junction-fk-cascade.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Typeorm1JunctionFkCascade1788703971461 implements MigrationInterface {
+    name = 'Typeorm1JunctionFkCascade1788703971461';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "file_entity_categories_category" DROP CONSTRAINT "FK_11fa102cb9cd8159957e630e9c6"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "tag_type_project_project" DROP CONSTRAINT "FK_524b6f4291e81c3f9292f044399"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "file_entity_categories_category" ADD CONSTRAINT "FK_11fa102cb9cd8159957e630e9c6" FOREIGN KEY ("categoryUuid") REFERENCES "category"("uuid") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "tag_type_project_project" ADD CONSTRAINT "FK_524b6f4291e81c3f9292f044399" FOREIGN KEY ("projectUuid") REFERENCES "project"("uuid") ON DELETE CASCADE ON UPDATE CASCADE`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "tag_type_project_project" DROP CONSTRAINT "FK_524b6f4291e81c3f9292f044399"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "file_entity_categories_category" DROP CONSTRAINT "FK_11fa102cb9cd8159957e630e9c6"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "tag_type_project_project" ADD CONSTRAINT "FK_524b6f4291e81c3f9292f044399" FOREIGN KEY ("projectUuid") REFERENCES "project"("uuid") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "file_entity_categories_category" ADD CONSTRAINT "FK_11fa102cb9cd8159957e630e9c6" FOREIGN KEY ("categoryUuid") REFERENCES "category"("uuid") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
`check-migrations` fails on `dev` since #2356: TypeORM 1 now creates ManyToMany junction-table foreign keys with `ON DELETE CASCADE ON UPDATE CASCADE` on both sides, so `migration:generate` produces a diff for `file_entity_categories_category` and `tag_type_project_project`.

This commits that generated migration under a descriptive name. Effect: deleting a category or project now removes its join rows instead of failing with an FK violation. No entity code changes.

## Verification
- `pnpm run migration:check` passes locally against a fresh Postgres 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn