### PR TITLE
test(files): API key can rename a file within its own mission

### DIFF
--- a/backend/tests/files/file-move-via-update.test.ts
+++ b/backend/tests/files/file-move-via-update.test.ts
@@ -255,7 +255,7 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
         await uploadFile(owner, 'file1.bag', missionUuid);
         const fileRepository = database.getRepository(FileEntity);
         const file = await fileRepository.findOneOrFail({
-            where: { filename: 'file1.bag' },
+            where: { filename: 'file1.bag', mission: { uuid: missionUuid } },
         });
 
         const apiKeyRepository = database.getRepository(ApiKeyEntity);

--- a/backend/tests/files/file-move-via-update.test.ts
+++ b/backend/tests/files/file-move-via-update.test.ts
@@ -251,11 +251,13 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
         );
 
         // the update path re-tags the object in storage, so the file has to
-        // exist there (a database-only row would make the request fail)
-        await uploadFile(owner, 'file1.bag', missionUuid);
+        // exist there (a database-only row would make the request fail). A
+        // yaml file is used because .bag uploads are picked up by the queue
+        // consumer, whose re-save can race with the rename.
+        await uploadFile(owner, 'config.yaml', missionUuid);
         const fileRepository = database.getRepository(FileEntity);
         const file = await fileRepository.findOneOrFail({
-            where: { filename: 'file1.bag', mission: { uuid: missionUuid } },
+            where: { filename: 'config.yaml', mission: { uuid: missionUuid } },
         });
 
         const apiKeyRepository = database.getRepository(ApiKeyEntity);
@@ -280,7 +282,7 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
             },
             body: JSON.stringify({
                 uuid: file.uuid,
-                filename: 'file1_renamed.bag',
+                filename: 'renamed_config.yaml',
                 date: file.date,
                 missionUuid,
                 categories: [],
@@ -293,7 +295,7 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
             where: { uuid: file.uuid },
             relations: { mission: true },
         });
-        expect(renamedFile.filename).toBe('file1_renamed.bag');
+        expect(renamedFile.filename).toBe('renamed_config.yaml');
         expect(renamedFile.mission?.uuid).toBe(missionUuid);
     }, 30_000);
 });

--- a/backend/tests/files/file-move-via-update.test.ts
+++ b/backend/tests/files/file-move-via-update.test.ts
@@ -237,4 +237,67 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
         });
         expect(unmovedFile.mission?.uuid).toBe(sourceMissionUuid);
     }, 30_000);
+
+    test('an API key can still rename a file within its own mission', async () => {
+        // Positive counterpart of the move rejection (ported from #2293):
+        // the API-key restriction only applies to changing the mission.
+        const { user: owner } = await generateAndFetchDatabaseUser(
+            'internal',
+            'user',
+        );
+        const { missionUuid } = await createProjectWithMission(
+            owner,
+            'key_rename',
+        );
+
+        const fileRepository = database.getRepository(FileEntity);
+        const file = await fileRepository.save(
+            fileRepository.create({
+                filename: 'before.bag',
+                mission: { uuid: missionUuid },
+                creator: { uuid: owner.uuid },
+                date: new Date(),
+                type: FileType.BAG,
+                size: 1024,
+            }),
+        );
+
+        const apiKeyRepository = database.getRepository(ApiKeyEntity);
+        const apiKey = apiKeyRepository.create({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            key_type: KeyTypes.ACTION,
+            mission: { uuid: missionUuid },
+            rights: AccessGroupRights.WRITE,
+            user: { uuid: owner.uuid },
+        });
+        await apiKeyRepository.save(apiKey);
+
+        const response = await fetch(`${DEFAULT_URL}/files/${file.uuid}`, {
+            method: 'PUT',
+            headers: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'Content-Type': 'application/json',
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'x-api-key': apiKey.apikey,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'kleinkram-client-version': appVersion,
+            },
+            body: JSON.stringify({
+                uuid: file.uuid,
+                filename: 'after.bag',
+                date: file.date,
+                missionUuid,
+                categories: [],
+            }),
+        });
+
+        expect(response.status).toBeLessThan(300);
+
+        const renamedFile = await fileRepository.findOneOrFail({
+            where: { uuid: file.uuid },
+            relations: { mission: true },
+        });
+        expect(renamedFile.filename).toBe('after.bag');
+        expect(renamedFile.mission?.uuid).toBe(missionUuid);
+    }, 30_000);
 });

--- a/backend/tests/files/file-move-via-update.test.ts
+++ b/backend/tests/files/file-move-via-update.test.ts
@@ -252,10 +252,10 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
 
         // the update path re-tags the object in storage, so the file has to
         // exist there (a database-only row would make the request fail)
-        await uploadFile(owner, 'before.bag', missionUuid);
+        await uploadFile(owner, 'file1.bag', missionUuid);
         const fileRepository = database.getRepository(FileEntity);
         const file = await fileRepository.findOneOrFail({
-            where: { filename: 'before.bag' },
+            where: { filename: 'file1.bag' },
         });
 
         const apiKeyRepository = database.getRepository(ApiKeyEntity);
@@ -280,7 +280,7 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
             },
             body: JSON.stringify({
                 uuid: file.uuid,
-                filename: 'after.bag',
+                filename: 'file1_renamed.bag',
                 date: file.date,
                 missionUuid,
                 categories: [],
@@ -293,7 +293,7 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
             where: { uuid: file.uuid },
             relations: { mission: true },
         });
-        expect(renamedFile.filename).toBe('after.bag');
+        expect(renamedFile.filename).toBe('file1_renamed.bag');
         expect(renamedFile.mission?.uuid).toBe(missionUuid);
     }, 30_000);
 });

--- a/backend/tests/files/file-move-via-update.test.ts
+++ b/backend/tests/files/file-move-via-update.test.ts
@@ -250,17 +250,13 @@ describe('PUT /files/:uuid moves a file into the mission of the request', () => 
             'key_rename',
         );
 
+        // the update path re-tags the object in storage, so the file has to
+        // exist there (a database-only row would make the request fail)
+        await uploadFile(owner, 'before.bag', missionUuid);
         const fileRepository = database.getRepository(FileEntity);
-        const file = await fileRepository.save(
-            fileRepository.create({
-                filename: 'before.bag',
-                mission: { uuid: missionUuid },
-                creator: { uuid: owner.uuid },
-                date: new Date(),
-                type: FileType.BAG,
-                size: 1024,
-            }),
-        );
+        const file = await fileRepository.findOneOrFail({
+            where: { filename: 'before.bag' },
+        });
 
         const apiKeyRepository = database.getRepository(ApiKeyEntity);
         const apiKey = apiKeyRepository.create({


### PR DESCRIPTION
Ports the positive test case from #2293 (closed as superseded by #2380): a mission-scoped API key may still update a file's name via `PUT /files/:uuid` as long as it does not change the mission. Complements the two rejection cases already in `file-move-via-update.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuDEPgsDsCx37kpab3ewSn