### PR TITLE
fix(frontend): show permission error instead of 'invalid mission name' on mission rename

### DIFF
--- a/backend/tests/auth/missions/mission-access.test.ts
+++ b/backend/tests/auth/missions/mission-access.test.ts
@@ -590,6 +590,46 @@ describe('Verify Mission Level User Access', () => {
         expect(response.status).toBe(403);
     });
 
+    // Renaming without write rights must be reported as a permission problem.
+    // The guard has to reject the request before the body is validated,
+    // otherwise the user is told the name is invalid instead of being told
+    // that they lack the rights to rename the mission.
+    test('if a user with read access renaming a mission gets 403, not 400', async () => {
+        const { user: creator } = await generateAndFetchDatabaseUser(
+            'internal',
+            'admin',
+        );
+        const { user: readUser } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        );
+
+        const { missionUuid } = await setupProjectWithAccess(
+            creator,
+            readUser,
+            AccessGroupRights.READ,
+        );
+
+        const headers = new HeaderCreator(readUser);
+        headers.addHeader('Content-Type', 'application/json');
+
+        // an invalid name (spaces are not allowed) must still be answered with
+        // the permission error, as the guard runs before the validation pipe
+        const response = await fetch(
+            `${DEFAULT_URL}/missions/${missionUuid}/name`,
+            {
+                method: 'PATCH',
+                headers: headers.getHeaders(),
+                body: JSON.stringify({
+                    name: 'not a valid mission name!',
+                }),
+            },
+        );
+
+        expect(response.status).not.toBe(400);
+        expect(response.status).toBe(403);
+    });
+
     test('if user with read access on a project cannot edit metadata of a mission', async () => {
         const { user: creator } = await generateAndFetchDatabaseUser(
             'internal',

--- a/frontend/src/components/edit-file.vue
+++ b/frontend/src/components/edit-file.vue
@@ -78,9 +78,9 @@
 import type { CategoryDto } from '@kleinkram/api-dto/types/category.dto';
 import type { FileWithTopicDto } from '@kleinkram/api-dto/types/file/file.dto';
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
-import { isAxiosError } from 'axios';
 import { Notify, useDialogPluginComponent } from 'quasar';
 import { formatDate, parseDate } from 'src/services/date-formating';
+import { getErrorMessage } from 'src/services/error-handling';
 import { updateFile } from 'src/services/mutations/file';
 import { ref, watch } from 'vue';
 
@@ -173,17 +173,10 @@ const { mutate: updateFileMutation } = useMutation({
     },
     onError(error: unknown) {
         console.error(error);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const message =
-            (isAxiosError(error)
-                ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                  error.response?.data?.message
-                : (error as Error).message) ?? 'Unknown error occurred';
 
         Notify.create({
             group: false,
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            message: `Error updating file: ${message}`,
+            message: `Error updating file: ${getErrorMessage(error)}`,
             color: 'negative',
             spinner: false,
             position: 'bottom',

--- a/frontend/src/components/edit-project.vue
+++ b/frontend/src/components/edit-project.vue
@@ -72,6 +72,7 @@ import type { ProjectWithRequiredTagsDto } from '@kleinkram/api-dto/types/projec
 import { useQueryClient } from '@tanstack/vue-query';
 import { Notify, QInput } from 'quasar';
 import { useProjectQuery } from 'src/hooks/query-hooks';
+import { getErrorMessage } from 'src/services/error-handling';
 import { updateProject } from 'src/services/mutations/project';
 import { computed, Ref, ref, watch } from 'vue';
 
@@ -128,28 +129,12 @@ async function save_changes(): Promise<void> {
         projectDescription.value,
         autoConvert.value,
     ).catch((error: unknown) => {
-        let errorMessage = '';
-        errorMessage =
-            error instanceof Error
-                ? error.message
-                : ((error as { response?: { data?: { message?: string } } })
-                      .response?.data?.message ?? 'Unknown error');
-
-        if (errorMessage.includes('Project')) {
-            Notify.create({
-                message: `Error updating project: ${errorMessage}`,
-                color: 'negative',
-                position: 'bottom',
-                timeout: 5000,
-            });
-        } else {
-            Notify.create({
-                message: `Error updating project: ${errorMessage}`,
-                color: 'negative',
-                position: 'bottom',
-                timeout: 5000,
-            });
-        }
+        Notify.create({
+            message: `Error updating project: ${getErrorMessage(error)}`,
+            color: 'negative',
+            position: 'bottom',
+            timeout: 5000,
+        });
 
         throw error as Error;
     });

--- a/frontend/src/dialogs/modify-mission-dialog.vue
+++ b/frontend/src/dialogs/modify-mission-dialog.vue
@@ -11,7 +11,7 @@
                 autofocus
                 style="padding-bottom: 30px"
                 :error="!isNameValid"
-                :error-message="'Please enter a valid mission name'"
+                :error-message="nameErrorMessage"
                 placeholder="Name..."
             />
         </template>
@@ -31,13 +31,17 @@ import type { MissionWithFilesDto } from '@kleinkram/api-dto/types/mission/missi
 import { useQueryClient } from '@tanstack/vue-query';
 import { QInput, useDialogPluginComponent, useQuasar } from 'quasar';
 import BaseDialog from 'src/dialogs/base-dialog.vue';
+import { getErrorMessage, getErrorStatus } from 'src/services/error-handling';
 import { updateMissionName } from 'src/services/mutations/mission';
 import { ref } from 'vue';
+
+const DEFAULT_NAME_ERROR = 'Please enter a valid mission name';
 
 const { dialogRef } = useDialogPluginComponent();
 const $q = useQuasar();
 const queryClient = useQueryClient();
 const isNameValid = ref(true);
+const nameErrorMessage = ref(DEFAULT_NAME_ERROR);
 
 const properties = defineProps<{
     mission: MissionWithFilesDto;
@@ -46,6 +50,7 @@ const properties = defineProps<{
 const missionName = ref(properties.mission.name);
 
 const saveMissionName = async () => {
+    isNameValid.value = true;
     await updateMissionName(properties.mission.uuid, missionName.value)
         .then(async () => {
             $q.notify({
@@ -66,7 +71,19 @@ const saveMissionName = async () => {
             });
             dialogRef.value?.hide();
         })
-        .catch(() => {
+        .catch((error: unknown) => {
+            // only a rejected name is reported on the input itself, every other
+            // failure (missing rights, name already taken, ...) is shown as a
+            // notification to not mislabel it as an invalid name
+            if (getErrorStatus(error) !== 400) {
+                $q.notify({
+                    message: `Failed to update mission name: ${getErrorMessage(error)}`,
+                    color: 'negative',
+                });
+                return;
+            }
+
+            nameErrorMessage.value = getErrorMessage(error, DEFAULT_NAME_ERROR);
             isNameValid.value = false;
         });
 };

--- a/frontend/src/services/error-handling.ts
+++ b/frontend/src/services/error-handling.ts
@@ -1,0 +1,71 @@
+import { isAxiosError } from 'axios';
+
+/**
+ * Message shown when the backend denied a request because the user lacks the
+ * required rights. Guards that simply deny access answer with the generic
+ * `Forbidden resource` body of NestJS, which is not helpful for the user.
+ */
+export const INSUFFICIENT_PERMISSIONS_MESSAGE =
+    'You do not have permission to perform this action.';
+
+const NEST_DEFAULT_FORBIDDEN_MESSAGE = 'Forbidden resource';
+
+/**
+ * The HTTP status code of a failed request, or `undefined` if the error did not
+ * originate from an HTTP response (e.g. a network error).
+ */
+export const getErrorStatus = (error: unknown): number | undefined =>
+    isAxiosError(error) ? error.response?.status : undefined;
+
+/**
+ * Whether the request was rejected because the user lacks the required rights.
+ */
+export const isPermissionError = (error: unknown): boolean =>
+    getErrorStatus(error) === 403;
+
+/**
+ * The message the backend sent alongside a failed request, if any.
+ *
+ * NestJS reports validation failures as a list of messages, hence both a single
+ * string and an array of strings must be handled.
+ */
+const getResponseMessage = (error: unknown): string | undefined => {
+    if (!isAxiosError(error)) return undefined;
+
+    const data: unknown = error.response?.data;
+    const message = (data as { message?: unknown } | undefined)?.message;
+
+    if (typeof message === 'string' && message !== '') return message;
+    if (Array.isArray(message) && message.length > 0)
+        return message.map(String).join(', ');
+
+    return undefined;
+};
+
+/**
+ * Builds a message describing why a request failed.
+ *
+ * Permission errors are translated into a readable message unless the backend
+ * provided a more specific one, as a denied guard only reports the generic
+ * `Forbidden resource`.
+ *
+ * @param error the error thrown by axios (or anything else)
+ * @param fallback message used if no message can be extracted
+ */
+export const getErrorMessage = (
+    error: unknown,
+    fallback = 'Unknown error occurred',
+): string => {
+    const responseMessage = getResponseMessage(error);
+
+    if (isPermissionError(error))
+        return responseMessage === undefined ||
+            responseMessage === NEST_DEFAULT_FORBIDDEN_MESSAGE
+            ? INSUFFICIENT_PERMISSIONS_MESSAGE
+            : responseMessage;
+
+    if (responseMessage !== undefined) return responseMessage;
+    if (error instanceof Error && error.message !== '') return error.message;
+
+    return fallback;
+};


### PR DESCRIPTION
## Problem

Renaming a mission without the required rights showed **"Please enter a valid mission name"** on the name input, which suggests the name is wrong instead of telling the user that they may not rename the mission (reported from manual testing of v0.60.0, PR #2173).

## Root cause

The backend is correct: `PATCH /missions/:uuid/name` is guarded by `@CanWriteMissionByBody(fromParameter('uuid'))`, and NestJS runs guards before the `ValidationPipe`, so a user with only READ rights gets a `403` (never a `400`).

The frontend threw that information away. `frontend/src/dialogs/modify-mission-dialog.vue` caught *every* rejection of `updateMissionName` and turned it into the inline validation error of the input:

```ts
.catch(() => {
    isNameValid.value = false;   // -> "Please enter a valid mission name"
});
```

So a `403` (missing rights), a `409` (name already taken) and a network error all rendered as "invalid mission name".

## Fix

- New shared helper `frontend/src/services/error-handling.ts` (`getErrorStatus`, `isPermissionError`, `getErrorMessage`). `getErrorMessage` unwraps the backend message (string or the `string[]` of class-validator) and maps the generic `Forbidden resource` body of a denied guard to a readable permission message.
- `modify-mission-dialog.vue`: only a `400` is reported on the input itself, using the message of the backend (e.g. `Mission name is not valid!`); every other failure is shown as a negative notification (`Failed to update mission name: You do not have permission to perform this action.`).
- Same pattern in the neighbouring flows: `edit-project.vue` (project rename) showed the generic `Request failed with status code 403` because it read `error.message` of the axios error, and `edit-file.vue` (file rename) duplicated the extraction. Both use the helper now.

No backend change was needed; the status codes stay as they are.

## Tests

Added an API test in `backend/tests/auth/missions/mission-access.test.ts`: a user with READ rights renaming a mission with an *invalid* name still gets `403` and not `400`, pinning down that the guard runs before the validation pipe.

## Verification

- `pnpm type-check` — passes
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm lint:check` — 0 errors (34 pre-existing warnings, none in the touched files)
- `pnpm prettier:check` — passes
- `cd backend && pnpm exec jest --testPathPatterns unit` — all 8 unit suites pass

The new API test needs the docker test stack and was therefore not executed locally; it follows the existing test in the same file one-to-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn
