### PR TITLE
fix(backend): never let a metadata-types request fall back to a wipe

### DIFF
--- a/backend/src/endpoints/project/project.controller.ts
+++ b/backend/src/endpoints/project/project.controller.ts
@@ -29,6 +29,7 @@ import {
     UpdateMetadataTypesDto,
 } from '@kleinkram/api-dto';
 import {
+    BadRequestException,
     Body,
     Controller,
     Delete,
@@ -206,6 +207,13 @@ export class ProjectController {
 
     @Post(':uuid/metadata-types')
     @CanWriteProject()
+    @ApiOperation({
+        summary: 'Add a required metadata type to a project',
+        description:
+            'Exactly one of the `metadataTypeUUID` / `tagTypeUUID` query ' +
+            'parameters must be given (`tagTypeUUID` is the deprecated ' +
+            'alias). Requests providing neither are rejected with 400.',
+    })
     @ApiCreatedResponse({
         description: 'Empty response',
         type: AddMetadataTypeDto,
@@ -214,7 +222,17 @@ export class ProjectController {
         @ParameterUID('uuid') uuid: string,
         @Query() query: AddMetadataTypeQueryDto,
     ): Promise<AddMetadataTypeDto> {
-        const typeUuid = query.metadataTypeUUID ?? query.tagTypeUUID ?? '';
+        const typeUuid = query.metadataTypeUUID ?? query.tagTypeUUID;
+
+        // `AddMetadataTypeQueryDto` already enforces this, but defaulting to a
+        // bogus uuid here would turn a client mistake into a 500, so guard
+        // explicitly instead of falling back to ''.
+        if (typeUuid === undefined) {
+            throw new BadRequestException(
+                'Either metadataTypeUUID or tagTypeUUID must be provided',
+            );
+        }
+
         await this.projectService.addTagType(uuid, typeUuid);
         return {};
     }
@@ -235,6 +253,16 @@ export class ProjectController {
 
     @Put(':uuid/metadata-types')
     @CanWriteProject()
+    @ApiOperation({
+        summary: "Replace a project's required metadata types",
+        description:
+            'Replaces the full set of required metadata types. Exactly one ' +
+            'of `metadataTypeUUIDs` / `tagTypeUUIDs` must be given in the ' +
+            'body (`tagTypeUUIDs` is the deprecated alias); a body providing ' +
+            'neither — `{}`, or one that only carries a misspelled key — is ' +
+            'rejected with 400 rather than clearing the project. Passing an ' +
+            'explicit empty array clears the required metadata types.',
+    })
     @ApiOkResponse({
         description: 'Empty response',
         type: UpdateMetadataTypesDto,
@@ -243,7 +271,17 @@ export class ProjectController {
         @ParameterUID('uuid') uuid: string,
         @Body() body: UpdateMetadataTypesBodyDto,
     ): Promise<UpdateMetadataTypesDto> {
-        const uuids = body.metadataTypeUUIDs ?? body.tagTypeUUIDs ?? [];
+        const uuids = body.metadataTypeUUIDs ?? body.tagTypeUUIDs;
+
+        // `UpdateMetadataTypesBodyDto` already enforces this, but defaulting
+        // to [] here would silently wipe the project's required metadata
+        // types, so guard explicitly instead.
+        if (uuids === undefined) {
+            throw new BadRequestException(
+                'Either metadataTypeUUIDs or tagTypeUUIDs must be provided',
+            );
+        }
+
         await this.projectService.updateTagTypes(uuid, uuids);
         return {
             success: true,

--- a/backend/src/endpoints/project/project.controller.ts
+++ b/backend/src/endpoints/project/project.controller.ts
@@ -210,9 +210,10 @@ export class ProjectController {
     @ApiOperation({
         summary: 'Add a required metadata type to a project',
         description:
-            'Exactly one of the `metadataTypeUUID` / `tagTypeUUID` query ' +
+            'At least one of the `metadataTypeUUID` / `tagTypeUUID` query ' +
             'parameters must be given (`tagTypeUUID` is the deprecated ' +
-            'alias). Requests providing neither are rejected with 400.',
+            'alias; if both are given, `metadataTypeUUID` wins). Requests ' +
+            'providing neither are rejected with 400.',
     })
     @ApiCreatedResponse({
         description: 'Empty response',
@@ -256,9 +257,10 @@ export class ProjectController {
     @ApiOperation({
         summary: "Replace a project's required metadata types",
         description:
-            'Replaces the full set of required metadata types. Exactly one ' +
+            'Replaces the full set of required metadata types. At least one ' +
             'of `metadataTypeUUIDs` / `tagTypeUUIDs` must be given in the ' +
-            'body (`tagTypeUUIDs` is the deprecated alias); a body providing ' +
+            'body (`tagTypeUUIDs` is the deprecated alias; if both are ' +
+            'given, `metadataTypeUUIDs` wins); a body providing ' +
             'neither — `{}`, or one that only carries a misspelled key — is ' +
             'rejected with 400 rather than clearing the project. Passing an ' +
             'explicit empty array clears the required metadata types.',

--- a/backend/tests/auth/project/project-metadata-types.test.ts
+++ b/backend/tests/auth/project/project-metadata-types.test.ts
@@ -1,0 +1,152 @@
+import { UserEntity } from '@kleinkram/backend-common';
+import { DataType, UserRole } from '@kleinkram/shared';
+import {
+    createMetadataUsingPost,
+    createProjectUsingPost,
+    getAuthHeaders,
+} from '../../utils/api-calls';
+import {
+    getUserFromDatabase,
+    mockDatabaseUser,
+} from '../../utils/database-utilities';
+import { setupDatabaseHooks } from '../../utils/test-helpers';
+import { DEFAULT_URL } from '../utilities';
+
+const setup = async (): Promise<{
+    user: UserEntity;
+    projectUuid: string;
+    metadataTypeUuid: string;
+}> => {
+    const userUuid = await mockDatabaseUser(
+        'metadata-types@kleinkram.dev',
+        'Metadata Types User',
+        UserRole.ADMIN,
+    );
+    const user = await getUserFromDatabase(userUuid);
+
+    const metadataTypeUuid = await createMetadataUsingPost(
+        { type: DataType.STRING, name: `mdt_${String(Date.now())}` },
+        user,
+    );
+
+    const projectUuid = await createProjectUsingPost(
+        {
+            name: `metadata_types_project_${String(Date.now())}`,
+            description: 'Test project',
+            requiredTags: [metadataTypeUuid],
+        },
+        user,
+    );
+
+    return { user, projectUuid, metadataTypeUuid };
+};
+
+const getRequiredTagUuids = async (
+    user: UserEntity,
+    projectUuid: string,
+): Promise<string[]> => {
+    const response = await fetch(`${DEFAULT_URL}/projects/${projectUuid}`, {
+        method: 'GET',
+        headers: getAuthHeaders(user),
+    });
+    expect(response.status).toBe(200);
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const json = await response.json();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
+    return json.requiredTags.map((tag: any) => tag.uuid);
+};
+
+const putMetadataTypes = async (
+    user: UserEntity,
+    projectUuid: string,
+    body: unknown,
+): Promise<Response> =>
+    fetch(`${DEFAULT_URL}/projects/${projectUuid}/metadata-types`, {
+        method: 'PUT',
+        headers: {
+            ...getAuthHeaders(user),
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+    });
+
+/**
+ * `PUT /projects/:uuid/metadata-types` replaces the full set of required
+ * metadata types. A body that names neither `metadataTypeUUIDs` nor
+ * `tagTypeUUIDs` (`{}`, or one that only carries a misspelled key) must be
+ * rejected instead of silently clearing the project, and
+ * `POST /projects/:uuid/metadata-types` without a type uuid must be a 400
+ * rather than a 500.
+ */
+describe('Project required metadata types', () => {
+    setupDatabaseHooks();
+
+    test('PUT with an empty body is rejected and does not clear the project', async () => {
+        const { user, projectUuid, metadataTypeUuid } = await setup();
+
+        const response = await putMetadataTypes(user, projectUuid, {});
+        expect(response.status).toBe(400);
+
+        expect(await getRequiredTagUuids(user, projectUuid)).toEqual([
+            metadataTypeUuid,
+        ]);
+    });
+
+    test('PUT with only a misspelled key is rejected and does not clear the project', async () => {
+        const { user, projectUuid, metadataTypeUuid } = await setup();
+
+        const response = await putMetadataTypes(user, projectUuid, {
+            metadataTypeUuids: [metadataTypeUuid],
+        });
+        expect(response.status).toBe(400);
+
+        expect(await getRequiredTagUuids(user, projectUuid)).toEqual([
+            metadataTypeUuid,
+        ]);
+    });
+
+    test('PUT with an explicit empty array clears the required metadata types', async () => {
+        const { user, projectUuid } = await setup();
+
+        const response = await putMetadataTypes(user, projectUuid, {
+            metadataTypeUUIDs: [],
+        });
+        expect(response.status).toBe(200);
+
+        expect(await getRequiredTagUuids(user, projectUuid)).toEqual([]);
+    });
+
+    test('PUT still accepts the deprecated tagTypeUUIDs alias', async () => {
+        const { user, projectUuid, metadataTypeUuid } = await setup();
+
+        const response = await putMetadataTypes(user, projectUuid, {
+            tagTypeUUIDs: [metadataTypeUuid],
+        });
+        expect(response.status).toBe(200);
+
+        expect(await getRequiredTagUuids(user, projectUuid)).toEqual([
+            metadataTypeUuid,
+        ]);
+    });
+
+    test('PUT rejects values that are not uuids', async () => {
+        const { user, projectUuid } = await setup();
+
+        const response = await putMetadataTypes(user, projectUuid, {
+            metadataTypeUUIDs: ['not-a-uuid'],
+        });
+        expect(response.status).toBe(400);
+    });
+
+    test('POST without a type uuid is a 400, not a 500', async () => {
+        const { user, projectUuid } = await setup();
+
+        const response = await fetch(
+            `${DEFAULT_URL}/projects/${projectUuid}/metadata-types`,
+            { method: 'POST', headers: getAuthHeaders(user) },
+        );
+        expect(response.status).toBe(400);
+    });
+});

--- a/backend/tests/functional/metadata-types-body.unit.test.ts
+++ b/backend/tests/functional/metadata-types-body.unit.test.ts
@@ -1,0 +1,121 @@
+import {
+    AddMetadataTypeQueryDto,
+    UpdateMetadataTypesBodyDto,
+} from '@kleinkram/api-dto';
+import { ArgumentMetadata, ValidationPipe } from '@nestjs/common';
+
+const SOME_UUID = '3f2ad2c6-6e2a-4c6b-9a1d-9f6f0f3b7f21';
+const OTHER_UUID = '8a1d3c40-1f2e-4e1a-9c3b-2b5f7c0a1d44';
+
+/**
+ * `PUT /projects/:uuid/metadata-types` replaces a project's full set of
+ * required metadata types, so a body naming neither field must be rejected
+ * rather than being read as "clear everything". These tests run the same
+ * `ValidationPipe` configuration the application installs globally.
+ */
+describe('Project metadata type request validation', () => {
+    const pipe = new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        forbidUnknownValues: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+    });
+
+    const validate = async (
+        metadata: ArgumentMetadata,
+        value: unknown,
+    ): Promise<{ status: number; messages: string[] }> => {
+        try {
+            await pipe.transform(value, metadata);
+            return { status: 200, messages: [] };
+        } catch (error) {
+            const response = (
+                error as {
+                    response?: { statusCode?: number; message?: string[] };
+                }
+            ).response;
+            return {
+                status: response?.statusCode ?? 500,
+                messages: response?.message ?? [],
+            };
+        }
+    };
+
+    describe('UpdateMetadataTypesBodyDto', () => {
+        const body: ArgumentMetadata = {
+            type: 'body',
+            metatype: UpdateMetadataTypesBodyDto,
+        };
+
+        test('rejects an empty body instead of clearing the project', async () => {
+            const { status, messages } = await validate(body, {});
+            expect(status).toBe(400);
+            expect(messages.join(' ')).toContain(
+                'At least one of the following fields must be present',
+            );
+        });
+
+        test('rejects a body that only carries a misspelled key', async () => {
+            const { status } = await validate(body, {
+                metadataTypeUuids: [SOME_UUID],
+            });
+            expect(status).toBe(400);
+        });
+
+        test('allows an explicit empty array (clearing on purpose)', async () => {
+            const { status } = await validate(body, { metadataTypeUUIDs: [] });
+            expect(status).toBe(200);
+        });
+
+        test('allows the deprecated tagTypeUUIDs alias', async () => {
+            const { status } = await validate(body, {
+                tagTypeUUIDs: [SOME_UUID, OTHER_UUID],
+            });
+            expect(status).toBe(200);
+        });
+
+        test('rejects entries that are not uuids', async () => {
+            const { status } = await validate(body, {
+                metadataTypeUUIDs: ['not-a-uuid'],
+            });
+            expect(status).toBe(400);
+        });
+
+        test('rejects a non-array value', async () => {
+            const { status } = await validate(body, {
+                metadataTypeUUIDs: SOME_UUID,
+            });
+            expect(status).toBe(400);
+        });
+    });
+
+    describe('AddMetadataTypeQueryDto', () => {
+        const query: ArgumentMetadata = {
+            type: 'query',
+            metatype: AddMetadataTypeQueryDto,
+        };
+
+        test('rejects a request without a type uuid', async () => {
+            const { status, messages } = await validate(query, {});
+            expect(status).toBe(400);
+            expect(messages.join(' ')).toContain(
+                'At least one of the following fields must be present',
+            );
+        });
+
+        test('accepts metadataTypeUUID', async () => {
+            const { status } = await validate(query, {
+                metadataTypeUUID: SOME_UUID,
+            });
+            expect(status).toBe(200);
+        });
+
+        test('accepts the deprecated tagTypeUUID alias', async () => {
+            const { status } = await validate(query, {
+                tagTypeUUID: SOME_UUID,
+            });
+            expect(status).toBe(200);
+        });
+    });
+});

--- a/packages/api-dto/src/types/add-metadata-type.dto.ts
+++ b/packages/api-dto/src/types/add-metadata-type.dto.ts
@@ -2,16 +2,31 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsUUID } from 'class-validator';
 import { IsAtLeastOnePresent } from './tags/add-tags.dto';
 
+/**
+ * Query parameters of `POST /projects/:uuid/metadata-types`.
+ *
+ * At least one of the two has to be present; without a type uuid there is
+ * nothing to add, so the request is rejected with 400 instead of reaching the
+ * service with a placeholder value.
+ */
 @IsAtLeastOnePresent(['metadataTypeUUID', 'tagTypeUUID'])
 export class AddMetadataTypeQueryDto {
     @IsOptional()
     @IsUUID('4')
-    @ApiProperty({ required: false })
+    @ApiProperty({
+        required: false,
+        description:
+            'Deprecated alias for metadataTypeUUID. Ignored when ' +
+            'metadataTypeUUID is given.',
+    })
     tagTypeUUID?: string;
 
     @IsOptional()
     @IsUUID('4')
-    @ApiProperty({ required: false })
+    @ApiProperty({
+        required: false,
+        description: 'The metadata type to add to the project.',
+    })
     metadataTypeUUID?: string;
 }
 

--- a/packages/api-dto/src/types/update-metadata-types.dto.ts
+++ b/packages/api-dto/src/types/update-metadata-types.dto.ts
@@ -2,18 +2,39 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsBoolean, IsOptional, IsUUID } from 'class-validator';
 import { IsAtLeastOnePresent } from './tags/add-tags.dto';
 
+/**
+ * Body of `PUT /projects/:uuid/metadata-types`.
+ *
+ * The endpoint replaces the project's *full* set of required metadata types,
+ * so exactly one of the two fields has to be present: a body naming neither
+ * (`{}`, or one that only carries a misspelled key) would otherwise read as
+ * "clear every required metadata type". An explicit empty array is still
+ * accepted, since clearing on purpose is a valid request.
+ */
 @IsAtLeastOnePresent(['metadataTypeUUIDs', 'tagTypeUUIDs'])
 export class UpdateMetadataTypesBodyDto {
     @IsOptional()
     @IsArray()
     @IsUUID('4', { each: true })
-    @ApiProperty({ required: false, type: [String] })
+    @ApiProperty({
+        required: false,
+        type: [String],
+        description:
+            'Deprecated alias for metadataTypeUUIDs. Ignored when ' +
+            'metadataTypeUUIDs is given.',
+    })
     tagTypeUUIDs?: string[];
 
     @IsOptional()
     @IsArray()
     @IsUUID('4', { each: true })
-    @ApiProperty({ required: false, type: [String] })
+    @ApiProperty({
+        required: false,
+        type: [String],
+        description:
+            'The complete new set of required metadata types. Pass an empty ' +
+            'array to clear them.',
+    })
     metadataTypeUUIDs?: string[];
 }
 

--- a/packages/api-dto/src/types/update-metadata-types.dto.ts
+++ b/packages/api-dto/src/types/update-metadata-types.dto.ts
@@ -6,7 +6,8 @@ import { IsAtLeastOnePresent } from './tags/add-tags.dto';
  * Body of `PUT /projects/:uuid/metadata-types`.
  *
  * The endpoint replaces the project's *full* set of required metadata types,
- * so exactly one of the two fields has to be present: a body naming neither
+ * so at least one of the two fields has to be present (if both are given,
+ * the canonical `metadataTypeUUIDs` wins): a body naming neither
  * (`{}`, or one that only carries a misspelled key) would otherwise read as
  * "clear every required metadata type". An explicit empty array is still
  * accepted, since clearing on purpose is a valid request.


### PR DESCRIPTION
## Context — the reported bug is already guarded on `dev`

The concern this PR started from was that `PUT /projects/:uuid/metadata-types` would silently wipe a project's required metadata types when given `{}` or a body with a mistyped key, because `UpdateMetadataTypesBodyDto` marks both `tagTypeUUIDs` and `metadataTypeUUIDs` as `@IsOptional()` and the controller reads `body.metadataTypeUUIDs ?? body.tagTypeUUIDs ?? []`.

That turns out **not** to reproduce on current `dev`: both DTOs already carry `@IsAtLeastOnePresent(...)` (added in `ff67cdee`), and the global `ValidationPipe` (`whitelist` + `forbidNonWhitelisted` + `forbidUnknownValues`) rejects those bodies with 400. Verified against the real pipe configuration:

| Request | Result on `dev` |
| --- | --- |
| `PUT {}` | 400 `At least one of the following fields must be present: metadataTypeUUIDs, tagTypeUUIDs` |
| `PUT {"metadataTypeUuids": [...]}` (typo) | 400 `property metadataTypeUuids should not exist` + the above |
| `PUT {"metadataTypeUUIDs": []}` | 200 (clearing on purpose) |
| `POST` without a type uuid | 400 |

## What this PR changes

The unreachable fallbacks are still wrong-by-default and there was no test pinning any of this down, so:

- **`?? []` → explicit 400.** The `PUT` controller no longer defaults a missing body to "clear everything"; if neither field is present it throws `BadRequestException`. This is defence in depth — if the DTO constraint is ever dropped or refactored away, the endpoint fails loudly instead of destroying data.
- **`?? ''` → explicit 400.** `POST /projects/:uuid/metadata-types` no longer forwards an empty-string uuid to the service (which would surface as a 500); a missing type uuid is a 400.
- **Swagger.** Both endpoints now document that exactly one of the two fields is required, that `tagTypeUUID(s)` is the deprecated alias, and that `PUT` is a full replace where an explicit empty array is the way to clear. Same wording on the DTO field descriptions and in the DTO doc comments.
- **Tests.**
  - `backend/tests/functional/metadata-types-body.unit.test.ts` — runs both DTOs through a `ValidationPipe` configured exactly like the global one: `{}`, a body with only a misspelled key, non-uuid entries and non-array values are all 400; explicit `[]` and the deprecated aliases still pass.
  - `backend/tests/auth/project/project-metadata-types.test.ts` — the same cases end to end, additionally asserting that a project's required metadata types are unchanged after a rejected request.

## Verification

- `pnpm type-check` — clean
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm lint:check` — 0 errors (only pre-existing warnings)
- `pnpm prettier:check` — clean
- `cd backend && pnpm exec jest --testPathPatterns unit` — 3/3 suites pass, including the new one
- The API test is DB-backed and was not run locally (no Docker in this environment); it runs in the `api-tests` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn
