### PR TITLE
fix(frontend): make action template version restore actually work

### DIFF
--- a/backend/tests/actions/action-crud.test.ts
+++ b/backend/tests/actions/action-crud.test.ts
@@ -498,4 +498,99 @@ describe('Action Management Tests', () => {
         });
         expect(stillThere).not.toBeNull();
     }, 30_000);
+
+    test('should restore an old template version as a new version', async () => {
+        const { user } = await setupTestEnvironment(
+            'test-restore@kleinkram.dev',
+            'Restore User',
+        );
+
+        const jsonHeaders = {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'Content-Type': 'application/json',
+            ...getAuthHeaders(user),
+        };
+
+        const versionOnePayload = {
+            name: 'Restore Test Action',
+            description: 'version one',
+            accessRights: AccessGroupRights.READ,
+            dockerImage: 'hello-world',
+            command: 'echo v1',
+            entrypoint: '/bin/sh',
+            maxRuntime: 10,
+            cpuCores: 1,
+            cpuMemory: 2,
+            gpuMemory: 0,
+        };
+
+        const versionOneUuid = await createActionUsingPost(
+            versionOnePayload,
+            user,
+        );
+
+        // Create a second version (this is what the "Save New Version" button does)
+        const versionTwoResponse = await fetch(
+            `${DEFAULT_URL}/templates/${versionOneUuid}/versions`,
+            {
+                method: 'POST',
+                headers: jsonHeaders,
+                body: JSON.stringify({
+                    ...versionOnePayload,
+                    uuid: versionOneUuid,
+                    description: 'version two',
+                    command: 'echo v2',
+                }),
+            },
+        );
+        expect(versionTwoResponse.status).toBe(201);
+        const versionTwo = (await versionTwoResponse.json()) as {
+            uuid: string;
+            version: string;
+        };
+        expect(Number(versionTwo.version)).toBe(2);
+
+        // Restore version one: the frontend posts the content of the old
+        // version, which the backend turns into a new (third) version.
+        const restoreResponse = await fetch(
+            `${DEFAULT_URL}/templates/${versionOneUuid}/versions`,
+            {
+                method: 'POST',
+                headers: jsonHeaders,
+                body: JSON.stringify({
+                    ...versionOnePayload,
+                    uuid: versionOneUuid,
+                }),
+            },
+        );
+        expect(restoreResponse.status).toBe(201);
+        const restored = (await restoreResponse.json()) as {
+            uuid: string;
+            version: string;
+            description: string;
+            command: string;
+        };
+        expect(Number(restored.version)).toBe(3);
+        expect(restored.uuid).not.toBe(versionOneUuid);
+        expect(restored.description).toBe('version one');
+        expect(restored.command).toBe('echo v1');
+
+        // The revision history contains all three versions, newest first
+        const revisionsResponse = await fetch(
+            `${DEFAULT_URL}/templates/${versionOneUuid}/revisions?skip=0&take=10`,
+            { headers: getAuthHeaders(user) },
+        );
+        expect(revisionsResponse.status).toBe(200);
+        const revisions = (await revisionsResponse.json()) as {
+            count: number;
+            data: { uuid: string; version: string; executionCount: number }[];
+        };
+        expect(revisions.count).toBe(3);
+        expect(revisions.data.map((rev) => Number(rev.version))).toEqual([
+            3, 2, 1,
+        ]);
+        expect(revisions.data.map((rev) => rev.executionCount)).toEqual([
+            0, 0, 0,
+        ]);
+    }, 30_000);
 });

--- a/frontend/src/components/actions/action-definition-drawer.vue
+++ b/frontend/src/components/actions/action-definition-drawer.vue
@@ -411,7 +411,10 @@ async function saveTemplate(): Promise<void> {
             };
             await updateTemplate(updatePayload);
             Notify.create({
-                message: `New version created`,
+                message:
+                    props.mode === ActionDrawerMode.ACTION_RESTORE
+                        ? 'Version restored as a new version'
+                        : 'New version created',
                 color: 'positive',
             });
         } else {

--- a/frontend/src/pages/action-page.vue
+++ b/frontend/src/pages/action-page.vue
@@ -171,6 +171,12 @@ const isCreateOpen = ref(false);
 const drawerMode = ref<ActionDrawerMode>(ActionDrawerMode.ACTION_CREATE);
 const selectedTemplate = ref<ActionTemplateDto | undefined>(undefined);
 
+/**
+ * Version picked in the history drawer that should be opened in the definition
+ * drawer (in restore mode) after leaving the history route.
+ */
+const pendingRestore = ref<ActionTemplateDto | undefined>(undefined);
+
 const isHistoryOpen = ref(false);
 const selectedHistoryVersions = ref<ActionTemplatesDto>({
     data: [],
@@ -193,10 +199,14 @@ const openHistoryDrawer = async (
 };
 
 const onRestoreVersion = (oldVersion: ActionTemplateDto): void => {
-    selectedTemplate.value = oldVersion;
-    drawerMode.value = ActionDrawerMode.ACTION_RESTORE;
+    // Closing the history drawer navigates back to the templates route, and
+    // `handleRouteUpdate()` closes every drawer on such a navigation. Opening
+    // the definition drawer here would therefore be undone again right away, so
+    // we remember the version and let `handleRouteUpdate()` open the drawer once
+    // the navigation has settled.
+    pendingRestore.value = oldVersion;
     isHistoryOpen.value = false;
-    isCreateOpen.value = true;
+    void closeDrawers();
 };
 
 const openLaunchConfiguration = async (template: ActionTemplateDto) => {
@@ -208,6 +218,10 @@ const openLaunchConfiguration = async (template: ActionTemplateDto) => {
 };
 
 const closeDrawers = async () => {
+    isCreateOpen.value = false;
+    isLaunchOpen.value = false;
+    isHistoryOpen.value = false;
+
     await router.push({
         name: ROUTES.ACTION.routeName,
         params: { tab: 'templates' },
@@ -246,6 +260,15 @@ const handleRouteUpdate = async () => {
     isCreateOpen.value = false;
     isLaunchOpen.value = false;
     isHistoryOpen.value = false;
+
+    const restoreTarget = pendingRestore.value;
+    pendingRestore.value = undefined;
+    if (restoreTarget && !drawerAction) {
+        selectedTemplate.value = restoreTarget;
+        drawerMode.value = ActionDrawerMode.ACTION_RESTORE;
+        isCreateOpen.value = true;
+        return;
+    }
 
     if (!drawerAction || typeof templateId !== 'string') {
         return;


### PR DESCRIPTION
## Problem

Reported while manually testing v0.60.0 (#2173): *"restoring a template version does not seem to be working"* — clicking **Restore this version** in the Actions → Templates → History drawer appears to do nothing.

## Root cause

Frontend only; the backend endpoint is fine.

`frontend/src/pages/action-page.vue` owns the drawer state, but that state is driven by the route (`handleRouteUpdate()` runs on every `route.fullPath` change and unconditionally resets `isCreateOpen` / `isLaunchOpen` / `isHistoryOpen` to `false`).

`onRestoreVersion()` fought that state machine:

1. it set `isCreateOpen = true` **and** `isHistoryOpen = false`;
2. closing the history drawer makes `action-revisions-drawer.vue` emit `close`;
3. that runs `closeHistoryDrawer()` → `closeDrawers()` → `router.push()` back to the templates route;
4. the route watcher then fires `handleRouteUpdate()`, which sets `isCreateOpen = false` again.

So the "Restore Action Template Version" drawer was opened and closed within the same tick — the user sees nothing happen.

A second, related state bug: `closeDrawers()` only navigated. When the navigation was a no-op (closing a drawer while already on `/actions/templates`, e.g. right after saving), `isCreateOpen` stayed stuck at `true`, so the next attempt to open the definition drawer never flipped the prop and the drawer stayed shut.

## Fix

- `onRestoreVersion()` parks the chosen version in a new `pendingRestore` ref and leaves the history route; `handleRouteUpdate()` — the single owner of drawer state — applies it once the navigation has settled.
- `closeDrawers()` now also resets the drawer flags, so a no-op navigation cannot leave stale `true` state behind.
- The success toast says "Version restored as a new version" in restore mode, so the outcome is unambiguous.

## Backend

`POST /templates/:uuid/versions` behaves correctly: restore means "create a new version from the content of an old one", and `TemplateService.createVersion()` drops the incoming `uuid`, computes `calculateNextVersion(name)` and saves a fresh row. The `CanCreate()` guard is a global-permission guard and needs no access source, so #2376 is not involved. It had no API coverage, so `backend/tests/actions/action-crud.test.ts` gains a test that creates v1, creates v2, restores v1 as v3 and asserts the revision list is `[3, 2, 1]` with v1's content on v3.

## Verification

- `pnpm type-check` — pass
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm lint:check` — 0 errors (35 pre-existing warnings)
- `pnpm prettier:check` — pass
- `cd backend && pnpm exec jest --testPathPatterns unit` — all suites pass
- `pnpm --filter kleinkram-frontend build` — pass

## Manual test

1. Actions → **Templates** tab.
2. Pick a template with more than one version (create one, hit the pencil icon, change the description, **Save New Version**).
3. Click the **history** icon on that template row.
4. On an older entry, click **Restore this version** → the "Restore Action Template Version" drawer must open, prefilled with that old version's description / image / command / resources, with the name read-only.
5. Click **Restore Version** → toast "Version restored as a new version"; the drawer closes and the template list shows a bumped `v{n+1}`.
6. Re-open the history drawer → the newest entry is marked "Current Latest" and carries the restored content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn