### PR TITLE
docs(migrations): document migration:show, working directory, release checklist

### DIFF
--- a/backend/migration/dev/migration.config.ts
+++ b/backend/migration/dev/migration.config.ts
@@ -6,8 +6,12 @@ const datasource = new DataSource(getConfig());
 
 datasource
     .initialize()
-    // eslint-disable-next-line no-console
-    .then(console.log)
+    .then((ds) => {
+        // eslint-disable-next-line no-console
+        console.log(
+            `Connected to ${ds.options.database as string} on ${(ds.options as { host?: string }).host ?? 'unknown host'}`,
+        );
+    })
     // eslint-disable-next-line unicorn/prefer-top-level-await
     .catch((error: unknown) => {
         console.error(error);

--- a/backend/migration/example.env
+++ b/backend/migration/example.env
@@ -1,23 +1,17 @@
 prod_dbpassword=
 dev_dbpassword=
-local_dbpassword=dbuserpass
 
 prod_port=
 dev_port=
-local_port=5432
 
 prod_dbname=
 dev_dbname=
-local_dbname=dbname
 
 prod_dbuser=
 dev_dbuser=
-local_dbuser=dbuser
 
 prod_dbhost=
 dev_dbhost=
-local_dbhost=localhost
 
 prod_ssl=true
 dev_ssl=true
-local_ssl=false

--- a/backend/migration/prod/migration.config.ts
+++ b/backend/migration/prod/migration.config.ts
@@ -6,8 +6,12 @@ const datasource = new DataSource(getConfig());
 
 datasource
     .initialize()
-    // eslint-disable-next-line no-console
-    .then(console.log)
+    .then((ds) => {
+        // eslint-disable-next-line no-console
+        console.log(
+            `Connected to ${ds.options.database as string} on ${(ds.options as { host?: string }).host ?? 'unknown host'}`,
+        );
+    })
     // eslint-disable-next-line unicorn/prefer-top-level-await
     .catch((error: unknown) => {
         console.error(error);

--- a/docs/development/migrations/migrations.md
+++ b/docs/development/migrations/migrations.md
@@ -117,5 +117,5 @@ Migrations that add a value to a Postgres enum (for example new `FileState` or `
 
 1. Merge all feature branches into `dev` and make sure the `Check Migrations` workflow is green.
 2. Run `migration:show` against the target database and review the pending list.
-3. Run `migration:run` against the target database. Migrations are written to be safe to apply while the previous backend version is still running.
+3. Review each pending migration for backward compatibility with the backend version that is still running (adding columns, enum values or constraints is usually safe; dropping or renaming columns is not). Then run `migration:run` against the target database. Use an expand-and-contract rollout, deploying compatible application code first, when a migration is not safe to apply against the running version.
 4. Deploy the new backend.

--- a/docs/development/migrations/migrations.md
+++ b/docs/development/migrations/migrations.md
@@ -3,7 +3,12 @@
 We rely on TypeORM Migrations to manage database schema changes safely and efficiently. See [TypeORM Migrations](https://typeorm.io/migrations) for more information.
 
 ::: warning Working Directory
-All commands on this page must be run from the `/backend/` directory.
+All commands on this page must be run from the `/backend/` directory. The `migration:*` scripts are defined in `backend/package.json`, not in the repository root, so `pnpm run migration:check` from the root fails with `Missing script`.
+
+```bash
+cd backend
+```
+
 :::
 
 ## Local Development (Auto-Sync)
@@ -37,11 +42,13 @@ Robust pipelines require valid migrations. Our CI runs a check on every PR to `m
 1. All migrations are generated.
 2. Current entities match the migration state.
 
-**If CI fails:** You likely changed an entity but forgot to generate a migration. Run the clean generation command locally and commit the result. You can verify this locally before pushing:
+**If CI fails:** You likely changed an entity but forgot to generate a migration. Run the clean generation command locally and commit the result. You can verify this locally before pushing (requires Docker, since the check spins up a temporary `postgres:17` container):
 
 ```bash
 pnpm run migration:check
 ```
+
+Note that some dependency upgrades change the schema TypeORM derives from unchanged entities (for example, TypeORM 1 changed the default `ON DELETE`/`ON UPDATE` behaviour of many-to-many junction tables). In that case the check fails without any entity change; commit the generated migration under a descriptive name.
 
 ### Fallback: Standard Generation
 
@@ -66,7 +73,19 @@ To run local or manual migrations, you must set up your environment variables.
 ```
 
 2. **Configure credentials:**
-   Edit `migration/.env` with your database connection details.
+   Edit `migration/.env` with your database connection details. The file is git-ignored. The dev configuration reads the `dev_*` variables, the production configuration the `prod_*` variables (`dbhost`, `port`, `dbname`, `dbuser`, `dbpassword`, `ssl`).
+
+### Check Which Migrations Are Pending
+
+Before applying anything, list the migrations known to the code and whether the target database has them (`[X]` applied, `[ ]` pending). This is read-only.
+
+```bash
+# Staging / Dev
+pnpm run typeorm migration:show -d migration/dev/migration.config.ts
+
+# Production
+pnpm run typeorm migration:show -d migration/prod/migration.config.ts
+```
 
 ### Apply Migrations
 
@@ -83,5 +102,20 @@ pnpm run typeorm migration:run -d migration/prod/migration.config.ts
 Undo the last applied migration if necessary.
 
 ```bash
+# Staging / Dev
+pnpm run typeorm migration:revert -d migration/dev/migration.config.ts
+
+# Production
 pnpm run typeorm migration:revert -d migration/prod/migration.config.ts
 ```
+
+::: warning Enum migrations
+Migrations that add a value to a Postgres enum (for example new `FileState` or `ActionState` values) can only be reverted while no row uses the new value; otherwise the `down()` cast fails. See [#2367](https://github.com/leggedrobotics/kleinkram/issues/2367).
+:::
+
+## Release Checklist
+
+1. Merge all feature branches into `dev` and make sure the `Check Migrations` workflow is green.
+2. Run `migration:show` against the target database and review the pending list.
+3. Run `migration:run` against the target database. Migrations are written to be safe to apply while the previous backend version is still running.
+4. Deploy the new backend.


### PR DESCRIPTION
## Summary
Brings `development/migrations/migrations.md` in line with how migrations are actually run:

- states that the `migration:*` scripts live in `backend/package.json` (running `pnpm run migration:check` from the root fails with *Missing script*)
- new **Check Which Migrations Are Pending** section using `typeorm migration:show` for dev and prod
- notes the Docker requirement of `migration:check` and that dependency upgrades can change the derived schema (the TypeORM 1 junction FK case)
- revert commands for dev and prod plus a warning on non-reversible enum migrations (#2367)
- a short release checklist
- `migration/example.env`: removed the `local_*` variables no config reads
- `migration/{dev,prod}/migration.config.ts`: print a one-line connection message instead of dumping the whole DataSource on connect, which buried the `migration:show` output

## Verification
- `pnpm run typeorm migration:show -d migration/dev/migration.config.ts` against the dev DB now prints the list without the config dump
- `docs:build:staging` builds, page renders at `development/migrations/migrations.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn