### PR TITLE
fix(frontend): expose BACKEND_URL from process.env in production builds (dev deployment login broken)

### DIFF
--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -39,6 +39,8 @@ RUN pnpm --filter @kleinkram/shared build
 RUN pnpm --filter @kleinkram/validation build
 RUN pnpm --filter @kleinkram/api-dto build
 RUN pnpm --filter kleinkram-frontend build
+# Fail the image build if the configured backend URL did not make it into the bundle
+RUN sh ./frontend/scripts/check-backend-url.sh frontend/dist/spa
 
 FROM debian:bookworm-slim AS nginx-base
 RUN apt-get update && \

--- a/frontend/quasar.config.ts
+++ b/frontend/quasar.config.ts
@@ -104,6 +104,16 @@ export default defineConfig((/* ctx */) => {
                 folder: path.resolve(appDirectory, '..'),
             },
 
+            // app-vite v3 only picks up prefixed variables from dotenv files;
+            // a bare `BACKEND_URL` set in process.env (the docker build ARG,
+            // no .env file in the image) is not exposed. Define it explicitly
+            // so production images do not silently fall back to localhost.
+            defineEnv: {
+                ...(process.env.BACKEND_URL === undefined
+                    ? {}
+                    : { BACKEND_URL: process.env.BACKEND_URL }),
+            },
+
             vueRouterMode: 'history', // available values: 'hash', 'history'
             // vueRouterBase,
             // vueDevtools,

--- a/frontend/quasar.config.ts
+++ b/frontend/quasar.config.ts
@@ -8,6 +8,13 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 const appDirectory = import.meta.dirname;
 
+// An unset docker build ARG / CI variable arrives as an empty string; treat
+// that (and whitespace) as "not provided" so the code fallback still applies.
+const backendUrlFromProcess = (() => {
+    const raw = (process.env.BACKEND_URL ?? '').trim();
+    return raw === '' ? undefined : raw;
+})();
+
 export default defineConfig((/* ctx */) => {
     return {
         // https://quasar.dev/quasar-cli-vite/prefetch-feature
@@ -109,9 +116,9 @@ export default defineConfig((/* ctx */) => {
             // no .env file in the image) is not exposed. Define it explicitly
             // so production images do not silently fall back to localhost.
             defineEnv: {
-                ...(process.env.BACKEND_URL === undefined
+                ...(backendUrlFromProcess === undefined
                     ? {}
-                    : { BACKEND_URL: process.env.BACKEND_URL }),
+                    : { BACKEND_URL: backendUrlFromProcess }),
             },
 
             vueRouterMode: 'history', // available values: 'hash', 'history'

--- a/frontend/scripts/check-backend-url.sh
+++ b/frontend/scripts/check-backend-url.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Fails the build when BACKEND_URL was supplied but did not end up in the
+# bundle. Guards the production image against silently shipping the
+# http://localhost:3000 fallback (see PR #2378).
+set -eu
+
+dist_dir="${1:-dist/spa}"
+url="$(printf '%s' "${BACKEND_URL:-}" | tr -d '[:space:]')"
+
+if [ -z "$url" ]; then
+    echo "check-backend-url: BACKEND_URL not set, skipping bundle assertion"
+    exit 0
+fi
+
+if grep -rqF -- "$url" "$dist_dir"; then
+    echo "check-backend-url: bundle contains BACKEND_URL=$url"
+    exit 0
+fi
+
+echo "check-backend-url: BACKEND_URL=$url is missing from $dist_dir" >&2
+exit 1


### PR DESCRIPTION
## Problem
Since the Quasar app-vite 3 migration (#2356) the deployed dev frontend (https://datasets.dev.leggedrobotics.com) calls `http://localhost:3000/auth/available-providers` and shows *Backend Unavailable* on `/login`.

Root cause: app-vite v3's `build.env.clientPrefix` exposes matching variables from dotenv files, but a bare `BACKEND_URL` set in `process.env` is not picked up (`VITE_*` process variables are). The docker build passes `BACKEND_URL` as a build ARG and `.env` files are excluded from the image, so the bundle got the `localhost:3000` fallback. Reproduced locally: building with `BACKEND_URL=https://probe.example.test` and no `.env` produced a bundle without that URL.

## Fix
`frontend/quasar.config.ts`: define `BACKEND_URL` explicitly through `build.defineEnv` when it is present in `process.env`. Dotenv-based local development is unchanged.

## Verification
- `BACKEND_URL=https://probe.example.test pnpm run build` without a `.env`: bundle contains the probe URL
- plain `pnpm run build` with the repo `.env`: bundle contains `http://localhost:3000` as before
- eslint and prettier clean

After merging, the `dev-build` workflow rebuilds `frontend-dev`; the swarm service `bagestry-dev_frontend` on rsl-s03 then needs to pick up the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn