### PR TITLE
fix(api-dto): stop coercing false query parameters to true

### DIFF
--- a/backend/src/endpoints/mission/mission.controller.ts
+++ b/backend/src/endpoints/mission/mission.controller.ts
@@ -16,6 +16,7 @@ import {
     SuccessResponseDto,
     UpdateMissionNameDto,
 } from '@kleinkram/api-dto';
+import { toBoolean } from '@kleinkram/validation';
 import {
     Body,
     Controller,
@@ -82,7 +83,11 @@ export class MissionController {
         description: 'Returns all missions',
         type: MissionsDto,
         resolver: (request: Request) =>
-            request.query.minimal === 'true' ? MinimumMissionsDto : MissionsDto,
+            // must stay in sync with `MissionQueryDto.minimal`, which accepts
+            // the same set of boolean-ish query parameter values
+            toBoolean(request.query.minimal) === true
+                ? MinimumMissionsDto
+                : MissionsDto,
     })
     async getMany(
         @Query() query: MissionQueryDto,

--- a/backend/tests/files/topic-match-mode.test.ts
+++ b/backend/tests/files/topic-match-mode.test.ts
@@ -1,0 +1,64 @@
+import { FileEntity, TopicEntity } from '@kleinkram/backend-common';
+import { DEFAULT_URL } from '../auth/utilities';
+import { getAuthHeaders, uploadFile } from '../utils/api-calls';
+import { database } from '../utils/database-utilities';
+import {
+    setupDatabaseHooks,
+    setupTestEnvironment,
+} from '../utils/test-helpers';
+
+/**
+ * `matchAllTopics=false` used to be coerced to `true` by
+ * `@Type(() => Boolean)`, so the "any of these topics" (OR) search behaved like
+ * an "all of these topics" (AND) search.
+ */
+describe('File topic match mode', () => {
+    jest.setTimeout(60_000);
+    setupDatabaseHooks();
+
+    test('matchAllTopics toggles between OR and AND topic search', async () => {
+        const { user, missionUuid } = await setupTestEnvironment(
+            'topic-match-mode@kleinkram.dev',
+            'Topic Match Mode User',
+        );
+
+        await uploadFile(user, 'test.bag', missionUuid);
+
+        const file = await database.getRepository(FileEntity).findOneOrFail({
+            where: { filename: 'test.bag' },
+        });
+
+        const topicRepository = database.getRepository(TopicEntity);
+        await topicRepository.save(
+            topicRepository.create({
+                name: '/present/topic',
+                type: 'std_msgs/String',
+                file: file,
+                nrMessages: 10n,
+                frequency: 1,
+                messageEncoding: 'none',
+            }),
+        );
+
+        const queryFiles = async (
+            matchAllTopics: string,
+        ): Promise<string[]> => {
+            const response = await fetch(
+                `${DEFAULT_URL}/files?missionUuids=${missionUuid}&topics=/present/topic,/absent/topic&matchAllTopics=${matchAllTopics}&take=10&skip=0`,
+                { method: 'GET', headers: getAuthHeaders(user) },
+            );
+            expect(response.status).toBe(200);
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const json = await response.json();
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
+            return json.data.map((f: any) => f.uuid);
+        };
+
+        // OR: the file has one of the two topics, so it matches
+        expect(await queryFiles('false')).toContain(file.uuid);
+
+        // AND: the file is missing '/absent/topic', so it does not match
+        expect(await queryFiles('true')).not.toContain(file.uuid);
+    });
+});

--- a/backend/tests/functional/boolean-query-parameters.unit.test.ts
+++ b/backend/tests/functional/boolean-query-parameters.unit.test.ts
@@ -4,8 +4,16 @@ import {
     MissionQueryDto,
 } from '@kleinkram/api-dto';
 import { toBoolean } from '@kleinkram/validation';
-import { plainToInstance } from 'class-transformer';
+import { plainToInstance as plainToInstanceRaw } from 'class-transformer';
 import { validateSync } from 'class-validator';
+
+// Mirror the global ValidationPipe options from backend/src/main.ts: implicit
+// conversion runs before custom transforms and is what made 'false' -> true.
+const plainToInstance: typeof plainToInstanceRaw = (cls, plain, options) =>
+    plainToInstanceRaw(cls, plain, {
+        enableImplicitConversion: true,
+        ...options,
+    });
 
 /**
  * Regression tests for boolean query parameters.

--- a/backend/tests/functional/boolean-query-parameters.unit.test.ts
+++ b/backend/tests/functional/boolean-query-parameters.unit.test.ts
@@ -1,0 +1,114 @@
+import {
+    ActionTemplatesQueryDto,
+    FileQueryDto,
+    MissionQueryDto,
+} from '@kleinkram/api-dto';
+import { toBoolean } from '@kleinkram/validation';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+/**
+ * Regression tests for boolean query parameters.
+ *
+ * `@Type(() => Boolean)` calls `Boolean('false')`, which is `true`, so every
+ * boolean query parameter used to be stuck at `true` as soon as the client sent
+ * it explicitly. The DTOs now use `@TransformToBoolean()` instead.
+ */
+describe('Boolean query parameter transformation', () => {
+    describe('toBoolean', () => {
+        test.each([
+            ['true', true],
+            ['TRUE', true],
+            ['  true  ', true],
+            ['1', true],
+            ['false', false],
+            ['False', false],
+            ['0', false],
+            [true, true],
+            [false, false],
+        ])('coerces %p to %p', (input, expected) => {
+            expect(toBoolean(input)).toBe(expected);
+        });
+
+        test('leaves undefined untouched', () => {
+            expect(toBoolean(undefined)).toBeUndefined();
+        });
+
+        test('leaves unrecognized values untouched so validation can reject them', () => {
+            expect(toBoolean('yes')).toBe('yes');
+            expect(toBoolean('')).toBe('');
+            expect(toBoolean(42)).toBe(42);
+        });
+    });
+
+    describe('FileQueryDto.matchAllTopics', () => {
+        test('"false" stays false (OR topic search)', () => {
+            const dto = plainToInstance(FileQueryDto, {
+                matchAllTopics: 'false',
+            });
+            expect(dto.matchAllTopics).toBe(false);
+            expect(validateSync(dto)).toHaveLength(0);
+        });
+
+        test('"true" becomes true (AND topic search)', () => {
+            const dto = plainToInstance(FileQueryDto, {
+                matchAllTopics: 'true',
+            });
+            expect(dto.matchAllTopics).toBe(true);
+            expect(validateSync(dto)).toHaveLength(0);
+        });
+
+        test('defaults to false when omitted', () => {
+            const dto = plainToInstance(FileQueryDto, {});
+            expect(dto.matchAllTopics).toBe(false);
+            expect(validateSync(dto)).toHaveLength(0);
+        });
+
+        test('rejects values that are not boolean-ish', () => {
+            const dto = plainToInstance(FileQueryDto, {
+                matchAllTopics: 'maybe',
+            });
+            const errors = validateSync(dto);
+            expect(errors).toHaveLength(1);
+            expect(errors[0]?.property).toBe('matchAllTopics');
+        });
+    });
+
+    describe('MissionQueryDto.minimal', () => {
+        test('"false" stays false', () => {
+            const dto = plainToInstance(MissionQueryDto, { minimal: 'false' });
+            expect(dto.minimal).toBe(false);
+            expect(validateSync(dto)).toHaveLength(0);
+        });
+
+        test('"true" becomes true', () => {
+            const dto = plainToInstance(MissionQueryDto, { minimal: 'true' });
+            expect(dto.minimal).toBe(true);
+            expect(validateSync(dto)).toHaveLength(0);
+        });
+
+        test('stays undefined when omitted', () => {
+            const dto = plainToInstance(MissionQueryDto, {});
+            expect(dto.minimal).toBeUndefined();
+            expect(validateSync(dto)).toHaveLength(0);
+        });
+    });
+
+    describe('ActionTemplatesQueryDto.includeArchived', () => {
+        test('"false" stays false (archived templates hidden)', () => {
+            const dto = plainToInstance(ActionTemplatesQueryDto, {
+                includeArchived: 'false',
+            });
+            expect(dto.includeArchived).toBe(false);
+            expect(validateSync(dto)).toHaveLength(0);
+        });
+
+        test('"true" becomes true', () => {
+            const dto = plainToInstance(ActionTemplatesQueryDto, {
+                includeArchived: 'true',
+            });
+            expect(dto.includeArchived).toBe(true);
+            expect(validateSync(dto)).toHaveLength(0);
+        });
+    });
+});

--- a/backend/tests/functional/boolean-query-parameters.unit.test.ts
+++ b/backend/tests/functional/boolean-query-parameters.unit.test.ts
@@ -4,16 +4,14 @@ import {
     MissionQueryDto,
 } from '@kleinkram/api-dto';
 import { toBoolean } from '@kleinkram/validation';
+import type { ClassConstructor } from 'class-transformer';
 import { plainToInstance as plainToInstanceRaw } from 'class-transformer';
 import { validateSync } from 'class-validator';
 
 // Mirror the global ValidationPipe options from backend/src/main.ts: implicit
 // conversion runs before custom transforms and is what made 'false' -> true.
-const plainToInstance: typeof plainToInstanceRaw = (cls, plain, options) =>
-    plainToInstanceRaw(cls, plain, {
-        enableImplicitConversion: true,
-        ...options,
-    });
+const plainToInstance = <T>(cls: ClassConstructor<T>, plain: object): T =>
+    plainToInstanceRaw(cls, plain, { enableImplicitConversion: true });
 
 /**
  * Regression tests for boolean query parameters.

--- a/packages/api-dto/src/types/file/file-query.dto.ts
+++ b/packages/api-dto/src/types/file/file-query.dto.ts
@@ -1,5 +1,6 @@
 import { MissionQueryDto } from '@api-dto/mission/mission-query.dto';
 import { HealthStatus } from '@kleinkram/shared';
+import { TransformToBoolean } from '@kleinkram/validation';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import {
@@ -133,8 +134,8 @@ export class FileQueryDto extends MissionQueryDto {
     categories?: string;
 
     @IsOptional()
+    @TransformToBoolean()
     @IsBoolean()
-    @Type(() => Boolean)
     @ApiProperty({
         required: false,
         description:

--- a/packages/api-dto/src/types/mission/mission-query.dto.ts
+++ b/packages/api-dto/src/types/mission/mission-query.dto.ts
@@ -1,7 +1,10 @@
 import { ProjectQueryDto } from '@api-dto/project/project-query.dto';
-import { IsRecordStringString } from '@kleinkram/validation';
+import {
+    IsRecordStringString,
+    TransformToBoolean,
+} from '@kleinkram/validation';
 import { ApiProperty } from '@nestjs/swagger';
-import { Transform, Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
 import {
     ArrayNotEmpty,
     IsArray,
@@ -39,8 +42,8 @@ export class MissionQueryDto extends ProjectQueryDto {
     metadata?: Record<string, string>;
 
     @IsOptional()
+    @TransformToBoolean()
     @IsBoolean()
-    @Type(() => Boolean)
     @ApiProperty({
         required: false,
         description: 'Return minimal mission info',

--- a/packages/api-dto/src/types/templates/action-templates-query.dto.ts
+++ b/packages/api-dto/src/types/templates/action-templates-query.dto.ts
@@ -1,3 +1,4 @@
+import { TransformToBoolean } from '@kleinkram/validation';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
@@ -31,8 +32,8 @@ export class ActionTemplatesQueryDto {
     search?: string;
 
     @IsOptional()
+    @TransformToBoolean()
     @IsBoolean()
-    @Type(() => Boolean)
     @ApiProperty({ required: false, default: false })
     includeArchived?: boolean;
 }

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -5,6 +5,7 @@ export * from './files/google-drive.validator';
 export * from './is-not-undefined';
 export * from './metadata-applier';
 export * from './property-decorator';
+export * from './query-transform';
 export * from './record-validation';
 export * from './skip-validation';
 export * from './take-validation';

--- a/packages/validation/src/query-transform.ts
+++ b/packages/validation/src/query-transform.ts
@@ -1,0 +1,47 @@
+import { Transform } from 'class-transformer';
+
+/**
+ * Coerces a query parameter value into a boolean.
+ *
+ * Query parameters always arrive as strings, so `@Type(() => Boolean)` cannot
+ * be used: it calls `Boolean('false')`, which is `true`. This helper only
+ * converts values it actually recognises and returns everything else
+ * unchanged, so `@IsBoolean()` can reject unparseable input and `@IsOptional()`
+ * can skip missing values.
+ *
+ * Accepted (case-insensitive, surrounding whitespace ignored):
+ * `true`, `false`, `1`, `0` and actual booleans.
+ *
+ * @param value the raw query parameter value
+ * @returns the coerced boolean, or `value` unchanged if it is not recognised
+ */
+export const toBoolean = (value: unknown): unknown => {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+
+        if (normalized === 'true' || normalized === '1') {
+            return true;
+        }
+
+        if (normalized === 'false' || normalized === '0') {
+            return false;
+        }
+    }
+
+    return value;
+};
+
+/**
+ * Property decorator applying {@link toBoolean} during transformation.
+ *
+ * Use together with `@IsBoolean()` (and `@IsOptional()` where applicable) on
+ * query parameter DTO fields instead of `@Type(() => Boolean)`.
+ *
+ * @returns the property decorator
+ */
+export const TransformToBoolean = (): PropertyDecorator =>
+    Transform(({ value }): unknown => toBoolean(value));

--- a/packages/validation/src/query-transform.ts
+++ b/packages/validation/src/query-transform.ts
@@ -49,9 +49,10 @@ export const TransformToBoolean = (): PropertyDecorator =>
         // class-transformer has already run `Boolean(value)` on the reflected
         // type before this hook is called, turning 'false' into `true`. Read
         // the untouched source value instead.
+        const source: unknown = obj;
         const raw =
-            obj !== null && typeof obj === 'object' && key in obj
-                ? (obj as Record<string, unknown>)[key]
-                : value;
+            source !== null && typeof source === 'object' && key in source
+                ? (source as Record<string, unknown>)[key]
+                : (value as unknown);
         return toBoolean(raw);
     });

--- a/packages/validation/src/query-transform.ts
+++ b/packages/validation/src/query-transform.ts
@@ -44,4 +44,14 @@ export const toBoolean = (value: unknown): unknown => {
  * @returns the property decorator
  */
 export const TransformToBoolean = (): PropertyDecorator =>
-    Transform(({ value }): unknown => toBoolean(value));
+    Transform(({ value, obj, key }): unknown => {
+        // With `enableImplicitConversion` (used by the global ValidationPipe)
+        // class-transformer has already run `Boolean(value)` on the reflected
+        // type before this hook is called, turning 'false' into `true`. Read
+        // the untouched source value instead.
+        const raw =
+            obj !== null && typeof obj === 'object' && key in obj
+                ? (obj as Record<string, unknown>)[key]
+                : value;
+        return toBoolean(raw);
+    });


### PR DESCRIPTION
## Problem

`@Type(() => Boolean)` on a query DTO field transforms the raw value with `Boolean(value)`. Query parameters always arrive as strings, and `Boolean('false')` is `true` — so every affected boolean query parameter was pinned to `true` the moment a client sent it explicitly.

Three query DTOs were affected (the only `@Type(() => Boolean)` occurrences in `packages/api-dto/src`):

| DTO | Field | User-visible effect |
| --- | --- | --- |
| `FileQueryDto` | `matchAllTopics` | The frontend always sends `matchAllTopics=false`, so the "any of these topics" (OR) search silently behaved like "all of these topics" (AND). |
| `ActionTemplatesQueryDto` | `includeArchived` | The frontend sends `includeArchived=false`, so archived action templates were always listed. |
| `MissionQueryDto` | `minimal` | `minimal=false` returned the minimal mission representation. |

## Fix

- New shared helper in `@kleinkram/validation` (`packages/validation/src/query-transform.ts`):
  - `toBoolean(value)` — accepts `true`/`false`/`1`/`0` (case-insensitive, trimmed) and real booleans, and returns anything else unchanged so `@IsBoolean()` can reject it and `@IsOptional()` still skips missing values. This mirrors what the removed `QueryBoolean` decorator did on `main`.
  - `TransformToBoolean()` — the `@Transform`-based property decorator to use on query DTO fields.
- The three DTO fields now use `@TransformToBoolean()` + `@IsBoolean()` instead of `@Type(() => Boolean)`.
- `GET /missions` had a Swagger response `resolver` comparing `request.query.minimal === 'true'`, which no longer matched the set of values the DTO accepts. It now goes through the same `toBoolean` helper, so the documented response type and the actual behaviour stay in sync.

Note this is a behaviour change for clients that were (unknowingly) relying on the broken coercion — e.g. anyone passing `matchAllTopics=false` now gets OR semantics, which is what the parameter has always documented.

## Tests

- `backend/tests/functional/boolean-query-parameters.unit.test.ts` — unit test running `plainToInstance` + `validateSync` over all three DTOs with `'true'`/`'false'`/omitted/garbage input, plus direct coverage of `toBoolean`.
- `backend/tests/files/topic-match-mode.test.ts` — API test that uploads a file, attaches one topic, then queries `GET /files?topics=/present/topic,/absent/topic` with `matchAllTopics=false` (file matches, OR) and `matchAllTopics=true` (file does not match, AND).

## Verification

- `pnpm type-check` — clean
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm lint:check` — 0 errors (only pre-existing warnings)
- `pnpm prettier:check` — clean
- `cd backend && pnpm exec jest --testPathPatterns unit` — 3/3 suites pass
- The new API test is DB/SeaweedFS-backed and was not run locally (no Docker available in this environment); it runs in the `api-tests` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn
