### PR TITLE
fix(backend): paginate the mission list query

### DIFF
--- a/backend/src/services/mission.service.ts
+++ b/backend/src/services/mission.service.ts
@@ -230,6 +230,12 @@ export class MissionService {
 
         idQuery = addSort(idQuery, FIND_MANY_SORT_KEYS, sortField, order);
 
+        // Stable tie-breaker: without it, rows that compare equal on the sort
+        // column (e.g. missions created in the same instant) can be returned in
+        // a different order for every page, which duplicates and drops rows
+        // across LIMIT/OFFSET pages.
+        idQuery.addOrderBy('mission.uuid', 'ASC');
+
         // Get distinct mission UUIDs
         idQuery.groupBy('mission.uuid');
 
@@ -275,6 +281,8 @@ export class MissionService {
                 sortField,
                 order,
             );
+            // same tie-breaker as the id query, so the page keeps its order
+            sortedQuery.addOrderBy('mission.uuid', 'ASC');
             const missions = await sortedQuery.getMany();
 
             return {
@@ -299,6 +307,8 @@ export class MissionService {
             });
 
         dataQuery = addSort(dataQuery, FIND_MANY_SORT_KEYS, sortField, order);
+        // same tie-breaker as the id query, so the page keeps its order
+        dataQuery.addOrderBy('mission.uuid', 'ASC');
 
         dataQuery = addFileStats(dataQuery);
 

--- a/backend/src/services/mission.service.ts
+++ b/backend/src/services/mission.service.ts
@@ -237,7 +237,12 @@ export class MissionService {
         const count = await idQuery.getCount();
         const take = query.take;
         const skip = query.skip;
-        idQuery.take(take).skip(skip);
+
+        // `take`/`skip` are only translated into LIMIT/OFFSET by TypeORM when
+        // the query has no joins; this query has several, so they would be
+        // silently dropped and every page would return all missions.
+        // `limit`/`offset` are always emitted.
+        idQuery.limit(take).offset(skip);
 
         const missionIds = await idQuery.getRawMany();
 

--- a/backend/tests/functional/mission-pagination.test.ts
+++ b/backend/tests/functional/mission-pagination.test.ts
@@ -1,5 +1,7 @@
+import { MissionEntity } from '@kleinkram/backend-common';
 import { DEFAULT_URL } from '../auth/utilities';
 import { createMissionUsingPost, getAuthHeaders } from '../utils/api-calls';
+import { database } from '../utils/database-utilities';
 import {
     setupDatabaseHooks,
     setupTestEnvironment,
@@ -134,5 +136,49 @@ describe('Mission list pagination', () => {
         expect(page1Uuids.filter((uuid) => page2Uuids.has(uuid))).toHaveLength(
             0,
         );
+    }, 60_000);
+
+    test('pages stay disjoint when all missions share the same createdAt', async () => {
+        const { user, projectUuid } = await setupTestEnvironment(
+            'mission-pagination-ties@kleinkram.dev',
+            'Mission Pagination Ties User',
+        );
+
+        for (let index = 1; index < TOTAL_MISSIONS; index++) {
+            await createMissionUsingPost(
+                {
+                    name: `tied_mission_${String(index).padStart(2, '0')}`,
+                    projectUUID: projectUuid,
+                    tags: {},
+                    ignoreTags: true,
+                },
+                user,
+            );
+        }
+
+        // force a tie on the default sort column, so the only thing that keeps
+        // the pages stable is the secondary sort on mission.uuid
+        const missionRepository = database.getRepository(MissionEntity);
+        await missionRepository
+            .createQueryBuilder()
+            .update()
+            .set({ createdAt: new Date('2020-01-01T00:00:00.000Z') })
+            .execute();
+
+        const sort = 'sortBy=createdAt&sortOrder=asc';
+        const seen: string[] = [];
+
+        for (let page = 0; page * PAGE_SIZE < TOTAL_MISSIONS; page++) {
+            const result = await fetchPage(
+                user,
+                `take=${String(PAGE_SIZE)}&skip=${String(page * PAGE_SIZE)}&${sort}`,
+            );
+            expect(result.count).toBe(TOTAL_MISSIONS);
+            seen.push(...result.data.map((mission) => mission.uuid));
+        }
+
+        // no mission is returned twice and none is missing
+        expect(seen).toHaveLength(TOTAL_MISSIONS);
+        expect(new Set(seen).size).toBe(TOTAL_MISSIONS);
     }, 60_000);
 });

--- a/backend/tests/functional/mission-pagination.test.ts
+++ b/backend/tests/functional/mission-pagination.test.ts
@@ -1,0 +1,138 @@
+import { DEFAULT_URL } from '../auth/utilities';
+import { createMissionUsingPost, getAuthHeaders } from '../utils/api-calls';
+import {
+    setupDatabaseHooks,
+    setupTestEnvironment,
+} from '../utils/test-helpers';
+
+interface MissionListResponse {
+    data: { uuid: string; name: string }[];
+    count: number;
+    take: number;
+    skip: number;
+}
+
+const TOTAL_MISSIONS = 7;
+const PAGE_SIZE = 3;
+
+const fetchPage = async (
+    user: Parameters<typeof getAuthHeaders>[0],
+    parameters: string,
+): Promise<MissionListResponse> => {
+    const response = await fetch(`${DEFAULT_URL}/missions?${parameters}`, {
+        method: 'GET',
+        headers: getAuthHeaders(user),
+    });
+    expect(response.status).toBe(200);
+    return (await response.json()) as MissionListResponse;
+};
+
+describe('Mission list pagination', () => {
+    setupDatabaseHooks();
+
+    test('honours take/skip and returns disjoint pages', async () => {
+        const { user, projectUuid } = await setupTestEnvironment(
+            'mission-pagination@kleinkram.dev',
+            'Mission Pagination User',
+        );
+
+        // setupTestEnvironment already created one mission ('test_mission')
+        for (let index = 1; index < TOTAL_MISSIONS; index++) {
+            await createMissionUsingPost(
+                {
+                    name: `pagination_mission_${String(index).padStart(2, '0')}`,
+                    projectUUID: projectUuid,
+                    tags: {},
+                    ignoreTags: true,
+                },
+                user,
+            );
+        }
+
+        const sort = 'sortBy=name&sortOrder=asc';
+
+        const page1 = await fetchPage(
+            user,
+            `take=${String(PAGE_SIZE)}&skip=0&${sort}`,
+        );
+        expect(page1.count).toBe(TOTAL_MISSIONS);
+        expect(page1.data).toHaveLength(PAGE_SIZE);
+
+        const page2 = await fetchPage(
+            user,
+            `take=${String(PAGE_SIZE)}&skip=${String(PAGE_SIZE)}&${sort}`,
+        );
+        expect(page2.count).toBe(TOTAL_MISSIONS);
+        expect(page2.data).toHaveLength(PAGE_SIZE);
+
+        const page1Uuids = page1.data.map((mission) => mission.uuid);
+        const page2Uuids = new Set(page2.data.map((mission) => mission.uuid));
+        expect(page1Uuids).not.toEqual([...page2Uuids]);
+        expect(page1Uuids.filter((uuid) => page2Uuids.has(uuid))).toHaveLength(
+            0,
+        );
+
+        // the last page only holds the remainder
+        const page3 = await fetchPage(
+            user,
+            `take=${String(PAGE_SIZE)}&skip=${String(2 * PAGE_SIZE)}&${sort}`,
+        );
+        expect(page3.data).toHaveLength(TOTAL_MISSIONS - 2 * PAGE_SIZE);
+
+        // all pages together cover every mission exactly once
+        const allUuids = new Set([
+            ...page1Uuids,
+            ...page2Uuids,
+            ...page3.data.map((mission) => mission.uuid),
+        ]);
+        expect(allUuids.size).toBe(TOTAL_MISSIONS);
+
+        // a skip beyond the end returns nothing but keeps the total count
+        const emptyPage = await fetchPage(
+            user,
+            `take=${String(PAGE_SIZE)}&skip=${String(TOTAL_MISSIONS)}&${sort}`,
+        );
+        expect(emptyPage.data).toHaveLength(0);
+        expect(emptyPage.count).toBe(TOTAL_MISSIONS);
+    }, 60_000);
+
+    test('honours take/skip for the minimal projection', async () => {
+        const { user, projectUuid } = await setupTestEnvironment(
+            'mission-pagination-minimal@kleinkram.dev',
+            'Mission Pagination Minimal User',
+        );
+
+        for (let index = 1; index < TOTAL_MISSIONS; index++) {
+            await createMissionUsingPost(
+                {
+                    name: `minimal_mission_${String(index).padStart(2, '0')}`,
+                    projectUUID: projectUuid,
+                    tags: {},
+                    ignoreTags: true,
+                },
+                user,
+            );
+        }
+
+        const sort = 'sortBy=name&sortOrder=asc';
+
+        const page1 = await fetchPage(
+            user,
+            `minimal=true&take=${String(PAGE_SIZE)}&skip=0&${sort}`,
+        );
+        expect(page1.count).toBe(TOTAL_MISSIONS);
+        expect(page1.data).toHaveLength(PAGE_SIZE);
+
+        const page2 = await fetchPage(
+            user,
+            `minimal=true&take=${String(PAGE_SIZE)}&skip=${String(PAGE_SIZE)}&${sort}`,
+        );
+        expect(page2.data).toHaveLength(PAGE_SIZE);
+
+        const page1Uuids = page1.data.map((mission) => mission.uuid);
+        const page2Uuids = new Set(page2.data.map((mission) => mission.uuid));
+        expect(page1Uuids.filter((uuid) => page2Uuids.has(uuid))).toHaveLength(
+            0,
+        );
+    }, 60_000);
+});


### PR DESCRIPTION
## Summary

`GET /missions` ignored `take`/`skip` and returned **every** mission on every page.

`MissionService.findMany` builds the id query with `.select('mission.uuid')` plus four `.leftJoin(...)` calls, groups by `mission.uuid`, and then applies `.take(take).skip(skip)` before `getRawMany()`. TypeORM only converts `take`/`skip` into `LIMIT`/`OFFSET` when the query has **no** joins:

```js
// node_modules/typeorm/query-builder/SelectQueryBuilder.js — createLimitOffsetExpression
if (offset === undefined && limit === undefined &&
    this.expressionMap.joinAttributes.length === 0) {
    offset = this.expressionMap.skip;
    limit = this.expressionMap.take;
}
```

For joined queries TypeORM normally handles `take`/`skip` through its two-query entity path, which `getRawMany()` never enters — so both values were silently dropped.

## Changes

- `backend/src/services/mission.service.ts`: the id query now uses `.limit(take).offset(skip)`, matching what `FileQueryService.findMany` already does for the equivalent joined+grouped id query. A comment records why.

**Count is unaffected.** `count` is still read from `getCount()` *before* pagination. TypeORM's `executeCountQuery` clones the builder, drops `orderBy`/`groupBy`/`limit`/`offset`/`take`/`skip` and — because the query has joins — counts `DISTINCT mission.uuid`, so the total remains the number of distinct matching missions.

## Tests

`backend/tests/functional/mission-pagination.test.ts` (new) creates 7 missions and asserts, for `take=3`:

- page 1 and page 2 each return 3 rows, page 3 returns the remaining 1
- `count` is 7 on every page
- page 2 is disjoint from page 1, and the three pages together cover all 7 missions exactly once
- a `skip` past the end returns 0 rows but still reports `count = 7`
- the same take/skip behaviour for `GET /missions?minimal=true`

Before the fix each of these pages returned all 7 missions.

## Verification

- `pnpm type-check` — clean
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm lint:check` — 0 errors (only the repo's pre-existing warnings)
- `pnpm prettier:check` — clean
- `cd backend && pnpm exec jest --testPathPatterns unit` — passes

The new test is DB-backed, so it runs in the api-tests workflow rather than locally.

## Note (not changed here)

`FIND_MANY_SORT_KEYS` allows sorting by `project.name` / `creator.name` while the id query groups by `mission.uuid`. Postgres' functional-dependency rule only covers columns of the grouped table, so those sort keys look like they would fail on the id query. That is pre-existing behaviour and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn