### PR TITLE
fix(files): make the edit dialog move files and give delete immediate feedback

### DIFF
--- a/backend/src/endpoints/file/file.controller.ts
+++ b/backend/src/endpoints/file/file.controller.ts
@@ -186,6 +186,7 @@ export class FileController {
             dto,
             auth.user,
             auth.apiKey?.action,
+            auth.apiKey,
         );
         return plainToInstance(FileDto, file, {
             excludeExtraneousValues: true,

--- a/backend/src/services/file-lifecycle.service.ts
+++ b/backend/src/services/file-lifecycle.service.ts
@@ -27,6 +27,7 @@ import {
 import {
     BadRequestException,
     ConflictException,
+    ForbiddenException,
     HttpException,
     HttpStatus,
     Inject,
@@ -127,6 +128,18 @@ export class FileLifecycleService implements OnModuleInit {
             file.missionUuid &&
             file.missionUuid !== databaseFile.mission.uuid
         ) {
+            // The route guard only authorizes the file itself, so the target
+            // mission is checked here (as `MoveFilesGuard` does for
+            // `PATCH /files`): moving a file there creates it there.
+            if (
+                !actor ||
+                !(await this.canCreateInMission(actor, file.missionUuid))
+            ) {
+                throw new ForbiddenException(
+                    'You do not have permission to move files into the target mission',
+                );
+            }
+
             oldMissionUuid = databaseFile.mission.uuid;
             const newMission = await this.missionRepository.findOneOrFail({
                 where: { uuid: file.missionUuid },
@@ -599,6 +612,52 @@ export class FileLifecycleService implements OnModuleInit {
                 return;
             }),
         );
+    }
+
+    /**
+     * Whether `user` may add files to the mission `missionUUID`, i.e. holds
+     * CREATE rights on the mission itself or on the project owning it.
+     */
+    private async canCreateInMission(
+        user: UserEntity,
+        missionUUID: string,
+    ): Promise<boolean> {
+        if (user.role === UserRole.ADMIN) {
+            return true;
+        }
+
+        const mission = await this.missionRepository.findOne({
+            where: { uuid: missionUUID },
+            relations: {
+                project: true,
+            },
+        });
+
+        if (mission?.project === undefined) {
+            return false;
+        }
+
+        const canAccessProject = await this.dataSource.manager.exists(
+            ProjectAccessViewEntity,
+            {
+                where: {
+                    projectUuid: mission.project.uuid,
+                    userUuid: user.uuid,
+                    rights: MoreThanOrEqual(AccessGroupRights.CREATE),
+                },
+            },
+        );
+        if (canAccessProject) {
+            return true;
+        }
+
+        return await this.dataSource.manager.exists(MissionAccessViewEntity, {
+            where: {
+                missionUuid: missionUUID,
+                userUuid: user.uuid,
+                rights: MoreThanOrEqual(AccessGroupRights.CREATE),
+            },
+        });
     }
 
     private async canCancelUpload(

--- a/backend/src/services/file-lifecycle.service.ts
+++ b/backend/src/services/file-lifecycle.service.ts
@@ -1,8 +1,10 @@
+import { MissionGuardService } from '@/endpoints/auth/mission-guard.service';
 import { TriggerService } from '@/services/trigger.service';
 import { TemporaryFileAccessesDto, UpdateFile } from '@kleinkram/api-dto';
 import { FileAuditService } from '@kleinkram/backend-common/audit/file-audit.service';
 import { redis } from '@kleinkram/backend-common/consts';
 import { ActionEntity } from '@kleinkram/backend-common/entities/action/action.entity';
+import { ApiKeyEntity } from '@kleinkram/backend-common/entities/auth/api-key.entity';
 import { CategoryEntity } from '@kleinkram/backend-common/entities/category/category.entity';
 import { FileEntity } from '@kleinkram/backend-common/entities/file/file.entity';
 import { IngestionJobEntity } from '@kleinkram/backend-common/entities/file/ingestion-job.entity';
@@ -76,6 +78,7 @@ export class FileLifecycleService implements OnModuleInit {
         private readonly dataSource: DataSource,
         private readonly auditService: FileAuditService,
         private readonly triggerService: TriggerService,
+        private readonly missionGuardService: MissionGuardService,
     ) {}
 
     onModuleInit(): void {
@@ -89,6 +92,7 @@ export class FileLifecycleService implements OnModuleInit {
         file: UpdateFile,
         actor?: UserEntity,
         action?: ActionEntity,
+        apiKey?: ApiKeyEntity,
     ): Promise<FileEntity | null> {
         logger.debug(`Updating file with uuid: ${uuid}`);
 
@@ -128,12 +132,27 @@ export class FileLifecycleService implements OnModuleInit {
             file.missionUuid &&
             file.missionUuid !== databaseFile.mission.uuid
         ) {
+            // An API key is scoped to a single mission and the guard of this
+            // route only ever validates the key against the file it addresses.
+            // Authorizing the target mission through the rights of the key
+            // owner would let a key move files out of its own scope, so keys
+            // may not move files at all (as for `PATCH /files`).
+            if (apiKey) {
+                throw new ForbiddenException(
+                    'API keys cannot move files between missions',
+                );
+            }
+
             // The route guard only authorizes the file itself, so the target
-            // mission is checked here (as `MoveFilesGuard` does for
-            // `PATCH /files`): moving a file there creates it there.
+            // mission is checked here through the very same service the guard
+            // of `PATCH /files` uses: moving a file there creates it there.
             if (
                 !actor ||
-                !(await this.canCreateInMission(actor, file.missionUuid))
+                !(await this.missionGuardService.canAccessMission(
+                    actor,
+                    file.missionUuid,
+                    AccessGroupRights.CREATE,
+                ))
             ) {
                 throw new ForbiddenException(
                     'You do not have permission to move files into the target mission',
@@ -612,52 +631,6 @@ export class FileLifecycleService implements OnModuleInit {
                 return;
             }),
         );
-    }
-
-    /**
-     * Whether `user` may add files to the mission `missionUUID`, i.e. holds
-     * CREATE rights on the mission itself or on the project owning it.
-     */
-    private async canCreateInMission(
-        user: UserEntity,
-        missionUUID: string,
-    ): Promise<boolean> {
-        if (user.role === UserRole.ADMIN) {
-            return true;
-        }
-
-        const mission = await this.missionRepository.findOne({
-            where: { uuid: missionUUID },
-            relations: {
-                project: true,
-            },
-        });
-
-        if (mission?.project === undefined) {
-            return false;
-        }
-
-        const canAccessProject = await this.dataSource.manager.exists(
-            ProjectAccessViewEntity,
-            {
-                where: {
-                    projectUuid: mission.project.uuid,
-                    userUuid: user.uuid,
-                    rights: MoreThanOrEqual(AccessGroupRights.CREATE),
-                },
-            },
-        );
-        if (canAccessProject) {
-            return true;
-        }
-
-        return await this.dataSource.manager.exists(MissionAccessViewEntity, {
-            where: {
-                missionUuid: missionUUID,
-                userUuid: user.uuid,
-                rights: MoreThanOrEqual(AccessGroupRights.CREATE),
-            },
-        });
     }
 
     private async canCancelUpload(

--- a/backend/tests/files/file-move-via-update.test.ts
+++ b/backend/tests/files/file-move-via-update.test.ts
@@ -1,5 +1,15 @@
-import { FileEntity, UserEntity } from '@kleinkram/backend-common';
-import { AccessGroupRights, FileType, UserRole } from '@kleinkram/shared';
+import { appVersion } from '@/app-version';
+import {
+    ApiKeyEntity,
+    FileEntity,
+    UserEntity,
+} from '@kleinkram/backend-common';
+import {
+    AccessGroupRights,
+    FileType,
+    KeyTypes,
+    UserRole,
+} from '@kleinkram/shared';
 import { DEFAULT_URL, generateAndFetchDatabaseUser } from '../auth/utilities';
 import {
     createMissionUsingPost,
@@ -111,8 +121,11 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
             'internal',
             'admin',
         );
+        // An external user: every internal user is a member of the affiliation
+        // group of `access_config.json`, which every new project grants CREATE
+        // rights to, so an internal user could legitimately move files here.
         const { user: editor } = await generateAndFetchDatabaseUser(
-            'internal',
+            'external',
             'user',
         );
 
@@ -143,6 +156,70 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
         const response = await fetch(`${DEFAULT_URL}/files/${file.uuid}`, {
             method: 'PUT',
             headers: jsonHeaders(editor),
+            body: JSON.stringify({
+                uuid: file.uuid,
+                filename: file.filename,
+                date: file.date,
+                missionUuid: targetMissionUuid,
+                categories: [],
+            }),
+        });
+
+        expect(response.status).toBe(403);
+
+        const unmovedFile = await fileRepository.findOneOrFail({
+            where: { uuid: file.uuid },
+            relations: { mission: true },
+        });
+        expect(unmovedFile.mission?.uuid).toBe(sourceMissionUuid);
+    }, 30_000);
+
+    test('an API key cannot move a file out of the mission it is scoped to', async () => {
+        // The key belongs to an admin: without the check on the update path,
+        // the rights of the key owner would authorize the move even though the
+        // key itself is scoped to a single mission.
+        const { user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'admin',
+        );
+
+        const { missionUuid: sourceMissionUuid } =
+            await createProjectWithMission(owner, 'key_source');
+        const { missionUuid: targetMissionUuid } =
+            await createProjectWithMission(owner, 'key_target');
+
+        const fileRepository = database.getRepository(FileEntity);
+        const file = await fileRepository.save(
+            fileRepository.create({
+                filename: 'scoped.bag',
+                mission: { uuid: sourceMissionUuid },
+                creator: { uuid: owner.uuid },
+                date: new Date(),
+                type: FileType.BAG,
+                size: 1024,
+            }),
+        );
+
+        const apiKeyRepository = database.getRepository(ApiKeyEntity);
+        const apiKey = apiKeyRepository.create({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            key_type: KeyTypes.ACTION,
+            mission: { uuid: sourceMissionUuid },
+            rights: AccessGroupRights.WRITE,
+            user: { uuid: owner.uuid },
+        });
+        await apiKeyRepository.save(apiKey);
+
+        const response = await fetch(`${DEFAULT_URL}/files/${file.uuid}`, {
+            method: 'PUT',
+            headers: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'Content-Type': 'application/json',
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'x-api-key': apiKey.apikey,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'kleinkram-client-version': appVersion,
+            },
             body: JSON.stringify({
                 uuid: file.uuid,
                 filename: file.filename,

--- a/backend/tests/files/file-move-via-update.test.ts
+++ b/backend/tests/files/file-move-via-update.test.ts
@@ -1,0 +1,163 @@
+import { FileEntity, UserEntity } from '@kleinkram/backend-common';
+import { AccessGroupRights, FileType, UserRole } from '@kleinkram/shared';
+import { DEFAULT_URL, generateAndFetchDatabaseUser } from '../auth/utilities';
+import {
+    createMissionUsingPost,
+    createProjectUsingPost,
+    getAuthHeaders,
+    uploadFile,
+} from '../utils/api-calls';
+import { database } from '../utils/database-utilities';
+import {
+    setupDatabaseHooks,
+    setupTestEnvironment,
+} from '../utils/test-helpers';
+
+const jsonHeaders = (user: UserEntity): Record<string, string> => ({
+    ...getAuthHeaders(user),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'Content-Type': 'application/json',
+});
+
+async function createProjectWithMission(
+    creator: UserEntity,
+    label: string,
+    accessGroups: { userUuid: string; rights: AccessGroupRights }[] = [],
+): Promise<{ projectUuid: string; missionUuid: string }> {
+    const suffix = `${label}_${String(Date.now())}_${String(
+        Math.floor(Math.random() * 100_000),
+    )}`;
+
+    const projectUuid = await createProjectUsingPost(
+        {
+            name: `move_project_${suffix}`,
+            description: 'Move test project',
+            requiredTags: [],
+            accessGroups,
+        },
+        creator,
+    );
+
+    const missionUuid = await createMissionUsingPost(
+        {
+            name: `move_mission_${suffix}`,
+            projectUUID: projectUuid,
+            tags: {},
+            ignoreTags: true,
+        },
+        creator,
+    );
+
+    return { projectUuid, missionUuid };
+}
+
+/**
+ * `PUT /files/:uuid` moves a file whenever the request names a `missionUuid`
+ * other than the current one. This is the endpoint the "Edit File" dialog of
+ * the frontend uses to change the location of a file.
+ */
+describe('PUT /files/:uuid moves a file into the mission of the request', () => {
+    setupDatabaseHooks();
+
+    test('a user changes the mission of a file through the update endpoint', async () => {
+        const { user, projectUuid, missionUuid } = await setupTestEnvironment(
+            'test-move-via-update@kleinkram.dev',
+            'Move Via Update User',
+            UserRole.ADMIN,
+        );
+
+        const targetMissionUuid = await createMissionUsingPost(
+            {
+                name: 'move_via_update_target',
+                projectUUID: projectUuid,
+                tags: {},
+                ignoreTags: true,
+            },
+            user,
+        );
+
+        await uploadFile(user, 'move_me.bag', missionUuid);
+
+        const fileRepository = database.getRepository(FileEntity);
+        const file = await fileRepository.findOneOrFail({
+            where: { filename: 'move_me.bag' },
+            relations: { mission: true },
+        });
+        expect(file.mission?.uuid).toBe(missionUuid);
+
+        const response = await fetch(`${DEFAULT_URL}/files/${file.uuid}`, {
+            method: 'PUT',
+            headers: jsonHeaders(user),
+            body: JSON.stringify({
+                uuid: file.uuid,
+                filename: file.filename,
+                date: file.date,
+                missionUuid: targetMissionUuid,
+                categories: [],
+            }),
+        });
+
+        expect(response.status).toBeLessThan(300);
+
+        const movedFile = await fileRepository.findOneOrFail({
+            where: { uuid: file.uuid },
+            relations: { mission: true },
+        });
+        expect(movedFile.mission?.uuid).toBe(targetMissionUuid);
+    }, 30_000);
+
+    test('a user without CREATE rights on the target mission cannot move a file there', async () => {
+        const { user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'admin',
+        );
+        const { user: editor } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        );
+
+        // The editor may write the files of the source project ...
+        const { missionUuid: sourceMissionUuid } =
+            await createProjectWithMission(owner, 'source', [
+                { userUuid: editor.uuid, rights: AccessGroupRights.WRITE },
+            ]);
+
+        // ... but may only read the target project.
+        const { missionUuid: targetMissionUuid } =
+            await createProjectWithMission(owner, 'target', [
+                { userUuid: editor.uuid, rights: AccessGroupRights.READ },
+            ]);
+
+        const fileRepository = database.getRepository(FileEntity);
+        const file = await fileRepository.save(
+            fileRepository.create({
+                filename: 'not_yours.bag',
+                mission: { uuid: sourceMissionUuid },
+                creator: { uuid: owner.uuid },
+                date: new Date(),
+                type: FileType.BAG,
+                size: 1024,
+            }),
+        );
+
+        const response = await fetch(`${DEFAULT_URL}/files/${file.uuid}`, {
+            method: 'PUT',
+            headers: jsonHeaders(editor),
+            body: JSON.stringify({
+                uuid: file.uuid,
+                filename: file.filename,
+                date: file.date,
+                missionUuid: targetMissionUuid,
+                categories: [],
+            }),
+        });
+
+        expect(response.status).toBe(403);
+
+        const unmovedFile = await fileRepository.findOneOrFail({
+            where: { uuid: file.uuid },
+            relations: { mission: true },
+        });
+        expect(unmovedFile.mission?.uuid).toBe(sourceMissionUuid);
+    }, 30_000);
+});

--- a/backend/tests/files/upload-preflight.test.ts
+++ b/backend/tests/files/upload-preflight.test.ts
@@ -16,6 +16,7 @@ import { FileAuditService } from '@kleinkram/backend-common/audit/file-audit.ser
 import { IStorageBucket } from '@kleinkram/backend-common/modules/storage/types';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
+import { MissionGuardService } from '../../src/endpoints/auth/mission-guard.service';
 import { FileLifecycleService } from '../../src/services/file-lifecycle.service';
 import { TriggerService } from '../../src/services/trigger.service';
 
@@ -88,6 +89,9 @@ describe('File Upload Pre-Flight Capacity Check', () => {
             {
                 addFileEvent: jest.fn(),
             } as unknown as jest.Mocked<TriggerService>,
+            {
+                canAccessMission: jest.fn().mockResolvedValue(true),
+            } as unknown as jest.Mocked<MissionGuardService>,
         );
     });
 
@@ -197,6 +201,9 @@ describe('File Upload Pre-Flight Capacity Check', () => {
             {
                 addFileEvent: jest.fn(),
             } as unknown as jest.Mocked<TriggerService>,
+            {
+                canAccessMission: jest.fn().mockResolvedValue(true),
+            } as unknown as jest.Mocked<MissionGuardService>,
         );
 
         const result = await serviceNoMetrics.getTemporaryAccess(

--- a/frontend/src/components/delete-file.vue
+++ b/frontend/src/components/delete-file.vue
@@ -13,6 +13,7 @@
 </template>
 <script setup lang="ts">
 import { useQueryClient } from '@tanstack/vue-query';
+import { isAxiosError } from 'axios';
 import { Notify } from 'quasar';
 import ROUTES from 'src/router/routes';
 import { deleteFile } from 'src/services/mutations/file';
@@ -28,52 +29,58 @@ const route = useRoute();
 const router = useRouter();
 
 async function deleteFileAction(): Promise<void> {
-    if (fileNameCheck.value === properties.file.filename) {
-        await deleteFile(properties.file)
-            .then(async () => {
-                await client.invalidateQueries({
-                    predicate: (query) =>
-                        query.queryKey[0] === 'files' ||
-                        (query.queryKey[0] === 'file' &&
-                            query.queryKey[1] === properties.file.uuid) ||
-                        query.queryKey[0] === 'Filtered Files',
-                });
-                Notify.create({
-                    message: 'File deleted',
-                    color: 'positive',
-                    timeout: 2000,
-                    position: 'bottom',
-                });
+    if (fileNameCheck.value !== properties.file.filename) return;
 
-                // Redirect to missions page if we are on the file page
-                if (route.name === ROUTES.FILE.routeName) {
-                    await router.push({
-                        name: ROUTES.FILES.routeName,
-                        params: {
-                            projectUuid: route.params.projectUuid,
-                            missionUuid: route.params.missionUuid,
-                        },
-                    });
-                }
-            })
-            .catch((error: unknown) => {
-                let errorMessage = '';
-                errorMessage =
-                    error instanceof Error
-                        ? error.message
-                        : ((
-                              error as {
-                                  response?: { data?: { message?: string } };
-                              }
-                          ).response?.data?.message ?? 'Unknown error');
+    try {
+        await deleteFile(properties.file);
+    } catch (error: unknown) {
+        const errorMessage =
+            (isAxiosError(error)
+                ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                  (error.response?.data?.message as string | undefined)
+                : undefined) ??
+            (error instanceof Error ? error.message : undefined) ??
+            'Unknown error';
 
-                Notify.create({
-                    message: `Error deleting file: ${errorMessage}`,
-                    color: 'negative',
-                    position: 'bottom',
-                });
-            });
+        Notify.create({
+            message: `Error deleting file: ${errorMessage}`,
+            color: 'negative',
+            position: 'bottom',
+        });
+        return;
     }
+
+    // Confirm the deletion before touching the query cache: invalidating the
+    // queries first delays the feedback by the (retried) refetches it triggers.
+    Notify.create({
+        message: 'File deleted',
+        color: 'positive',
+        timeout: 2000,
+        position: 'bottom',
+    });
+
+    // Leave the file page before its file query is dropped, otherwise the page
+    // refetches the file we just deleted and reports it as unloadable.
+    if (route.name === ROUTES.FILE.routeName) {
+        await router.push({
+            name: ROUTES.FILES.routeName,
+            params: {
+                projectUuid: route.params.projectUuid,
+                missionUuid: route.params.missionUuid,
+            },
+        });
+    }
+
+    // The file is gone, so its query is removed instead of invalidated
+    // (refetching it would only produce a 404).
+    client.removeQueries({ queryKey: ['file', properties.file.uuid] });
+
+    await client.invalidateQueries({
+        predicate: (query) =>
+            query.queryKey[0] === 'files' ||
+            query.queryKey[0] === 'Filtered Files' ||
+            query.queryKey[0] === 'missions',
+    });
 }
 
 const properties = defineProps<{

--- a/frontend/src/components/edit-file.vue
+++ b/frontend/src/components/edit-file.vue
@@ -144,7 +144,8 @@ watch(selectedMission, (newMission) => {
 });
 
 const { mutate: updateFileMutation } = useMutation({
-    mutationFn: (fileData: FileWithTopicDto) => updateFile({ file: fileData }),
+    mutationFn: (payload: { file: FileWithTopicDto; missionUuid: string }) =>
+        updateFile(payload),
     onSuccess: async () => {
         Notify.create({
             group: false,
@@ -155,15 +156,15 @@ const { mutate: updateFileMutation } = useMutation({
             timeout: 3000,
         });
         const cache = queryClient.getQueryCache();
-        const filtered = cache
-            .getAll()
-            .filter(
-                (query) =>
-                    query.queryKey[0] === 'Filtered Files' ||
-                    (query.queryKey[0] === 'file' &&
-                        query.queryKey[1] === fileUuid) ||
-                    query.queryKey[0] === 'files',
-            );
+        const filtered = cache.getAll().filter(
+            (query) =>
+                query.queryKey[0] === 'Filtered Files' ||
+                (query.queryKey[0] === 'file' &&
+                    query.queryKey[1] === fileUuid) ||
+                query.queryKey[0] === 'files' ||
+                // a file may have been moved into another mission
+                query.queryKey[0] === 'missions',
+        );
 
         await Promise.all(
             filtered.map((query) =>
@@ -197,17 +198,19 @@ function _updateMission(): void {
 
     if (
         editableFile.value &&
+        missionUuid.value &&
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         convertedDate &&
         !Number.isNaN(convertedDate.getTime())
     ) {
         editableFile.value.date = convertedDate;
 
-        const noncircularMission = { ...editableFile.value.mission };
-        noncircularMission.project =
-            undefined as unknown as typeof noncircularMission.project;
-        editableFile.value.mission = noncircularMission;
-        updateFileMutation(editableFile.value);
+        // The mission selected in the ScopeSelector is the target location of
+        // the file; sending a different mission than the current one moves it.
+        updateFileMutation({
+            file: editableFile.value,
+            missionUuid: missionUuid.value,
+        });
         onDialogOK();
     }
 }

--- a/frontend/src/services/mutations/file.ts
+++ b/frontend/src/services/mutations/file.ts
@@ -27,14 +27,20 @@ export type GenerateTemporaryCredentialsResponse = {
     } | null;
 }[];
 
+/**
+ * Updates a file. Passing a `missionUuid` of another mission moves the file
+ * into that mission (see `PUT /files/:uuid`).
+ */
 export const updateFile = async ({
     file,
+    missionUuid,
 }: {
     file: FileWithTopicDto;
+    missionUuid: string;
 }): Promise<FileDto> => {
     const response = await axios.put<FileDto>(`/files/${file.uuid}`, {
         uuid: file.uuid,
-        missionUuid: file.missionUUID,
+        missionUuid,
         filename: file.filename,
         date: file.date,
         categories: file.categories.map(


### PR DESCRIPTION
Two bugs from the manual test of v0.60.0 (#2173), both in the file CRUD flows.

## (a) Moving a file via the "Edit File" dialog does nothing

The "Name & Location" tab of the edit dialog (three-dot menu -> Edit in the file
table, "Edit File" button on the file info page) lets the user pick the project
and mission a file belongs to. `updateFile` however built the request body from
`file.missionUUID` — a frontend-only field of `FileWithTopicDto` that is only
populated while uploading and is `undefined` for every file that came from the
API. `PUT /files/:uuid` therefore received `missionUuid: undefined` and left the
file where it was: the filename and the categories were saved, the location was
silently dropped. (Long standing: the field was wired up in 2f005284.)

The mission uuid is now passed explicitly from the ScopeSelector, which is the
source of truth for the target location. As the mission object is no longer part
of the payload, the workaround that stripped the circular `mission.project`
reference before serialising could go as well. `missions` queries are
invalidated too, since a file may have changed mission.

`PATCH /files` (the separate "Move" menu entry) was fine and stays untouched.

### Backend: the destination of a move was not authorized

Once the UI actually uses this path, a gap in `PUT /files/:uuid` matters: its
guard authorizes the *file* only, so it never looked at where the file was going.
`PATCH /files` guards exactly this with CREATE rights on the target mission
(`MoveFilesGuard`) and rejects API keys outright. The update path now does the
same before it reassigns the mission:

- a user needs CREATE rights on the target mission, checked through the very
  same `MissionGuardService` the move guard uses;
- a request authenticated with an API key may not change the mission at all —
  the key is scoped to one mission, and authorizing the destination through the
  rights of the key *owner* would let it move files out of that scope
  (Greptile).

## (b) Deleting a file from the file info page has no feedback and no redirect

The success notification and the redirect to the mission were both awaited
behind `invalidateQueries`, whose predicate also matched the `['file', uuid]`
query of the page the user was standing on. Invalidating it refetches the file
that was just deleted; it is an active query, so vue-query retried the 404 three
times with exponential backoff before the promise resolved — several seconds in
which nothing was confirmed and the page reported the file as unloadable.

The delete is now confirmed first, the page is left before the file query is
dropped, and the deleted file's query is removed (refetching it can only 404)
instead of invalidated. Errors additionally prefer the server message over the
generic axios one, as the other delete dialogs do.

## Verification

- `pnpm type-check`, `pnpm lint:check` (0 errors), `pnpm prettier:check`
- `cd backend && pnpm exec jest --testPathPatterns unit` — all suites pass
- `pnpm --filter kleinkram-frontend build`
- New API tests `backend/tests/files/file-move-via-update.test.ts`: a move
  through `PUT /files/:uuid`, a move into a project the caller may only read
  (403), and a mission-scoped API key attempting a move (403).

## Manual test

(a) Open a mission, three-dot menu of a file -> **Edit** (or **Edit File** on the
file info page) -> tab "Name & Location" -> pick another project/mission ->
**Save**. The file now disappears from the old mission and shows up in the
chosen one ("File updated"). Repeat with a user that only has read access to the
target project: the move is refused with a 403 error notification.

(b) Open a file info page, three-dot menu -> **Delete File**, type the filename,
confirm. The "File deleted" notification appears at once and the browser lands
on the mission's file list. Deleting from the file table still shows the
notification and keeps you on the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn
