### PR TITLE
fix(ci): match dependabot author in automated stale-PR cleanup

### DIFF
--- a/.github/workflows/automated-dependency-update.yml
+++ b/.github/workflows/automated-dependency-update.yml
@@ -36,7 +36,7 @@ jobs:
                       age_seconds=$((now - created_epoch))
                       age_days=$((age_seconds / 86400))
 
-                      if [ "$age_days" -ge 7 ] && { [ "$pr_author" = "dependabot[bot]" ] || [[ "$pr_branch" == deps/* ]]; }; then
+                      if [ "$age_days" -ge 7 ] && { { [ "$pr_author" = "app/dependabot" ] || [ "$pr_author" = "dependabot[bot]" ]; } || [[ "$pr_branch" == deps/* ]]; }; then
                           echo "Closing PR #$pr_number ($pr_branch) created by $pr_author - $age_days days old..."
                           gh pr close "$pr_number" --comment "Closing this dependency update pull request because it has been unmerged for over a week."
                           # Only delete branches that live in this repository, never for PRs opened from forks


### PR DESCRIPTION
`gh pr list --json author` reports Dependabot as `app/dependabot`, not `dependabot[bot]`, so the weekly cleanup step in `automated-dependency-update.yml` never closed Dependabot PRs. Accept both spellings.

Found in the v0.60.0 review (#2173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn