### PR TITLE
fix(backend): resolve guard uuids from a declared source and scope API key file listings

### DIFF
--- a/backend/src/endpoints/access/access.controller.ts
+++ b/backend/src/endpoints/access/access.controller.ts
@@ -41,6 +41,7 @@ import {
     CanDeleteProject,
     CanEditGroup,
     CanWriteProject,
+    fromParameter,
     UserOnly,
 } from '../auth/roles.decorator';
 
@@ -249,7 +250,7 @@ export class AccessController {
         type: ProjectDto,
     })
     @Post(':uuid/projects/:projectUuid')
-    @CanWriteProject()
+    @CanWriteProject(fromParameter('projectUuid'))
     async addAccessGroupToProject(
         @ParameterUID('uuid', 'UUID of AccessGroup') uuid: string,
         @ParameterUID('projectUuid', 'UUID of Project') projectUuid: string,
@@ -265,7 +266,7 @@ export class AccessController {
     }
 
     @Delete(':uuid/projects/:projectUuid')
-    @CanDeleteProject()
+    @CanDeleteProject(fromParameter('projectUuid'))
     @ApiResponse({
         status: 200,
         type: RemoveAccessGroupFromProjectResponseDto,

--- a/backend/src/endpoints/auth/access-source.ts
+++ b/backend/src/endpoints/auth/access-source.ts
@@ -1,0 +1,104 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import logger from '../../logger';
+
+/**
+ * Metadata key under which a route declares where the guard has to read the
+ * uuid of the resource it authorizes against.
+ */
+export const ACCESS_SOURCE_METADATA_KEY = 'accessSource';
+
+/**
+ * The part of the request a resource uuid is read from.
+ *
+ * `param` refers to a route parameter (`/files/:uuid`), `query` to a query
+ * string parameter (`?uuid=...`) and `body` to a property of the (JSON) request
+ * body.
+ */
+export type AccessSourceLocation = 'param' | 'query' | 'body';
+
+/**
+ * Declares the exact location of the resource uuid an access guard authorizes
+ * against.
+ *
+ * Guards must never fall back to another location: doing so allows a caller to
+ * point the guard at a resource they may access while the handler operates on a
+ * different one (e.g. `DELETE /files?uuid=<readable>` with a body naming
+ * another mission).
+ */
+export interface AccessSource {
+    from: AccessSourceLocation;
+    key: string;
+}
+
+/**
+ * The uuid lives in the route parameter `key` (default `uuid`).
+ */
+export const fromParameter = (key = 'uuid'): AccessSource => ({
+    from: 'param',
+    key,
+});
+
+/**
+ * The uuid lives in the query string parameter `key`.
+ */
+export const fromQuery = (key: string): AccessSource => ({
+    from: 'query',
+    key,
+});
+
+/**
+ * The uuid lives in the request body property `key`.
+ */
+export const fromBody = (key: string): AccessSource => ({
+    from: 'body',
+    key,
+});
+
+const pickContainer = (
+    request: Request,
+    from: AccessSourceLocation,
+): Record<string, unknown> | undefined => {
+    switch (from) {
+        case 'param': {
+            return request.params as Record<string, unknown> | undefined;
+        }
+        case 'query': {
+            return request.query as Record<string, unknown> | undefined;
+        }
+        case 'body': {
+            return request.body as Record<string, unknown> | undefined;
+        }
+    }
+};
+
+/**
+ * Reads the resource uuid from the single location the route declared through
+ * its access decorator.
+ *
+ * Returns `undefined` when the route did not declare a source (which is a
+ * programming error and must result in denied access) or when the declared
+ * location does not hold a string value.
+ */
+export const resolveAccessUuid = (
+    reflector: Reflector,
+    context: ExecutionContext,
+    request: Request,
+): string | undefined => {
+    const source = reflector.get<AccessSource | undefined>(
+        ACCESS_SOURCE_METADATA_KEY,
+        context.getHandler(),
+    );
+
+    if (!source) {
+        logger.error(
+            `Route ${context.getClass().name}.${context.getHandler().name} is guarded ` +
+                `but does not declare an '${ACCESS_SOURCE_METADATA_KEY}'. Denying access.`,
+        );
+        return undefined;
+    }
+
+    const value = pickContainer(request, source.from)?.[source.key];
+    return typeof value === 'string' ? value : undefined;
+};

--- a/backend/src/endpoints/auth/guards/access-group.guards.ts
+++ b/backend/src/endpoints/auth/guards/access-group.guards.ts
@@ -8,7 +8,6 @@ import { BaseGuard } from './base.guards';
 
 interface AccessGroupBody {
     projectAccessUUID?: string;
-    uuid?: string;
 }
 
 interface AccessGroupParameters {
@@ -31,10 +30,12 @@ export class IsAccessGroupCreatorByProjectAccessGuard extends BaseGuard {
             );
         }
 
+        // The route parameter wins: a body value must never be able to point the
+        // guard at a different project access than the one in the path.
         const body = request.body as AccessGroupBody | undefined;
         const params = request.params as AccessGroupParameters | undefined;
         const projectAccessUUID =
-            body?.projectAccessUUID ?? params?.projectAccessUUID;
+            params?.projectAccessUUID ?? body?.projectAccessUUID;
 
         if (!projectAccessUUID) {
             return false; // Deny access if UUID not provided
@@ -62,9 +63,10 @@ export class CanEditGroupByGroupUuid extends BaseGuard {
             );
         }
 
-        const body = request.body as AccessGroupBody | undefined;
+        // Every route using this guard addresses the access group through the
+        // route parameter (`/access-groups/:uuid/...`); the body is never read.
         const params = request.params as AccessGroupParameters | undefined;
-        const aguUUID = body?.uuid ?? params?.uuid;
+        const aguUUID = params?.uuid;
 
         if (!aguUUID) {
             return false; // Deny access if UUID not provided

--- a/backend/src/endpoints/auth/guards/action.guards.ts
+++ b/backend/src/endpoints/auth/guards/action.guards.ts
@@ -60,12 +60,10 @@ export class ReadActionGuard extends BaseGuard {
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const { user, apiKey, request } = await this.getUser(context);
 
+        // Every route using this guard addresses the action through the route
+        // parameter (`/actions/:uuid/...`); query and body are never consulted.
         const params = request.params as { uuid?: string } | undefined;
-        const body = request.body as ActionBody | undefined;
-        const actionUUID =
-            (request.query.uuid as string | undefined) ??
-            params?.uuid ??
-            body?.actionUUID;
+        const actionUUID = params?.uuid;
 
         if (!actionUUID) {
             return false; // Deny access if UUID not provided
@@ -143,9 +141,12 @@ export abstract class BaseActionModificationGuard extends BaseGuard {
     ) {
         const { user, apiKey, request } = await this.getUser(context);
 
+        // `DELETE /actions/:uuid` and `POST /actions/:uuid/cancel` address the
+        // action through the route parameter. The body is only honoured when the
+        // route has no parameter, so a body value can never override the path.
         const body = request.body as ActionBody | undefined;
         const params = request.params as { uuid?: string } | undefined;
-        const actionUUID = body?.actionUUID ?? params?.uuid;
+        const actionUUID = params?.uuid ?? body?.actionUUID;
 
         if (!actionUUID) {
             return null;

--- a/backend/src/endpoints/auth/guards/file.guards.ts
+++ b/backend/src/endpoints/auth/guards/file.guards.ts
@@ -1,3 +1,4 @@
+import { resolveAccessUuid } from '@/endpoints/auth/access-source';
 import { MissionGuardService } from '@/endpoints/auth/mission-guard.service';
 import { FileGuardService } from '@/services/file-guard.service';
 import { AccessGroupRights } from '@kleinkram/shared';
@@ -10,13 +11,8 @@ import { Reflector } from '@nestjs/core';
 import { BaseGuard } from './base.guards';
 
 interface FileBody {
-    uuid?: string;
     fileUUIDs?: string[];
     missionUUID?: string;
-}
-
-interface FileParameters {
-    uuid?: string;
 }
 
 @Injectable()
@@ -37,12 +33,10 @@ export class FileAccessGuard extends BaseGuard {
                 context.getHandler(),
             ) ?? AccessGroupRights.READ;
 
-        const body = request.body as FileBody | undefined;
-        const params = request.params as FileParameters | undefined;
-        const fileUUID =
-            (request.query.uuid as string | undefined) ??
-            body?.uuid ??
-            params?.uuid;
+        // The file uuid is read from exactly the location the route declared.
+        // Falling back to another location would let a caller authorize against
+        // a different file than the one the handler actually operates on.
+        const fileUUID = resolveAccessUuid(this.reflector, context, request);
 
         if (!fileUUID) {
             return false; // Deny access if UUID not provided
@@ -75,6 +69,8 @@ export class MoveFilesGuard extends BaseGuard {
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const { user, apiKey, request } = await this.getUser(context);
 
+        // `PATCH /files`: both the moved files and the target mission are only
+        // ever read from the request body.
         const body = request.body as FileBody;
         const fileUUIDs = body.fileUUIDs;
         const missionUUID = body.missionUUID;

--- a/backend/src/endpoints/auth/guards/index.ts
+++ b/backend/src/endpoints/auth/guards/index.ts
@@ -21,6 +21,9 @@ export {
 // File guards
 export { FileAccessGuard, MoveFilesGuard } from './file.guards';
 
+// Queue guards
+export { QueueItemAccessGuard } from './queue.guards';
+
 // Action guards
 export {
     CanModifyTriggerGuard,

--- a/backend/src/endpoints/auth/guards/mission.guards.ts
+++ b/backend/src/endpoints/auth/guards/mission.guards.ts
@@ -1,3 +1,4 @@
+import { resolveAccessUuid } from '@/endpoints/auth/access-source';
 import { MissionGuardService } from '@/endpoints/auth/mission-guard.service';
 import { ProjectGuardService } from '@/services/project-guard.service';
 import { AccessGroupRights } from '@kleinkram/shared';
@@ -8,17 +9,6 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { BaseGuard } from './base.guards';
-
-interface MissionBody {
-    missionUUID?: string;
-    missionUuid?: string;
-    uuid?: string;
-    mission?: string;
-}
-
-interface TagParameters {
-    uuid?: string;
-}
 
 @Injectable()
 export class MissionAccessGuard extends BaseGuard {
@@ -38,17 +28,10 @@ export class MissionAccessGuard extends BaseGuard {
                 context.getHandler(),
             ) ?? AccessGroupRights.READ;
 
-        const body = request.body as MissionBody | undefined;
-        const params = request.params as { uuid?: string } | undefined;
-        const missionUUID =
-            params?.uuid ??
-            (request.query.uuid as string | undefined) ??
-            (request.query.missionUuid as string | undefined) ??
-            (request.query.missionUUID as string | undefined) ??
-            body?.missionUUID ??
-            body?.missionUuid ??
-            body?.uuid ??
-            body?.mission;
+        // The mission uuid is read from exactly the location the route declared.
+        // Falling back to another location would let a caller authorize against
+        // a different mission than the one the handler actually operates on.
+        const missionUUID = resolveAccessUuid(this.reflector, context, request);
 
         if (!missionUUID) {
             return false; // Deny access if UUID not provided
@@ -116,9 +99,7 @@ export class DeleteTagGuard extends BaseGuard {
                 context.getHandler(),
             ) ?? AccessGroupRights.DELETE;
 
-        const body = request.body as MissionBody | undefined;
-        const params = request.params as TagParameters;
-        const tagUuid = body?.uuid ?? params.uuid;
+        const tagUuid = resolveAccessUuid(this.reflector, context, request);
 
         if (!tagUuid) {
             return false; // Deny access if tag UUID not provided
@@ -153,9 +134,10 @@ export class MoveMissionToProjectGuard extends BaseGuard {
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const { user, apiKey, request } = await this.getUser(context);
 
+        // `POST /missions/:uuid/move?projectUUID=...`: the mission is always the
+        // route parameter, the target project always the query parameter.
         const params = request.params as { uuid?: string } | undefined;
-        const missionUUID =
-            params?.uuid ?? (request.query.missionUUID as string | undefined);
+        const missionUUID = params?.uuid;
         const projectUUID = request.query.projectUUID as string | undefined;
 
         if (!missionUUID || !projectUUID) {

--- a/backend/src/endpoints/auth/guards/project.guards.ts
+++ b/backend/src/endpoints/auth/guards/project.guards.ts
@@ -1,3 +1,4 @@
+import { resolveAccessUuid } from '@/endpoints/auth/access-source';
 import { ProjectGuardService } from '@/services/project-guard.service';
 import { AccessGroupRights, KeyTypes } from '@kleinkram/shared';
 import {
@@ -8,16 +9,6 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { BaseGuard } from './base.guards';
-
-interface ProjectBody {
-    projectUUID?: string;
-    uuid?: string;
-}
-
-interface ProjectParameters {
-    uuid?: string;
-    projectUuid?: string;
-}
 
 @Injectable()
 export class ProjectAccessGuard extends BaseGuard {
@@ -37,15 +28,10 @@ export class ProjectAccessGuard extends BaseGuard {
                 context.getHandler(),
             ) ?? AccessGroupRights.READ;
 
-        const body = request.body as ProjectBody | undefined;
-        const params = request.params as ProjectParameters | undefined;
-        const projectUUID =
-            (request.query.projectUuid as string | undefined) ??
-            (request.query.uuid as string | undefined) ??
-            params?.projectUuid ??
-            params?.uuid ??
-            body?.projectUUID ??
-            body?.uuid;
+        // The project uuid is read from exactly the location the route declared.
+        // Falling back to another location would let a caller authorize against
+        // a different project than the one the handler actually operates on.
+        const projectUUID = resolveAccessUuid(this.reflector, context, request);
 
         if (!projectUUID) {
             return false; // Deny access if UUID not provided

--- a/backend/src/endpoints/auth/guards/queue.guards.ts
+++ b/backend/src/endpoints/auth/guards/queue.guards.ts
@@ -1,0 +1,61 @@
+import { MissionGuardService } from '@/endpoints/auth/mission-guard.service';
+import { IngestionJobEntity } from '@kleinkram/backend-common/entities/file/ingestion-job.entity';
+import { AccessGroupRights } from '@kleinkram/shared';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BaseGuard } from './base.guards';
+
+/**
+ * Authorizes the queue (ingestion job) routes `/files/queue/:uuid`.
+ *
+ * The route parameter is the uuid of the ingestion job, not of a mission, so the
+ * mission that owns the job is resolved from the database. The mission uuid a
+ * caller may pass in the body is never used for authorization: it only scopes
+ * the subsequent lookup in the queue service.
+ */
+@Injectable()
+export class QueueItemAccessGuard extends BaseGuard {
+    constructor(
+        private missionGuardService: MissionGuardService,
+        @InjectRepository(IngestionJobEntity)
+        private ingestionJobRepository: Repository<IngestionJobEntity>,
+    ) {
+        super();
+    }
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const { user, apiKey, request } = await this.getUser(context);
+
+        const params = request.params as { uuid?: string } | undefined;
+        const queueUUID = params?.uuid;
+
+        if (!queueUUID) {
+            return false; // Deny access if UUID not provided
+        }
+
+        const ingestionJob = await this.ingestionJobRepository.findOne({
+            where: { uuid: queueUUID },
+            relations: { mission: true },
+        });
+
+        const missionUUID = ingestionJob?.mission?.uuid;
+        if (!missionUUID) {
+            return false; // Deny access for unknown or orphaned queue entries
+        }
+
+        if (apiKey) {
+            return this.missionGuardService.canKeyAccessMission(
+                apiKey,
+                missionUUID,
+                AccessGroupRights.DELETE,
+            );
+        }
+
+        return this.missionGuardService.canAccessMission(
+            user,
+            missionUUID,
+            AccessGroupRights.DELETE,
+        );
+    }
+}

--- a/backend/src/endpoints/auth/roles.decorator.ts
+++ b/backend/src/endpoints/auth/roles.decorator.ts
@@ -8,6 +8,12 @@ import {
     UseGuards,
 } from '@nestjs/common';
 import {
+    ACCESS_SOURCE_METADATA_KEY,
+    AccessSource,
+    fromBody,
+    fromParameter,
+} from './access-source';
+import {
     AdminOnlyGuard,
     CancelActionGuard,
     CanEditGroupByGroupUuid,
@@ -24,9 +30,17 @@ import {
     MoveFilesGuard,
     MoveMissionToProjectGuard,
     ProjectAccessGuard,
+    QueueItemAccessGuard,
     ReadActionGuard,
     UserGuard,
 } from './guards';
+
+export {
+    fromBody,
+    fromParameter,
+    fromQuery,
+    type AccessSource,
+} from './access-source';
 
 // Logged-in user route decorator
 export function LoggedIn() {
@@ -68,9 +82,15 @@ export function AdminOnly() {
     );
 }
 
-export function CanReadProject() {
+/**
+ * Requires READ rights on a project.
+ *
+ * @param source where the project uuid lives, defaults to the `uuid` route parameter
+ */
+export function CanReadProject(source: AccessSource = fromParameter()) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.READ),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(ProjectAccessGuard),
         ApiResponse({
             status: 401,
@@ -81,9 +101,17 @@ export function CanReadProject() {
     );
 }
 
-export function CanCreateInProjectByBody() {
+/**
+ * Requires CREATE rights on a project.
+ *
+ * @param source where the project uuid lives, defaults to the `projectUUID` body property
+ */
+export function CanCreateInProjectByBody(
+    source: AccessSource = fromBody('projectUUID'),
+) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.CREATE),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(ProjectAccessGuard),
         ApiResponse({
             status: 401,
@@ -94,9 +122,15 @@ export function CanCreateInProjectByBody() {
     );
 }
 
-export function CanWriteProject() {
+/**
+ * Requires WRITE rights on a project.
+ *
+ * @param source where the project uuid lives, defaults to the `uuid` route parameter
+ */
+export function CanWriteProject(source: AccessSource = fromParameter()) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.WRITE),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(ProjectAccessGuard),
         ApiResponse({
             status: 401,
@@ -107,9 +141,15 @@ export function CanWriteProject() {
     );
 }
 
-export function CanDeleteProject() {
+/**
+ * Requires DELETE rights on a project.
+ *
+ * @param source where the project uuid lives, defaults to the `uuid` route parameter
+ */
+export function CanDeleteProject(source: AccessSource = fromParameter()) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.DELETE),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(ProjectAccessGuard),
         ApiResponse({
             status: 401,
@@ -133,9 +173,15 @@ export function CanCreate() {
     );
 }
 
-export function CanReadMission() {
+/**
+ * Requires READ rights on a mission.
+ *
+ * @param source where the mission uuid lives, defaults to the `uuid` route parameter
+ */
+export function CanReadMission(source: AccessSource = fromParameter()) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.READ),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(MissionAccessGuard),
         ApiResponse({
             status: 403,
@@ -159,9 +205,15 @@ export function CanMoveMission() {
     );
 }
 
-export function CanReadFile() {
+/**
+ * Requires READ rights on a file.
+ *
+ * @param source where the file uuid lives, defaults to the `uuid` route parameter
+ */
+export function CanReadFile(source: AccessSource = fromParameter()) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.READ),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(FileAccessGuard),
         ApiResponse({
             status: 403,
@@ -172,9 +224,15 @@ export function CanReadFile() {
     );
 }
 
-export function CanWriteFile() {
+/**
+ * Requires WRITE rights on a file.
+ *
+ * @param source where the file uuid lives, defaults to the `uuid` route parameter
+ */
+export function CanWriteFile(source: AccessSource = fromParameter()) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.WRITE),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(FileAccessGuard),
         ApiResponse({
             status: 403,
@@ -198,9 +256,17 @@ export function CanMoveFiles() {
     );
 }
 
-export function CanCreateInMissionByBody() {
+/**
+ * Requires CREATE rights on a mission.
+ *
+ * @param source where the mission uuid lives, defaults to the `missionUUID` body property
+ */
+export function CanCreateInMissionByBody(
+    source: AccessSource = fromBody('missionUUID'),
+) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.CREATE),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(MissionAccessGuard),
         ApiResponse({
             status: 403,
@@ -211,9 +277,17 @@ export function CanCreateInMissionByBody() {
     );
 }
 
-export function CanWriteMissionByBody() {
+/**
+ * Requires WRITE rights on a mission.
+ *
+ * @param source where the mission uuid lives, defaults to the `missionUUID` body property
+ */
+export function CanWriteMissionByBody(
+    source: AccessSource = fromBody('missionUUID'),
+) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.WRITE),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(MissionAccessGuard),
         ApiResponse({
             status: 403,
@@ -224,9 +298,15 @@ export function CanWriteMissionByBody() {
     );
 }
 
-export function CanDeleteMission() {
+/**
+ * Requires DELETE rights on a mission.
+ *
+ * @param source where the mission uuid lives, defaults to the `uuid` route parameter
+ */
+export function CanDeleteMission(source: AccessSource = fromParameter()) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.DELETE),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(MissionAccessGuard),
         ApiResponse({
             status: 403,
@@ -237,15 +317,41 @@ export function CanDeleteMission() {
     );
 }
 
-export function CanDeleteFile() {
+/**
+ * Requires DELETE rights on a file.
+ *
+ * @param source where the file uuid lives, defaults to the `uuid` route parameter
+ */
+export function CanDeleteFile(source: AccessSource = fromParameter()) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.DELETE),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(FileAccessGuard),
         ApiResponse({
             status: 403,
             type: ForbiddenException,
             description:
                 'User does not have Delete permissions on the specified project.',
+        }),
+    );
+}
+
+/**
+ * Requires DELETE rights on the mission owning the queue entry (ingestion job)
+ * addressed by the `uuid` route parameter.
+ *
+ * The route parameter is an ingestion job uuid, so the guard resolves the owning
+ * mission from the database instead of trusting a mission uuid from the request.
+ */
+export function CanDeleteQueueItem() {
+    return applyDecorators(
+        SetMetadata('accessRight', AccessGroupRights.DELETE),
+        UseGuards(QueueItemAccessGuard),
+        ApiResponse({
+            status: 403,
+            type: ForbiddenException,
+            description:
+                'User does not have Delete permissions on the mission of this queue entry.',
         }),
     );
 }
@@ -315,9 +421,15 @@ export function CanCancelAction() {
     );
 }
 
-export function CanAddTag() {
+/**
+ * Requires WRITE rights on the mission a tag is added to.
+ *
+ * @param source where the mission uuid lives, defaults to the `uuid` route parameter
+ */
+export function CanAddTag(source: AccessSource = fromParameter()) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.WRITE),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(MissionAccessGuard),
         ApiResponse({
             status: 401,
@@ -328,9 +440,15 @@ export function CanAddTag() {
     );
 }
 
-export function CanDeleteTag() {
+/**
+ * Requires DELETE rights on the mission a tag belongs to.
+ *
+ * @param source where the tag uuid lives, defaults to the `uuid` route parameter
+ */
+export function CanDeleteTag(source: AccessSource = fromParameter()) {
     return applyDecorators(
         SetMetadata('accessRight', AccessGroupRights.DELETE),
+        SetMetadata(ACCESS_SOURCE_METADATA_KEY, source),
         UseGuards(DeleteTagGuard),
         ApiResponse({
             status: 401,

--- a/backend/src/endpoints/category/category.controller.ts
+++ b/backend/src/endpoints/category/category.controller.ts
@@ -14,6 +14,7 @@ import {
     CanCreateInProjectByBody,
     CanReadProject,
     CanWriteMissionByBody,
+    fromQuery,
 } from '../auth/roles.decorator';
 
 @Controller('categories')
@@ -21,7 +22,7 @@ export class CategoryController {
     constructor(private readonly categoryService: CategoryService) {}
 
     @Get()
-    @CanReadProject()
+    @CanReadProject(fromQuery('projectUuid'))
     @ApiOkResponse({
         description: 'Get all categories in a project',
         type: CategoriesDto,

--- a/backend/src/endpoints/file/file.controller.ts
+++ b/backend/src/endpoints/file/file.controller.ts
@@ -68,10 +68,13 @@ import {
     CanCreateInMissionByBody,
     CanDeleteFile,
     CanDeleteMission,
+    CanDeleteQueueItem,
     CanMoveFiles,
     CanReadFile,
     CanReadMission,
     CanWriteFile,
+    fromBody,
+    fromQuery,
     LoggedIn,
     UserOnly,
 } from '../auth/roles.decorator';
@@ -99,16 +102,18 @@ export class FileController {
         @Query() query: FileQueryDto,
         @AddUser() auth: AuthHeader,
     ): Promise<FilesDto> {
-        let _missionUUID = query.missionUUID;
-        if (auth.apiKey) {
-            _missionUUID = auth.apiKey.mission.uuid;
-        }
+        // A mission scoped API key may only ever list files of its own mission.
+        // `resolveMissionScope` is the single place where that is enforced, so
+        // this pre-check and `findMany` below cannot drift apart.
+        const apiKeyMissionUuid = auth.apiKey?.mission.uuid;
 
         const projectUuids =
             query.projectUuids ??
             (query.projectUUID ? [query.projectUUID] : []);
-        const missionUuids =
-            query.missionUuids ?? (_missionUUID ? [_missionUUID] : []);
+        const { missionUuids } = this.fileQueryService.resolveMissionScope(
+            query,
+            apiKeyMissionUuid,
+        );
 
         // we pre-check the access to give a proper error message
         // the actual findMany method will check access again per file
@@ -129,7 +134,7 @@ export class FileController {
         return await this.fileQueryService.findMany(
             query,
             auth.user.uuid,
-            _missionUUID,
+            apiKeyMissionUuid,
         );
     }
 
@@ -209,7 +214,7 @@ export class FileController {
     }
 
     @Get('oneByName')
-    @CanReadMission()
+    @CanReadMission(fromQuery('uuid'))
     @ApiOkResponse({
         description: 'File',
         type: FileDto,
@@ -313,7 +318,7 @@ export class FileController {
     }
 
     @Delete()
-    @CanDeleteMission()
+    @CanDeleteMission(fromBody('missionUUID'))
     @ApiOkResponse({
         description: 'Delete Files Response',
         type: DeleteFileResponseDto,
@@ -328,7 +333,7 @@ export class FileController {
     }
 
     @Get('exists')
-    @CanReadFile()
+    @CanReadFile(fromQuery('uuid'))
     @ApiOkResponse({
         description: 'File exists',
         type: FileExistsResponseDto,
@@ -502,7 +507,7 @@ export class FileController {
     }
 
     @Delete('queue/:uuid')
-    @CanDeleteMission()
+    @CanDeleteQueueItem()
     @ApiOkResponse({
         type: DeleteMissionResponseDto,
     })
@@ -514,7 +519,7 @@ export class FileController {
     }
 
     @Post('queue/:uuid/cancel')
-    @CanDeleteMission()
+    @CanDeleteQueueItem()
     @ApiCreatedResponse({
         type: CancelProcessingResponseDto,
     })
@@ -526,7 +531,7 @@ export class FileController {
     }
 
     @Post('queue/:uuid/stop')
-    @CanDeleteMission()
+    @CanDeleteQueueItem()
     @ApiCreatedResponse({
         type: StopJobResponseDto,
     })

--- a/backend/src/endpoints/mission/mission.controller.ts
+++ b/backend/src/endpoints/mission/mission.controller.ts
@@ -34,6 +34,7 @@ import {
     CanMoveMission,
     CanReadMission,
     CanWriteMissionByBody,
+    fromParameter,
     UserOnly,
 } from '../auth/roles.decorator';
 
@@ -60,7 +61,7 @@ export class MissionController {
     }
 
     @Patch(':uuid/name')
-    @CanWriteMissionByBody()
+    @CanWriteMissionByBody(fromParameter('uuid'))
     @ApiOkResponse({
         description: 'Returns the updated mission',
         type: FlatMissionDto,

--- a/backend/src/endpoints/trigger/trigger.controller.ts
+++ b/backend/src/endpoints/trigger/trigger.controller.ts
@@ -20,6 +20,7 @@ import { AddUser, AuthHeader } from '../auth/parameter-decorator';
 import {
     CanCreateInMissionByBody,
     CanModifyTrigger,
+    fromBody,
     LoggedIn,
 } from '../auth/roles.decorator';
 
@@ -38,7 +39,7 @@ export class TriggerController {
     }
 
     @Post()
-    @CanCreateInMissionByBody()
+    @CanCreateInMissionByBody(fromBody('missionUuid'))
     @ApiCreatedResponse({ type: ActionTriggerDto })
     async create(
         @Body() dto: CreateActionTriggerDto,

--- a/backend/src/routing/interceptors/output-validation.ts
+++ b/backend/src/routing/interceptors/output-validation.ts
@@ -14,6 +14,23 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import logger from '../../logger';
 
+/**
+ * Options used to validate a response against its output DTO.
+ *
+ * `forbidUnknownValues` is off on purpose. class-validator reports an
+ * `unknownValue` error for every instance of a class that carries no validation
+ * metadata at all, which includes the intentionally empty response DTOs
+ * (`CancelProcessingResponseDto`, `AddMetadataTypeDto`, `RemoveTagTypeDto`, ...)
+ * that describe a `{}` body. Those routes would otherwise always fail with a 500
+ * in development. A DTO that merely forgot its decorators is still caught: as
+ * soon as the response carries any property, `forbidNonWhitelisted` rejects it.
+ */
+const VALIDATOR_OPTIONS = {
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    forbidUnknownValues: false,
+};
+
 function validateResponseJSON<T extends object>(dto: ClassConstructor<T>) {
     return (data: JSON): JSON => {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -29,19 +46,11 @@ function validateResponseJSON<T extends object>(dto: ClassConstructor<T>) {
             if (Array.isArray(instance)) {
                 for (const item of instance) {
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    const itemErrors = validateSync(item, {
-                        whitelist: true,
-                        forbidNonWhitelisted: true,
-                        forbidUnknownValues: true,
-                    });
+                    const itemErrors = validateSync(item, VALIDATOR_OPTIONS);
                     errors.push(...itemErrors);
                 }
             } else {
-                errors = validateSync(instance as object, {
-                    whitelist: true,
-                    forbidNonWhitelisted: true,
-                    forbidUnknownValues: true,
-                });
+                errors = validateSync(instance as object, VALIDATOR_OPTIONS);
             }
 
             if (errors.length > 0) {

--- a/backend/src/services/file-query.service.ts
+++ b/backend/src/services/file-query.service.ts
@@ -25,7 +25,11 @@ import {
     HealthStatus,
     UserRole,
 } from '@kleinkram/shared';
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+    ForbiddenException,
+    Injectable,
+    NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brackets, In, Repository, SelectQueryBuilder } from 'typeorm';
 import logger from '../logger';
@@ -80,6 +84,51 @@ export class FileQueryService {
         private eventRepo: Repository<FileEventEntity>,
     ) {}
 
+    /**
+     * Normalizes the mission filter of a file query.
+     *
+     * A request authenticated with a mission scoped API key may only ever see
+     * files of that one mission. Naming a different mission in the query is
+     * rejected instead of silently widening (or narrowing) the result set, so
+     * that controller and service can never disagree on what the key may see.
+     *
+     * @param query the (untrusted) file query of the request
+     * @param apiKeyMissionUuid the mission of the API key, `undefined` for cookie authenticated users
+     *
+     * @returns the mission uuids to filter by and, for API keys, the mission the
+     *          query has to be hard-restricted to
+     *
+     * @throws ForbiddenException if a mission scoped API key asks for another mission
+     */
+    resolveMissionScope(
+        query: FileQueryDto,
+        apiKeyMissionUuid?: string,
+    ): { missionUuids: string[]; enforcedMissionUuid?: string } {
+        const requestedMissionUuids =
+            query.missionUuids ??
+            (query.missionUUID ? [query.missionUUID] : []);
+
+        if (apiKeyMissionUuid === undefined) {
+            return { missionUuids: requestedMissionUuids };
+        }
+
+        const foreignMissionUuids = requestedMissionUuids.filter(
+            (missionUuid) => missionUuid !== apiKeyMissionUuid,
+        );
+
+        if (foreignMissionUuids.length > 0) {
+            throw new ForbiddenException(
+                `API key is scoped to mission ${apiKeyMissionUuid} and cannot access ` +
+                    `the following missions: ${foreignMissionUuids.join(', ')}`,
+            );
+        }
+
+        return {
+            missionUuids: [apiKeyMissionUuid],
+            enforcedMissionUuid: apiKeyMissionUuid,
+        };
+    }
+
     async findMany(
         query: FileQueryDto,
         userUuid: string,
@@ -121,13 +170,21 @@ export class FileQueryService {
         }
 
         // Apply mission filters
-        const missionUuids =
-            query.missionUuids ??
-            (query.missionUUID
-                ? [query.missionUUID]
-                : apiKeyMissionUuid
-                  ? [apiKeyMissionUuid]
-                  : []);
+        const { missionUuids, enforcedMissionUuid } = this.resolveMissionScope(
+            query,
+            apiKeyMissionUuid,
+        );
+
+        // A mission scoped API key is restricted to its own mission with a
+        // separate AND constraint: mission uuids, name patterns and metadata are
+        // OR-ed inside `addMissionFilters`, so a pattern would otherwise widen
+        // the query beyond the mission the key is scoped to.
+        if (enforcedMissionUuid !== undefined) {
+            idQuery.andWhere('mission.uuid = :enforcedMissionUuid', {
+                enforcedMissionUuid,
+            });
+        }
+
         if (
             missionUuids.length > 0 ||
             (query.missionPatterns && query.missionPatterns.length > 0) ||

--- a/backend/tests/auth/guard-access-source.unit.test.ts
+++ b/backend/tests/auth/guard-access-source.unit.test.ts
@@ -1,0 +1,235 @@
+import { AccessSource } from '@/endpoints/auth/access-source';
+import { FileAccessGuard } from '@/endpoints/auth/guards/file.guards';
+import { MissionAccessGuard } from '@/endpoints/auth/guards/mission.guards';
+import { ProjectAccessGuard } from '@/endpoints/auth/guards/project.guards';
+import { MissionGuardService } from '@/endpoints/auth/mission-guard.service';
+import { FileGuardService } from '@/services/file-guard.service';
+import { ProjectGuardService } from '@/services/project-guard.service';
+import { UserEntity } from '@kleinkram/backend-common/entities/user/user.entity';
+import { AccessGroupRights } from '@kleinkram/shared';
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+const ACCESSIBLE_UUID = '11111111-1111-4111-8111-111111111111';
+const FOREIGN_UUID = '22222222-2222-4222-8222-222222222222';
+
+interface RequestParts {
+    params?: Record<string, unknown>;
+    query?: Record<string, unknown>;
+    body?: Record<string, unknown>;
+}
+
+const user = { uuid: 'user-uuid' } as unknown as UserEntity;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function routeHandler(): void {}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class -- only used as a name in log output
+class TestController {}
+
+/**
+ * Builds an execution context whose request carries the given params, query and
+ * body, and whose handler declares `accessSource` (plus an optional
+ * `accessRight`) as route metadata.
+ */
+const buildContext = (
+    parts: RequestParts,
+    accessSource: AccessSource | undefined,
+    accessRight: AccessGroupRights = AccessGroupRights.READ,
+): { context: ExecutionContext; reflector: Reflector } => {
+    const request = {
+        params: parts.params ?? {},
+        query: parts.query ?? {},
+        body: parts.body ?? {},
+        user: { user, apiKey: undefined },
+    };
+
+    const context = {
+        switchToHttp: () => ({ getRequest: () => request }),
+        getHandler: () => routeHandler,
+        getClass: () => TestController,
+    } as unknown as ExecutionContext;
+
+    const metadata: Record<string, unknown> = {
+        accessRight,
+        accessSource,
+    };
+
+    const reflector = {
+        get: (key: string): unknown => metadata[key],
+    } as unknown as Reflector;
+
+    return { context, reflector };
+};
+
+describe('Access guards read the uuid from the declared source only', () => {
+    describe('MissionAccessGuard', () => {
+        let missionGuardService: { canAccessMission: jest.Mock };
+
+        beforeEach(() => {
+            missionGuardService = {
+                canAccessMission: jest.fn().mockResolvedValue(true),
+            };
+        });
+
+        const buildGuard = (reflector: Reflector) =>
+            new MissionAccessGuard(
+                missionGuardService as unknown as MissionGuardService,
+                reflector,
+            );
+
+        test('a body scoped route ignores a uuid smuggled through the query string', async () => {
+            const { context, reflector } = buildContext(
+                {
+                    params: { uuid: ACCESSIBLE_UUID },
+                    query: { uuid: ACCESSIBLE_UUID },
+                    body: { missionUUID: FOREIGN_UUID },
+                },
+                { from: 'body', key: 'missionUUID' },
+                AccessGroupRights.DELETE,
+            );
+
+            await buildGuard(reflector).canActivate(context);
+
+            expect(missionGuardService.canAccessMission).toHaveBeenCalledWith(
+                user,
+                FOREIGN_UUID,
+                AccessGroupRights.DELETE,
+            );
+        });
+
+        test('a param scoped route ignores query and body values', async () => {
+            const { context, reflector } = buildContext(
+                {
+                    params: { uuid: ACCESSIBLE_UUID },
+                    query: { uuid: FOREIGN_UUID },
+                    body: { missionUUID: FOREIGN_UUID, uuid: FOREIGN_UUID },
+                },
+                { from: 'param', key: 'uuid' },
+            );
+
+            await buildGuard(reflector).canActivate(context);
+
+            expect(missionGuardService.canAccessMission).toHaveBeenCalledWith(
+                user,
+                ACCESSIBLE_UUID,
+                AccessGroupRights.READ,
+            );
+        });
+
+        test('a query scoped route reads the declared query parameter', async () => {
+            const { context, reflector } = buildContext(
+                {
+                    query: { uuid: ACCESSIBLE_UUID },
+                    body: { missionUUID: FOREIGN_UUID },
+                },
+                { from: 'query', key: 'uuid' },
+            );
+
+            await buildGuard(reflector).canActivate(context);
+
+            expect(missionGuardService.canAccessMission).toHaveBeenCalledWith(
+                user,
+                ACCESSIBLE_UUID,
+                AccessGroupRights.READ,
+            );
+        });
+
+        test('access is denied when the route declares no source', async () => {
+            const { context, reflector } = buildContext(
+                { params: { uuid: ACCESSIBLE_UUID } },
+                undefined,
+            );
+
+            await expect(
+                buildGuard(reflector).canActivate(context),
+            ).resolves.toBe(false);
+            expect(missionGuardService.canAccessMission).not.toHaveBeenCalled();
+        });
+
+        test('access is denied when the declared source is empty', async () => {
+            const { context, reflector } = buildContext(
+                { params: { uuid: ACCESSIBLE_UUID } },
+                { from: 'body', key: 'missionUUID' },
+            );
+
+            await expect(
+                buildGuard(reflector).canActivate(context),
+            ).resolves.toBe(false);
+            expect(missionGuardService.canAccessMission).not.toHaveBeenCalled();
+        });
+
+        test('access is denied when the declared source holds a repeated query parameter', async () => {
+            const { context, reflector } = buildContext(
+                { query: { uuid: [ACCESSIBLE_UUID, FOREIGN_UUID] } },
+                { from: 'query', key: 'uuid' },
+            );
+
+            await expect(
+                buildGuard(reflector).canActivate(context),
+            ).resolves.toBe(false);
+            expect(missionGuardService.canAccessMission).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('FileAccessGuard', () => {
+        test('a param scoped route ignores a uuid smuggled through the query string', async () => {
+            const fileGuardService = {
+                canAccessFile: jest.fn().mockResolvedValue(true),
+            };
+            const { context, reflector } = buildContext(
+                {
+                    params: { uuid: FOREIGN_UUID },
+                    query: { uuid: ACCESSIBLE_UUID },
+                },
+                { from: 'param', key: 'uuid' },
+                AccessGroupRights.WRITE,
+            );
+
+            const guard = new FileAccessGuard(
+                fileGuardService as unknown as FileGuardService,
+                reflector,
+            );
+            await guard.canActivate(context);
+
+            expect(fileGuardService.canAccessFile).toHaveBeenCalledWith(
+                user,
+                FOREIGN_UUID,
+                AccessGroupRights.WRITE,
+            );
+        });
+    });
+
+    describe('ProjectAccessGuard', () => {
+        test('a route may declare a non-default parameter name', async () => {
+            const projectGuardService = {
+                canAccessProject: jest.fn().mockResolvedValue(true),
+            };
+            const { context, reflector } = buildContext(
+                {
+                    // `/access-groups/:uuid/projects/:projectUuid`: `uuid` is the
+                    // access group, the project lives in `projectUuid`.
+                    params: {
+                        uuid: FOREIGN_UUID,
+                        projectUuid: ACCESSIBLE_UUID,
+                    },
+                    query: { uuid: FOREIGN_UUID },
+                },
+                { from: 'param', key: 'projectUuid' },
+                AccessGroupRights.WRITE,
+            );
+
+            const guard = new ProjectAccessGuard(
+                projectGuardService as unknown as ProjectGuardService,
+                reflector,
+            );
+            await guard.canActivate(context);
+
+            expect(projectGuardService.canAccessProject).toHaveBeenCalledWith(
+                user,
+                ACCESSIBLE_UUID,
+                AccessGroupRights.WRITE,
+            );
+        });
+    });
+});

--- a/backend/tests/auth/route-access-sources.unit.test.ts
+++ b/backend/tests/auth/route-access-sources.unit.test.ts
@@ -1,114 +1,213 @@
-import { AccessController } from '@/endpoints/access/access.controller';
 import {
     ACCESS_SOURCE_METADATA_KEY,
     AccessSource,
+    fromBody,
+    fromParameter,
+    fromQuery,
 } from '@/endpoints/auth/access-source';
-import { CategoryController } from '@/endpoints/category/category.controller';
-import { FileController } from '@/endpoints/file/file.controller';
-import { MetadataController } from '@/endpoints/metadata/metadata.controller';
-import { MissionController } from '@/endpoints/mission/mission.controller';
-import { ProjectController } from '@/endpoints/project/project.controller';
-import { TriggerController } from '@/endpoints/trigger/trigger.controller';
+import {
+    DeleteTagGuard,
+    FileAccessGuard,
+    MissionAccessGuard,
+    ProjectAccessGuard,
+    QueueItemAccessGuard,
+} from '@/endpoints/auth/guards';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
 import 'reflect-metadata';
 
+const ENDPOINTS_DIRECTORY = path.join(
+    __dirname,
+    '..',
+    '..',
+    'src',
+    'endpoints',
+);
+
 /**
- * The declared access source of every guarded route.
+ * Guards that authorize against a uuid taken from the request. Every route using
+ * one of them has to declare where that uuid lives.
+ */
+const SOURCE_AWARE_GUARDS = new Set<unknown>([
+    MissionAccessGuard,
+    FileAccessGuard,
+    ProjectAccessGuard,
+    DeleteTagGuard,
+]);
+
+/**
+ * The declared access source of every guarded route, keyed by
+ * `<Controller>.<handler>`.
  *
  * This is the authorization contract of the API: the guard reads the resource
  * uuid from exactly this location, so it has to match the parameter the handler
- * itself works with. Adding a guarded route without adding it here (or changing
- * where a handler reads its uuid from) has to fail this test.
+ * itself works with. The routes are discovered from the controllers below, so
+ * adding a guarded route without listing it here fails, and so does leaving a
+ * stale entry behind.
  */
-interface ControllerLike {
-    name: string;
-    prototype: object;
-}
-
-const EXPECTED_ACCESS_SOURCES: [ControllerLike, string, AccessSource][] = [
+const EXPECTED_ACCESS_SOURCES = new Map<string, AccessSource>([
     // --- files -----------------------------------------------------------
-    [FileController, 'download', { from: 'param', key: 'uuid' }],
-    [FileController, 'update', { from: 'param', key: 'uuid' }],
-    [FileController, 'getOneFileByName', { from: 'query', key: 'uuid' }],
-    [FileController, 'deleteFile', { from: 'param', key: 'uuid' }],
-    [
-        FileController,
-        'getTemporaryAccess',
-        { from: 'body', key: 'missionUUID' },
-    ],
-    [FileController, 'deleteMultiple', { from: 'body', key: 'missionUUID' }],
-    [FileController, 'exists', { from: 'query', key: 'uuid' }],
-    [FileController, 'getEvents', { from: 'param', key: 'uuid' }],
-    [FileController, 'getFoxgloveLink', { from: 'param', key: 'uuid' }],
-    [FileController, 'importFromDrive', { from: 'body', key: 'missionUUID' }],
-    [FileController, 'getFileById', { from: 'param', key: 'uuid' }],
+    ['FileController.download', fromParameter('uuid')],
+    ['FileController.update', fromParameter('uuid')],
+    ['FileController.getOneFileByName', fromQuery('uuid')],
+    ['FileController.deleteFile', fromParameter('uuid')],
+    ['FileController.getTemporaryAccess', fromBody('missionUUID')],
+    ['FileController.deleteMultiple', fromBody('missionUUID')],
+    ['FileController.exists', fromQuery('uuid')],
+    ['FileController.getEvents', fromParameter('uuid')],
+    ['FileController.getFoxgloveLink', fromParameter('uuid')],
+    ['FileController.importFromDrive', fromBody('missionUUID')],
+    ['FileController.getFileById', fromParameter('uuid')],
 
     // --- missions --------------------------------------------------------
-    [MissionController, 'createMission', { from: 'body', key: 'projectUUID' }],
-    [MissionController, 'updateMissionName', { from: 'param', key: 'uuid' }],
-    [MissionController, 'getMissionById', { from: 'param', key: 'uuid' }],
-    [MissionController, 'downloadWithToken', { from: 'param', key: 'uuid' }],
-    [MissionController, 'deleteMission', { from: 'param', key: 'uuid' }],
-    [MissionController, 'addTags', { from: 'param', key: 'uuid' }],
+    ['MissionController.createMission', fromBody('projectUUID')],
+    ['MissionController.updateMissionName', fromParameter('uuid')],
+    ['MissionController.getMissionById', fromParameter('uuid')],
+    ['MissionController.downloadWithToken', fromParameter('uuid')],
+    ['MissionController.deleteMission', fromParameter('uuid')],
+    ['MissionController.addTags', fromParameter('uuid')],
 
     // --- projects --------------------------------------------------------
-    [ProjectController, 'getProjectById', { from: 'param', key: 'uuid' }],
-    [ProjectController, 'updateProject', { from: 'param', key: 'uuid' }],
-    [ProjectController, 'deleteProject', { from: 'param', key: 'uuid' }],
-    [ProjectController, 'addUserToProject', { from: 'param', key: 'uuid' }],
-    [ProjectController, 'addTagType', { from: 'param', key: 'uuid' }],
-    [ProjectController, 'removeTagType', { from: 'param', key: 'uuid' }],
-    [ProjectController, 'updateTagTypes', { from: 'param', key: 'uuid' }],
-    [ProjectController, 'getProjectAccess', { from: 'param', key: 'uuid' }],
-    [ProjectController, 'updateProjectAccess', { from: 'param', key: 'uuid' }],
+    ['ProjectController.getProjectById', fromParameter('uuid')],
+    ['ProjectController.updateProject', fromParameter('uuid')],
+    ['ProjectController.deleteProject', fromParameter('uuid')],
+    ['ProjectController.addUserToProject', fromParameter('uuid')],
+    ['ProjectController.addTagType', fromParameter('uuid')],
+    ['ProjectController.removeTagType', fromParameter('uuid')],
+    ['ProjectController.updateTagTypes', fromParameter('uuid')],
+    ['ProjectController.getProjectAccess', fromParameter('uuid')],
+    ['ProjectController.updateProjectAccess', fromParameter('uuid')],
 
     // --- access groups ---------------------------------------------------
     // `uuid` is the access group here, the project is `projectUuid`.
+    ['AccessController.addAccessGroupToProject', fromParameter('projectUuid')],
     [
-        AccessController,
-        'addAccessGroupToProject',
-        { from: 'param', key: 'projectUuid' },
-    ],
-    [
-        AccessController,
-        'removeAccessGroupFromProject',
-        { from: 'param', key: 'projectUuid' },
+        'AccessController.removeAccessGroupFromProject',
+        fromParameter('projectUuid'),
     ],
 
     // --- categories ------------------------------------------------------
-    [CategoryController, 'getAll', { from: 'query', key: 'projectUuid' }],
-    [
-        CategoryController,
-        'createCategory',
-        { from: 'body', key: 'projectUUID' },
-    ],
-    [
-        CategoryController,
-        'addManyCategories',
-        { from: 'body', key: 'missionUUID' },
-    ],
+    ['CategoryController.getAll', fromQuery('projectUuid')],
+    ['CategoryController.createCategory', fromBody('projectUUID')],
+    ['CategoryController.addManyCategories', fromBody('missionUUID')],
 
     // --- triggers --------------------------------------------------------
-    [TriggerController, 'create', { from: 'body', key: 'missionUuid' }],
+    ['TriggerController.create', fromBody('missionUuid')],
 
     // --- metadata --------------------------------------------------------
-    [MetadataController, 'deleteTag', { from: 'param', key: 'uuid' }],
+    ['MetadataController.deleteTag', fromParameter('uuid')],
+]);
+
+/**
+ * Routes authorized by the queue guard. It resolves the mission from the
+ * ingestion job in the database rather than from the request, so these routes
+ * declare no access source.
+ */
+const EXPECTED_QUEUE_ROUTES = [
+    'FileController.deleteQueueItem',
+    'FileController.cancelProcessing',
+    'FileController.stopJob',
 ];
 
+const listControllerFiles = (directory: string): string[] => {
+    const files: string[] = [];
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+        const fullPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...listControllerFiles(fullPath));
+        } else if (entry.name.endsWith('.controller.ts')) {
+            files.push(fullPath);
+        }
+    }
+    return files;
+};
+
+interface DiscoveredRoute {
+    key: string;
+    guards: unknown[];
+    accessSource: AccessSource | undefined;
+}
+
+/**
+ * Imports every `*.controller.ts` below `src/endpoints` and reads the guard and
+ * access source metadata Nest stored on each handler.
+ */
+const discoverRoutes = (): DiscoveredRoute[] => {
+    const routes: DiscoveredRoute[] = [];
+
+    for (const file of listControllerFiles(ENDPOINTS_DIRECTORY)) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
+        const module = require(file);
+
+        for (const exported of Object.values(
+            module as Record<string, unknown>,
+        )) {
+            if (typeof exported !== 'function') continue;
+            const prototype = (exported as { prototype?: object }).prototype;
+            if (!prototype) continue;
+
+            for (const name of Object.getOwnPropertyNames(prototype)) {
+                if (name === 'constructor') continue;
+                const handler = Object.getOwnPropertyDescriptor(prototype, name)
+                    ?.value as unknown;
+                if (typeof handler !== 'function') continue;
+
+                const guards =
+                    (Reflect.getMetadata(GUARDS_METADATA, handler) as
+                        unknown[] | undefined) ?? [];
+                if (guards.length === 0) continue;
+
+                routes.push({
+                    key: `${exported.name}.${name}`,
+                    guards,
+                    accessSource: Reflect.getMetadata(
+                        ACCESS_SOURCE_METADATA_KEY,
+                        handler,
+                    ) as AccessSource | undefined,
+                });
+            }
+        }
+    }
+
+    return routes;
+};
+
 describe('Guarded routes declare where their resource uuid lives', () => {
-    test.each(EXPECTED_ACCESS_SOURCES)(
-        '%s.%s',
-        (controller, handlerName, expected) => {
-            const handler = (controller.prototype as Record<string, unknown>)[
-                handlerName
-            ];
-            expect(handler).toBeDefined();
+    const routes = discoverRoutes();
 
-            const source = Reflect.getMetadata(
-                ACCESS_SOURCE_METADATA_KEY,
-                handler as object,
-            ) as AccessSource | undefined;
-
-            expect(source).toEqual(expected);
-        },
+    const sourceAwareRoutes = routes.filter((route) =>
+        route.guards.some((guard) => SOURCE_AWARE_GUARDS.has(guard)),
     );
+
+    test('controllers were discovered', () => {
+        expect(routes.length).toBeGreaterThan(0);
+        expect(sourceAwareRoutes.length).toBeGreaterThan(0);
+    });
+
+    test('the declared sources cover exactly the routes that need one', () => {
+        expect(new Set(sourceAwareRoutes.map((route) => route.key))).toEqual(
+            new Set(EXPECTED_ACCESS_SOURCES.keys()),
+        );
+    });
+
+    test('every route reads its uuid from the expected location', () => {
+        const actual = new Map(
+            sourceAwareRoutes.map((route) => [route.key, route.accessSource]),
+        );
+        expect(actual).toEqual(EXPECTED_ACCESS_SOURCES);
+    });
+
+    test('the queue routes resolve their mission from the ingestion job', () => {
+        const queueRoutes = routes.filter((route) =>
+            route.guards.includes(QueueItemAccessGuard),
+        );
+
+        expect(new Set(queueRoutes.map((route) => route.key))).toEqual(
+            new Set(EXPECTED_QUEUE_ROUTES),
+        );
+        for (const route of queueRoutes) {
+            expect(route.accessSource).toBeUndefined();
+        }
+    });
 });

--- a/backend/tests/auth/route-access-sources.unit.test.ts
+++ b/backend/tests/auth/route-access-sources.unit.test.ts
@@ -1,0 +1,114 @@
+import { AccessController } from '@/endpoints/access/access.controller';
+import {
+    ACCESS_SOURCE_METADATA_KEY,
+    AccessSource,
+} from '@/endpoints/auth/access-source';
+import { CategoryController } from '@/endpoints/category/category.controller';
+import { FileController } from '@/endpoints/file/file.controller';
+import { MetadataController } from '@/endpoints/metadata/metadata.controller';
+import { MissionController } from '@/endpoints/mission/mission.controller';
+import { ProjectController } from '@/endpoints/project/project.controller';
+import { TriggerController } from '@/endpoints/trigger/trigger.controller';
+import 'reflect-metadata';
+
+/**
+ * The declared access source of every guarded route.
+ *
+ * This is the authorization contract of the API: the guard reads the resource
+ * uuid from exactly this location, so it has to match the parameter the handler
+ * itself works with. Adding a guarded route without adding it here (or changing
+ * where a handler reads its uuid from) has to fail this test.
+ */
+interface ControllerLike {
+    name: string;
+    prototype: object;
+}
+
+const EXPECTED_ACCESS_SOURCES: [ControllerLike, string, AccessSource][] = [
+    // --- files -----------------------------------------------------------
+    [FileController, 'download', { from: 'param', key: 'uuid' }],
+    [FileController, 'update', { from: 'param', key: 'uuid' }],
+    [FileController, 'getOneFileByName', { from: 'query', key: 'uuid' }],
+    [FileController, 'deleteFile', { from: 'param', key: 'uuid' }],
+    [
+        FileController,
+        'getTemporaryAccess',
+        { from: 'body', key: 'missionUUID' },
+    ],
+    [FileController, 'deleteMultiple', { from: 'body', key: 'missionUUID' }],
+    [FileController, 'exists', { from: 'query', key: 'uuid' }],
+    [FileController, 'getEvents', { from: 'param', key: 'uuid' }],
+    [FileController, 'getFoxgloveLink', { from: 'param', key: 'uuid' }],
+    [FileController, 'importFromDrive', { from: 'body', key: 'missionUUID' }],
+    [FileController, 'getFileById', { from: 'param', key: 'uuid' }],
+
+    // --- missions --------------------------------------------------------
+    [MissionController, 'createMission', { from: 'body', key: 'projectUUID' }],
+    [MissionController, 'updateMissionName', { from: 'param', key: 'uuid' }],
+    [MissionController, 'getMissionById', { from: 'param', key: 'uuid' }],
+    [MissionController, 'downloadWithToken', { from: 'param', key: 'uuid' }],
+    [MissionController, 'deleteMission', { from: 'param', key: 'uuid' }],
+    [MissionController, 'addTags', { from: 'param', key: 'uuid' }],
+
+    // --- projects --------------------------------------------------------
+    [ProjectController, 'getProjectById', { from: 'param', key: 'uuid' }],
+    [ProjectController, 'updateProject', { from: 'param', key: 'uuid' }],
+    [ProjectController, 'deleteProject', { from: 'param', key: 'uuid' }],
+    [ProjectController, 'addUserToProject', { from: 'param', key: 'uuid' }],
+    [ProjectController, 'addTagType', { from: 'param', key: 'uuid' }],
+    [ProjectController, 'removeTagType', { from: 'param', key: 'uuid' }],
+    [ProjectController, 'updateTagTypes', { from: 'param', key: 'uuid' }],
+    [ProjectController, 'getProjectAccess', { from: 'param', key: 'uuid' }],
+    [ProjectController, 'updateProjectAccess', { from: 'param', key: 'uuid' }],
+
+    // --- access groups ---------------------------------------------------
+    // `uuid` is the access group here, the project is `projectUuid`.
+    [
+        AccessController,
+        'addAccessGroupToProject',
+        { from: 'param', key: 'projectUuid' },
+    ],
+    [
+        AccessController,
+        'removeAccessGroupFromProject',
+        { from: 'param', key: 'projectUuid' },
+    ],
+
+    // --- categories ------------------------------------------------------
+    [CategoryController, 'getAll', { from: 'query', key: 'projectUuid' }],
+    [
+        CategoryController,
+        'createCategory',
+        { from: 'body', key: 'projectUUID' },
+    ],
+    [
+        CategoryController,
+        'addManyCategories',
+        { from: 'body', key: 'missionUUID' },
+    ],
+
+    // --- triggers --------------------------------------------------------
+    [TriggerController, 'create', { from: 'body', key: 'missionUuid' }],
+
+    // --- metadata --------------------------------------------------------
+    [MetadataController, 'deleteTag', { from: 'param', key: 'uuid' }],
+];
+
+describe('Guarded routes declare where their resource uuid lives', () => {
+    test.each(EXPECTED_ACCESS_SOURCES)(
+        '%s.%s',
+        (controller, handlerName, expected) => {
+            const handler = (controller.prototype as Record<string, unknown>)[
+                handlerName
+            ];
+            expect(handler).toBeDefined();
+
+            const source = Reflect.getMetadata(
+                ACCESS_SOURCE_METADATA_KEY,
+                handler as object,
+            ) as AccessSource | undefined;
+
+            expect(source).toEqual(expected);
+        },
+    );
+});

--- a/backend/tests/files/api-key-file-listing.test.ts
+++ b/backend/tests/files/api-key-file-listing.test.ts
@@ -1,0 +1,200 @@
+import { appVersion } from '@/app-version';
+import {
+    ApiKeyEntity,
+    FileEntity,
+    UserEntity,
+} from '@kleinkram/backend-common';
+import { AccessGroupRights, FileType, KeyTypes } from '@kleinkram/shared';
+import { DEFAULT_URL, generateAndFetchDatabaseUser } from '../auth/utilities';
+import {
+    createMissionUsingPost,
+    createProjectUsingPost,
+    getAuthHeaders,
+} from '../utils/api-calls';
+import { database } from '../utils/database-utilities';
+import { setupDatabaseHooks } from '../utils/test-helpers';
+
+async function createTestFile(
+    filename: string,
+    missionUuid: string,
+    creator: UserEntity,
+): Promise<FileEntity> {
+    const fileRepository = database.getRepository(FileEntity);
+    return fileRepository.save(
+        fileRepository.create({
+            filename,
+            mission: { uuid: missionUuid },
+            creator: { uuid: creator.uuid },
+            date: new Date(),
+            type: FileType.BAG,
+            size: 1024,
+        }),
+    );
+}
+
+async function createMissionScopedApiKey(
+    missionUuid: string,
+    user: UserEntity,
+): Promise<string> {
+    const apiKeyRepository = database.getRepository(ApiKeyEntity);
+    const apiKey = apiKeyRepository.create({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        key_type: KeyTypes.ACTION,
+        mission: { uuid: missionUuid },
+        rights: AccessGroupRights.READ,
+        user: { uuid: user.uuid },
+    });
+    await apiKeyRepository.save(apiKey);
+    return apiKey.apikey;
+}
+
+const apiKeyHeaders = (apiKey: string): Record<string, string> => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'x-api-key': apiKey,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'kleinkram-client-version': appVersion,
+});
+
+interface FileListing {
+    data: { uuid: string; filename: string }[];
+}
+
+/**
+ * A mission scoped API key must only ever see files of its own mission, even
+ * when the user the key belongs to has access to the other missions as well.
+ */
+describe('Mission scoped API keys can only list their own mission', () => {
+    setupDatabaseHooks();
+
+    let owner: UserEntity;
+    let missionA: string;
+    let missionB: string;
+    let fileInA: FileEntity;
+    let fileInB: FileEntity;
+    let apiKey: string;
+
+    beforeEach(async () => {
+        // A regular (non-admin) user with access to both missions: the point of
+        // the test is that the *key* is narrower than the user.
+        ({ user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        ));
+
+        const suffix = `${String(Date.now())}_${String(
+            Math.floor(Math.random() * 100_000),
+        )}`;
+
+        const projectUuid = await createProjectUsingPost(
+            {
+                name: `api_key_scope_project_${suffix}`,
+                description: 'API key scope test project',
+                requiredTags: [],
+                accessGroups: [
+                    {
+                        userUuid: owner.uuid,
+                        rights: AccessGroupRights.DELETE,
+                    },
+                ],
+            },
+            owner,
+        );
+
+        missionA = await createMissionUsingPost(
+            {
+                name: `api_key_scope_a_${suffix}`,
+                projectUUID: projectUuid,
+                tags: {},
+                ignoreTags: true,
+            },
+            owner,
+        );
+        missionB = await createMissionUsingPost(
+            {
+                name: `api_key_scope_b_${suffix}`,
+                projectUUID: projectUuid,
+                tags: {},
+                ignoreTags: true,
+            },
+            owner,
+        );
+
+        fileInA = await createTestFile('in_mission_a.bag', missionA, owner);
+        fileInB = await createTestFile('in_mission_b.bag', missionB, owner);
+
+        apiKey = await createMissionScopedApiKey(missionA, owner);
+    }, 60_000);
+
+    test('an unfiltered listing only returns files of the key mission', async () => {
+        const response = await fetch(`${DEFAULT_URL}/files`, {
+            method: 'GET',
+            headers: apiKeyHeaders(apiKey),
+        });
+
+        expect(response.status).toBe(200);
+        const listing = (await response.json()) as FileListing;
+        const uuids = listing.data.map((file) => file.uuid);
+
+        expect(uuids).toContain(fileInA.uuid);
+        expect(uuids).not.toContain(fileInB.uuid);
+    }, 30_000);
+
+    test('the key mission may be named explicitly', async () => {
+        const response = await fetch(
+            `${DEFAULT_URL}/files?missionUUID=${missionA}`,
+            { method: 'GET', headers: apiKeyHeaders(apiKey) },
+        );
+
+        expect(response.status).toBe(200);
+        const listing = (await response.json()) as FileListing;
+        const uuids = listing.data.map((file) => file.uuid);
+
+        expect(uuids).toContain(fileInA.uuid);
+        expect(uuids).not.toContain(fileInB.uuid);
+    }, 30_000);
+
+    test('another mission cannot be requested through missionUUID', async () => {
+        const response = await fetch(
+            `${DEFAULT_URL}/files?missionUUID=${missionB}`,
+            { method: 'GET', headers: apiKeyHeaders(apiKey) },
+        );
+
+        expect(response.status).toBe(403);
+    }, 30_000);
+
+    test('another mission cannot be requested through missionUuids', async () => {
+        const response = await fetch(
+            `${DEFAULT_URL}/files?missionUuids=${missionB}`,
+            { method: 'GET', headers: apiKeyHeaders(apiKey) },
+        );
+
+        expect(response.status).toBe(403);
+    }, 30_000);
+
+    test('a mission pattern cannot widen the listing past the key mission', async () => {
+        const response = await fetch(`${DEFAULT_URL}/files?missionPatterns=*`, {
+            method: 'GET',
+            headers: apiKeyHeaders(apiKey),
+        });
+
+        expect(response.status).toBe(200);
+        const listing = (await response.json()) as FileListing;
+        const uuids = listing.data.map((file) => file.uuid);
+
+        expect(uuids).not.toContain(fileInB.uuid);
+    }, 30_000);
+
+    test('the same user still sees both missions with a cookie session', async () => {
+        const response = await fetch(`${DEFAULT_URL}/files`, {
+            method: 'GET',
+            headers: getAuthHeaders(owner),
+        });
+
+        expect(response.status).toBe(200);
+        const listing = (await response.json()) as FileListing;
+        const uuids = listing.data.map((file) => file.uuid);
+
+        expect(uuids).toContain(fileInA.uuid);
+        expect(uuids).toContain(fileInB.uuid);
+    }, 30_000);
+});

--- a/backend/tests/files/api-key-mission-scope.unit.test.ts
+++ b/backend/tests/files/api-key-mission-scope.unit.test.ts
@@ -1,0 +1,75 @@
+import { FileQueryService } from '@/services/file-query.service';
+import { FileQueryDto } from '@kleinkram/api-dto';
+import { ForbiddenException } from '@nestjs/common';
+
+const MISSION_A = '11111111-1111-4111-8111-111111111111';
+const MISSION_B = '22222222-2222-4222-8222-222222222222';
+
+/**
+ * `resolveMissionScope` only reads its arguments, so the repositories the
+ * service is otherwise built from are not needed here.
+ */
+const buildService = (): FileQueryService =>
+    new (FileQueryService as unknown as new () => FileQueryService)();
+
+const buildQuery = (parts: Partial<FileQueryDto>): FileQueryDto =>
+    parts as FileQueryDto;
+
+describe('FileQueryService.resolveMissionScope', () => {
+    let service: FileQueryService;
+
+    beforeEach(() => {
+        service = buildService();
+    });
+
+    test('a cookie authenticated user keeps the requested missions', () => {
+        expect(
+            service.resolveMissionScope(
+                buildQuery({ missionUuids: [MISSION_A, MISSION_B] }),
+            ),
+        ).toEqual({ missionUuids: [MISSION_A, MISSION_B] });
+    });
+
+    test('a cookie authenticated user without a mission filter is unrestricted', () => {
+        expect(service.resolveMissionScope(buildQuery({}))).toEqual({
+            missionUuids: [],
+        });
+    });
+
+    test('a mission scoped API key without a mission filter is pinned to its mission', () => {
+        expect(service.resolveMissionScope(buildQuery({}), MISSION_A)).toEqual({
+            missionUuids: [MISSION_A],
+            enforcedMissionUuid: MISSION_A,
+        });
+    });
+
+    test('a mission scoped API key may ask for its own mission', () => {
+        expect(
+            service.resolveMissionScope(
+                buildQuery({ missionUUID: MISSION_A }),
+                MISSION_A,
+            ),
+        ).toEqual({
+            missionUuids: [MISSION_A],
+            enforcedMissionUuid: MISSION_A,
+        });
+    });
+
+    test('a mission scoped API key cannot ask for another mission via missionUUID', () => {
+        expect(() =>
+            service.resolveMissionScope(
+                buildQuery({ missionUUID: MISSION_B }),
+                MISSION_A,
+            ),
+        ).toThrow(ForbiddenException);
+    });
+
+    test('a mission scoped API key cannot ask for another mission via missionUuids', () => {
+        expect(() =>
+            service.resolveMissionScope(
+                buildQuery({ missionUuids: [MISSION_A, MISSION_B] }),
+                MISSION_A,
+            ),
+        ).toThrow(ForbiddenException);
+    });
+});

--- a/backend/tests/files/file-delete-scope.test.ts
+++ b/backend/tests/files/file-delete-scope.test.ts
@@ -1,0 +1,150 @@
+import { FileEntity, UserEntity } from '@kleinkram/backend-common';
+import { AccessGroupRights, FileType } from '@kleinkram/shared';
+import { DEFAULT_URL, generateAndFetchDatabaseUser } from '../auth/utilities';
+import {
+    createMissionUsingPost,
+    createProjectUsingPost,
+    getAuthHeaders,
+} from '../utils/api-calls';
+import { database } from '../utils/database-utilities';
+import { setupDatabaseHooks } from '../utils/test-helpers';
+
+async function setupProjectWithAccess(
+    creator: UserEntity,
+    accessUser: UserEntity,
+    rights: AccessGroupRights,
+    label: string,
+): Promise<{ projectUuid: string; missionUuid: string }> {
+    const suffix = `${label}_${String(Date.now())}_${String(
+        Math.floor(Math.random() * 100_000),
+    )}`;
+
+    const projectUuid = await createProjectUsingPost(
+        {
+            name: `delete_scope_project_${suffix}`,
+            description: 'Delete scope test project',
+            requiredTags: [],
+            accessGroups: [{ userUuid: accessUser.uuid, rights }],
+        },
+        creator,
+    );
+
+    const missionUuid = await createMissionUsingPost(
+        {
+            name: `delete_scope_mission_${suffix}`,
+            projectUUID: projectUuid,
+            tags: {},
+            ignoreTags: true,
+        },
+        creator,
+    );
+
+    return { projectUuid, missionUuid };
+}
+
+async function createTestFile(
+    filename: string,
+    missionUuid: string,
+    creator: UserEntity,
+): Promise<FileEntity> {
+    const fileRepository = database.getRepository(FileEntity);
+    return fileRepository.save(
+        fileRepository.create({
+            filename,
+            mission: { uuid: missionUuid },
+            creator: { uuid: creator.uuid },
+            date: new Date(),
+            type: FileType.BAG,
+            size: 1024,
+        }),
+    );
+}
+
+const jsonHeaders = (user: UserEntity): Record<string, string> => ({
+    ...getAuthHeaders(user),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'Content-Type': 'application/json',
+});
+
+/**
+ * `DELETE /files` deletes the files of the mission named in the request body.
+ * The guard has to authorize against exactly that mission, never against a
+ * mission uuid a caller appends to the query string.
+ */
+describe('DELETE /files authorizes against the mission in the body', () => {
+    setupDatabaseHooks();
+
+    test('a uuid in the query string cannot authorize a deletion in another mission', async () => {
+        const { user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'admin',
+        );
+        const { user: attacker } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        );
+
+        // The attacker may delete everything in mission A ...
+        const { missionUuid: missionA } = await setupProjectWithAccess(
+            owner,
+            attacker,
+            AccessGroupRights.DELETE,
+            'a',
+        );
+
+        // ... and has no rights on mission B.
+        const { missionUuid: missionB } = await setupProjectWithAccess(
+            owner,
+            owner,
+            AccessGroupRights.DELETE,
+            'b',
+        );
+        const fileInB = await createTestFile('victim.bag', missionB, owner);
+
+        const response = await fetch(`${DEFAULT_URL}/files?uuid=${missionA}`, {
+            method: 'DELETE',
+            headers: jsonHeaders(attacker),
+            body: JSON.stringify({
+                uuids: [fileInB.uuid],
+                missionUUID: missionB,
+            }),
+        });
+
+        expect(response.status).toBe(403);
+
+        const survivor = await database
+            .getRepository(FileEntity)
+            .findOne({ where: { uuid: fileInB.uuid } });
+        expect(survivor).not.toBeNull();
+    }, 30_000);
+
+    test('a user with DELETE rights can still delete files of their own mission', async () => {
+        const { user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'admin',
+        );
+        const { user: deleter } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        );
+
+        const { missionUuid } = await setupProjectWithAccess(
+            owner,
+            deleter,
+            AccessGroupRights.DELETE,
+            'own',
+        );
+        const file = await createTestFile('own.bag', missionUuid, owner);
+
+        const response = await fetch(`${DEFAULT_URL}/files`, {
+            method: 'DELETE',
+            headers: jsonHeaders(deleter),
+            body: JSON.stringify({
+                uuids: [file.uuid],
+                missionUUID: missionUuid,
+            }),
+        });
+
+        expect(response.status).not.toBe(403);
+    }, 30_000);
+});

--- a/backend/tests/files/queue-access.test.ts
+++ b/backend/tests/files/queue-access.test.ts
@@ -1,0 +1,253 @@
+import { IngestionJobEntity, UserEntity } from '@kleinkram/backend-common';
+import { AccessGroupRights, QueueState } from '@kleinkram/shared';
+import { randomUUID } from 'node:crypto';
+import { DEFAULT_URL, generateAndFetchDatabaseUser } from '../auth/utilities';
+import {
+    createMissionUsingPost,
+    createProjectUsingPost,
+    getAuthHeaders,
+} from '../utils/api-calls';
+import { database } from '../utils/database-utilities';
+import { setupDatabaseHooks } from '../utils/test-helpers';
+
+/**
+ * Creates a project (owned by `creator`) that grants `accessUser` the given
+ * rights, plus one mission inside it.
+ */
+async function setupProjectWithAccess(
+    creator: UserEntity,
+    accessUser: UserEntity,
+    rights: AccessGroupRights,
+): Promise<{ projectUuid: string; missionUuid: string }> {
+    const suffix = `${String(Date.now())}_${String(
+        Math.floor(Math.random() * 100_000),
+    )}`;
+
+    const projectUuid = await createProjectUsingPost(
+        {
+            name: `queue_project_${suffix}`,
+            description: 'Queue access test project',
+            requiredTags: [],
+            accessGroups: [{ userUuid: accessUser.uuid, rights }],
+        },
+        creator,
+    );
+
+    const missionUuid = await createMissionUsingPost(
+        {
+            name: `queue_mission_${suffix}`,
+            projectUUID: projectUuid,
+            tags: {},
+            ignoreTags: true,
+        },
+        creator,
+    );
+
+    return { projectUuid, missionUuid };
+}
+
+async function createQueueEntry(
+    missionUuid: string,
+    creator: UserEntity,
+    state: QueueState = QueueState.AWAITING_UPLOAD,
+): Promise<IngestionJobEntity> {
+    const repository = database.getRepository(IngestionJobEntity);
+    return repository.save(
+        repository.create({
+            identifier: randomUUID(),
+            displayName: 'queued.bag',
+            state,
+            mission: { uuid: missionUuid },
+            creator: { uuid: creator.uuid },
+        }),
+    );
+}
+
+const jsonHeaders = (user: UserEntity): Record<string, string> => ({
+    ...getAuthHeaders(user),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'Content-Type': 'application/json',
+});
+
+/**
+ * The `/files/queue/:uuid` routes address an ingestion job, not a mission. The
+ * guard therefore has to resolve the owning mission from the job instead of
+ * treating the route parameter (or a mission uuid in the body) as the
+ * authorized resource.
+ */
+describe('Queue entry access control', () => {
+    setupDatabaseHooks();
+
+    test('a non-admin with DELETE rights can delete a queue entry', async () => {
+        const { user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'admin',
+        );
+        const { user: deleter } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        );
+
+        const { missionUuid } = await setupProjectWithAccess(
+            owner,
+            deleter,
+            AccessGroupRights.DELETE,
+        );
+        const queueEntry = await createQueueEntry(missionUuid, owner);
+
+        const response = await fetch(
+            `${DEFAULT_URL}/files/queue/${queueEntry.uuid}`,
+            {
+                method: 'DELETE',
+                headers: jsonHeaders(deleter),
+                body: JSON.stringify({ missionUUID: missionUuid }),
+            },
+        );
+
+        expect(response.status).toBeLessThan(300);
+
+        const remaining = await database
+            .getRepository(IngestionJobEntity)
+            .findOne({ where: { uuid: queueEntry.uuid } });
+        expect(remaining).toBeNull();
+    }, 30_000);
+
+    test('a non-admin with DELETE rights can cancel a queue entry', async () => {
+        const { user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'admin',
+        );
+        const { user: deleter } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        );
+
+        const { missionUuid } = await setupProjectWithAccess(
+            owner,
+            deleter,
+            AccessGroupRights.DELETE,
+        );
+        const queueEntry = await createQueueEntry(missionUuid, owner);
+
+        const response = await fetch(
+            `${DEFAULT_URL}/files/queue/${queueEntry.uuid}/cancel`,
+            {
+                method: 'POST',
+                headers: jsonHeaders(deleter),
+                body: JSON.stringify({ missionUUID: missionUuid }),
+            },
+        );
+
+        expect(response.status).toBeLessThan(300);
+
+        const cancelled = await database
+            .getRepository(IngestionJobEntity)
+            .findOneOrFail({ where: { uuid: queueEntry.uuid } });
+        expect(cancelled.state).toBe(QueueState.CANCELED);
+    }, 30_000);
+
+    test('a non-admin with DELETE rights passes the guard when stopping a queue entry', async () => {
+        const { user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'admin',
+        );
+        const { user: deleter } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        );
+
+        const { missionUuid } = await setupProjectWithAccess(
+            owner,
+            deleter,
+            AccessGroupRights.DELETE,
+        );
+        const queueEntry = await createQueueEntry(missionUuid, owner);
+
+        const response = await fetch(
+            `${DEFAULT_URL}/files/queue/${queueEntry.uuid}/stop`,
+            {
+                method: 'POST',
+                headers: jsonHeaders(deleter),
+            },
+        );
+
+        // The job is not processing, so the handler rejects it with a conflict.
+        // What matters here is that authorization no longer fails with a 403:
+        // the route carries no mission uuid at all.
+        expect(response.status).toBe(409);
+    }, 30_000);
+
+    test('a user with only READ rights cannot delete a queue entry', async () => {
+        const { user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'admin',
+        );
+        const { user: reader } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        );
+
+        const { missionUuid } = await setupProjectWithAccess(
+            owner,
+            reader,
+            AccessGroupRights.READ,
+        );
+        const queueEntry = await createQueueEntry(missionUuid, owner);
+
+        const response = await fetch(
+            `${DEFAULT_URL}/files/queue/${queueEntry.uuid}`,
+            {
+                method: 'DELETE',
+                headers: jsonHeaders(reader),
+                body: JSON.stringify({ missionUUID: missionUuid }),
+            },
+        );
+
+        expect(response.status).toBe(403);
+    }, 30_000);
+
+    test('the mission uuid in the body cannot authorize a foreign queue entry', async () => {
+        const { user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'admin',
+        );
+        const { user: attacker } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        );
+
+        // The attacker may delete everything in their own mission ...
+        const { missionUuid: ownMissionUuid } = await setupProjectWithAccess(
+            owner,
+            attacker,
+            AccessGroupRights.DELETE,
+        );
+
+        // ... but has no rights at all on this one.
+        const foreign = await setupProjectWithAccess(
+            owner,
+            owner,
+            AccessGroupRights.DELETE,
+        );
+        const foreignQueueEntry = await createQueueEntry(
+            foreign.missionUuid,
+            owner,
+        );
+
+        const response = await fetch(
+            `${DEFAULT_URL}/files/queue/${foreignQueueEntry.uuid}`,
+            {
+                method: 'DELETE',
+                headers: jsonHeaders(attacker),
+                body: JSON.stringify({ missionUUID: ownMissionUuid }),
+            },
+        );
+
+        expect(response.status).toBe(403);
+
+        const remaining = await database
+            .getRepository(IngestionJobEntity)
+            .findOne({ where: { uuid: foreignQueueEntry.uuid } });
+        expect(remaining).not.toBeNull();
+    }, 30_000);
+});

--- a/backend/tests/files/queue-access.test.ts
+++ b/backend/tests/files/queue-access.test.ts
@@ -46,6 +46,14 @@ async function setupProjectWithAccess(
     return { projectUuid, missionUuid };
 }
 
+/**
+ * Inserts an ingestion job directly.
+ *
+ * Going through the real upload flow would also enqueue a Bull job, which none
+ * of the handlers under test need: `delete` and `cancelProcessing` look the Bull
+ * job up by uuid and simply skip the removal when it is not there, and `stopJob`
+ * answers with a conflict.
+ */
 async function createQueueEntry(
     missionUuid: string,
     creator: UserEntity,
@@ -161,23 +169,31 @@ describe('Queue entry access control', () => {
             deleter,
             AccessGroupRights.DELETE,
         );
-        const queueEntry = await createQueueEntry(missionUuid, owner);
-
-        const response = await fetch(
-            `${DEFAULT_URL}/files/queue/${queueEntry.uuid}/stop`,
-            {
-                method: 'POST',
-                headers: jsonHeaders(deleter),
-            },
+        // `/stop` only ever succeeds for a job that a worker is currently
+        // running, which a test cannot arrange without a live Bull job. Both
+        // reachable states answer with a conflict; what matters here is that
+        // authorization no longer fails with a 403 on a route that carries no
+        // mission uuid at all.
+        const pendingEntry = await createQueueEntry(missionUuid, owner);
+        const pendingResponse = await fetch(
+            `${DEFAULT_URL}/files/queue/${pendingEntry.uuid}/stop`,
+            { method: 'POST', headers: jsonHeaders(deleter) },
         );
+        expect(pendingResponse.status).toBe(409);
 
-        // The job is not processing, so the handler rejects it with a conflict.
-        // What matters here is that authorization no longer fails with a 403:
-        // the route carries no mission uuid at all.
-        expect(response.status).toBe(409);
+        const processingEntry = await createQueueEntry(
+            missionUuid,
+            owner,
+            QueueState.PROCESSING,
+        );
+        const processingResponse = await fetch(
+            `${DEFAULT_URL}/files/queue/${processingEntry.uuid}/stop`,
+            { method: 'POST', headers: jsonHeaders(deleter) },
+        );
+        expect(processingResponse.status).toBe(409);
     }, 30_000);
 
-    test('a user with only READ rights cannot delete a queue entry', async () => {
+    test('a user with only READ rights is denied on every queue route', async () => {
         const { user: owner } = await generateAndFetchDatabaseUser(
             'internal',
             'admin',
@@ -192,18 +208,48 @@ describe('Queue entry access control', () => {
             reader,
             AccessGroupRights.READ,
         );
-        const queueEntry = await createQueueEntry(missionUuid, owner);
 
-        const response = await fetch(
-            `${DEFAULT_URL}/files/queue/${queueEntry.uuid}`,
+        const deleteEntry = await createQueueEntry(missionUuid, owner);
+        const deleteResponse = await fetch(
+            `${DEFAULT_URL}/files/queue/${deleteEntry.uuid}`,
             {
                 method: 'DELETE',
                 headers: jsonHeaders(reader),
                 body: JSON.stringify({ missionUUID: missionUuid }),
             },
         );
+        expect(deleteResponse.status).toBe(403);
 
-        expect(response.status).toBe(403);
+        const cancelEntry = await createQueueEntry(missionUuid, owner);
+        const cancelResponse = await fetch(
+            `${DEFAULT_URL}/files/queue/${cancelEntry.uuid}/cancel`,
+            {
+                method: 'POST',
+                headers: jsonHeaders(reader),
+                body: JSON.stringify({ missionUUID: missionUuid }),
+            },
+        );
+        expect(cancelResponse.status).toBe(403);
+
+        const stopEntry = await createQueueEntry(missionUuid, owner);
+        const stopResponse = await fetch(
+            `${DEFAULT_URL}/files/queue/${stopEntry.uuid}/stop`,
+            { method: 'POST', headers: jsonHeaders(reader) },
+        );
+        expect(stopResponse.status).toBe(403);
+
+        // Nothing was touched.
+        const survivors = await database
+            .getRepository(IngestionJobEntity)
+            .findBy([
+                { uuid: deleteEntry.uuid },
+                { uuid: cancelEntry.uuid },
+                { uuid: stopEntry.uuid },
+            ]);
+        expect(survivors).toHaveLength(3);
+        for (const survivor of survivors) {
+            expect(survivor.state).toBe(QueueState.AWAITING_UPLOAD);
+        }
     }, 30_000);
 
     test('the mission uuid in the body cannot authorize a foreign queue entry', async () => {

--- a/backend/tests/functional/output-validation.unit.test.ts
+++ b/backend/tests/functional/output-validation.unit.test.ts
@@ -1,0 +1,71 @@
+import { GlobalResponseValidationInterceptor } from '@/routing/interceptors/output-validation';
+import {
+    CancelProcessingResponseDto,
+    DeleteMissionResponseDto,
+} from '@kleinkram/api-dto';
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { firstValueFrom, of } from 'rxjs';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function routeHandler(): void {}
+
+const buildContext = (): ExecutionContext =>
+    ({
+        getHandler: () => routeHandler,
+        switchToHttp: () => ({ getRequest: () => ({}) }),
+    }) as unknown as ExecutionContext;
+
+const validate = async (dto: unknown, body: unknown): Promise<unknown> => {
+    const reflector = {
+        get: (key: string): unknown => (key === 'outputDto' ? dto : undefined),
+    } as unknown as Reflector;
+
+    const next = { handle: () => of(body) } as unknown as CallHandler;
+
+    return firstValueFrom(
+        new GlobalResponseValidationInterceptor(reflector).intercept(
+            buildContext(),
+            next,
+        ),
+    );
+};
+
+/**
+ * Several routes intentionally answer with an empty body and describe it with an
+ * empty DTO (`CancelProcessingResponseDto`, `AddMetadataTypeDto`, ...).
+ * class-validator's `forbidUnknownValues` rejects any class without validation
+ * metadata, which used to turn every one of those successful responses into a
+ * 500 whenever the interceptor is enabled (development and CI).
+ */
+describe('GlobalResponseValidationInterceptor', () => {
+    test('accepts an empty body for an empty response DTO', async () => {
+        await expect(
+            validate(CancelProcessingResponseDto, {}),
+        ).resolves.toEqual({});
+    });
+
+    test('still rejects unexpected properties on an empty response DTO', async () => {
+        await expect(
+            validate(CancelProcessingResponseDto, { leaked: 'secret' }),
+        ).rejects.toThrow('Validation failed');
+    });
+
+    test('accepts a valid body for a populated response DTO', async () => {
+        await expect(
+            validate(DeleteMissionResponseDto, { success: true }),
+        ).resolves.toEqual({ success: true });
+    });
+
+    test('rejects a missing property on a populated response DTO', async () => {
+        await expect(validate(DeleteMissionResponseDto, {})).rejects.toThrow(
+            'Validation failed',
+        );
+    });
+
+    test('rejects an extra property on a populated response DTO', async () => {
+        await expect(
+            validate(DeleteMissionResponseDto, { success: true, extra: 1 }),
+        ).rejects.toThrow('Validation failed');
+    });
+});


### PR DESCRIPTION
Fixes two confirmed authorization bugs in the backend.

## Bug 1 — guards resolved the wrong uuid

`MissionAccessGuard`, `FileAccessGuard` and `ProjectAccessGuard` resolved the uuid of the resource they authorize by trying route params, query string and body in turn:

```ts
params.uuid ?? query.uuid ?? query.missionUuid ?? query.missionUUID
  ?? body.missionUUID ?? body.missionUuid ?? body.uuid ?? body.mission
```

Two consequences:

- **Broken:** `DELETE /files/queue/:uuid`, `POST /files/queue/:uuid/cancel` and `POST /files/queue/:uuid/stop` are decorated `@CanDeleteMission()`, but the route parameter is an *ingestion job* uuid. The guard authorized against that uuid as if it were a mission, so every non-admin got a 403.
- **Escalation:** any body-scoped route could be authorized against a different resource by appending `?uuid=<something accessible>` to the query string. Verified against the running dev backend: a user with DELETE rights only on mission A deleted a file in mission B with `DELETE /files?uuid=<missionA>` and body `{uuids: [fileInB], missionUUID: missionB}` — HTTP **200**.

### Design

Decorators now declare where the uuid lives; guards read exactly that location with no fallback.

```ts
// backend/src/endpoints/auth/access-source.ts
export interface AccessSource { from: 'param' | 'query' | 'body'; key: string }
export const fromParameter = (key = 'uuid') => ({ from: 'param', key });
export const fromQuery = (key: string) => ({ from: 'query', key });
export const fromBody = (key: string) => ({ from: 'body', key });
```

Each decorator takes an optional source with a documented default and stores it as `accessSource` metadata next to the existing `accessRight`; `resolveAccessUuid(reflector, context, request)` reads it. A route without the metadata is denied (and logged) rather than falling back. Decorator names are unchanged.

Every controller usage of every guard decorator was checked against what the handler actually reads. The resulting table:

| Decorator | Default source | Routes overriding the default |
| --- | --- | --- |
| `CanReadMission` | `param uuid` | `GET /files/oneByName` → `fromQuery('uuid')` |
| `CanWriteMissionByBody` | `body missionUUID` | `PATCH /missions/:uuid/name` → `fromParameter('uuid')` |
| `CanCreateInMissionByBody` | `body missionUUID` | `POST /triggers` → `fromBody('missionUuid')` (DTO field is `missionUuid`) |
| `CanDeleteMission` | `param uuid` | `DELETE /files` → `fromBody('missionUUID')` |
| `CanAddTag` | `param uuid` | — |
| `CanReadFile` / `CanWriteFile` / `CanDeleteFile` | `param uuid` | `GET /files/exists` → `fromQuery('uuid')` |
| `CanReadProject` | `param uuid` | `GET /categories` → `fromQuery('projectUuid')` |
| `CanWriteProject` | `param uuid` | `POST /access-groups/:uuid/projects/:projectUuid` → `fromParameter('projectUuid')` |
| `CanDeleteProject` | `param uuid` | `DELETE /access-groups/:uuid/projects/:projectUuid` → `fromParameter('projectUuid')` |
| `CanCreateInProjectByBody` | `body projectUUID` | — |
| `CanDeleteTag` | `param uuid` | — |
| `CanDeleteQueueItem` (new) | resolved from the ingestion job | the three `/files/queue/:uuid` routes |

Single-source guards were tightened in place instead of taking metadata, since every route using them addresses its resource the same way:

- `ReadActionGuard`: was `query.uuid ?? params.uuid ?? body.actionUUID`, now the route parameter only.
- `DeleteActionGuard` / `CancelActionGuard`: was `body.actionUUID ?? params.uuid`, now the route parameter wins.
- `CanEditGroupByGroupUuid`: was `body.uuid ?? params.uuid`, now the route parameter only.
- `IsAccessGroupCreatorByProjectAccessGuard`: route parameter now wins over the body.
- `MoveMissionToProjectGuard`: mission from the route parameter only (was also accepting `query.missionUUID`).
- `MoveFilesGuard`, `CreateActionGuard`, `CreateActionsGuard`, `CanModifyTriggerGuard`: already single-source, unchanged.

### The queue routes

`POST /files/queue/:uuid/stop` carries no mission uuid anywhere — not in the path, not in the body. Rather than change the public API, the new `QueueItemAccessGuard` loads the ingestion job named by the route parameter and requires DELETE rights on *its* mission. It is applied to all three queue routes, so `missionUUID` in the body of delete/cancel is no longer trusted for authorization (the queue service still uses it to scope its lookup). API-key handling (`canKeyAccessMission`) is preserved.

## Bug 2 — mission-scoped API keys could list any mission's files

`GET /files` passed the key's mission to `FileQueryService.findMany` as a *fallback*, which `query.missionUuids` / `query.missionUUID` overrode. Since the row-level constraints are built from the key owner's access, a key scoped to mission A listed mission B's files whenever its user could see B. Verified against the running dev backend: HTTP **200** with mission B's files.

`FileQueryService.resolveMissionScope(query, apiKeyMissionUuid)` is now the single place that normalizes the mission filter, used by both the controller pre-check and `findMany`:

- no API key → the requested missions, unchanged;
- mission-scoped API key → exactly the key's mission; naming any other mission is a **403** listing the rejected uuids.

`findMany` additionally applies `mission.uuid = :enforcedMissionUuid` as a separate `AND`. This matters because `addMissionFilters` **OR**s uuids, name patterns and metadata inside one subquery, so `?missionPatterns=*` would otherwise have widened the result set past the key's mission.

## Verification

- `pnpm exec jest --testPathPatterns unit` (backend): 5/5 suites pass, including the three new unit suites.
- `pnpm exec tsc -p backend/tsconfig.json --noEmit`: clean. (Root `pnpm type-check` fails on pre-existing frontend errors — `frontend/.quasar/tsconfig.json` is not generated in this checkout — none in backend.)
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec eslint backend`: 0 errors (18 pre-existing warnings).
- `pnpm prettier:check`: clean.
- **The new integration tests were run against the running (unpatched) dev backend.** Exactly the seven bug-detecting assertions failed and every setup/positive-control assertion passed, which is what confirms both vulnerabilities and shows the tests are wired correctly:
  - queue delete / cancel / stop for a non-admin with DELETE rights → `403` (bug 1);
  - `DELETE /files?uuid=<missionA>` with body mission B → `200`, file deleted (bug 1 escalation);
  - API key scoped to mission A listing mission B via `missionUUID`, via `missionUuids`, and widening via `missionPatterns=*` → all succeeded (bug 2).
  - Passing on the old backend: READ-only user denied on the queue, a foreign queue entry denied, the key's own mission listed correctly, the same user still seeing both missions over a cookie session, and deleting files of one's own mission.
- The patched integration tests were **not** run end-to-end locally: that needs a backend built from this branch, and this environment's stack is shared. CI runs them.

### New tests

| File | Covers |
| --- | --- |
| `backend/tests/auth/guard-access-source.unit.test.ts` | guards read only the declared source; deny on missing/absent/non-string values |
| `backend/tests/auth/route-access-sources.unit.test.ts` | pins the declared source of all 33 guarded routes, so a new route or a moved uuid has to be declared |
| `backend/tests/files/api-key-mission-scope.unit.test.ts` | `resolveMissionScope` |
| `backend/tests/files/queue-access.test.ts` | non-admin with DELETE can delete/cancel/stop; READ-only denied; body `missionUUID` cannot authorize a foreign queue entry |
| `backend/tests/files/file-delete-scope.test.ts` | `DELETE /files?uuid=<A>` with body mission B rejected; own-mission deletion still works |
| `backend/tests/files/api-key-file-listing.test.ts` | key scoped to A cannot list B via `missionUUID`, `missionUuids` or `missionPatterns`; cookie session unaffected |

## Notes for the reviewer

- `CanDeleteQueueItem` is a new decorator; all pre-existing decorator names are unchanged.
- `POST /files/queue/:uuid/stop` behaviour changes from "403 unless admin" to "allowed with DELETE rights on the job's mission". The frontend's `stopQueueItem` helper exists but is currently unused.
- The task description mentioned `CanReadProjectByQuery`; no such decorator exists on `dev`. `GET /categories` is the query-scoped `CanReadProject` usage and is handled with an explicit `fromQuery('projectUuid')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn
