### PR TITLE
Fix typos in the documentation

### DIFF
--- a/docs/development/python/getting-started.md
+++ b/docs/development/python/getting-started.md
@@ -14,7 +14,7 @@ If you wish to use the CLI follow the [Getting Started](../../usage/python/cli.m
 First you need to follow the steps described in the [Getting Started (For Developers)](../getting-started.md) guide.
 
 Next make sure to navigate to the `/cli` directory of repository.
-Now setup a `python3.10` virtual enviroment and install the dependencies:
+Now setup a `python3.10` virtual environment and install the dependencies:
 
 ```bash
 virtualenv -p python3.10 .venv
@@ -87,7 +87,7 @@ cli/
 ### Packaging
 
 For packaging we use [declarative metadata](https://www.youtube.com/watch?v=GaWs-LenLYE) inside the `setup.cfg`.
-Depending on the python distrubution you are using you might need to install `setuptools` seperately ([read more here](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/)).
+Depending on the python distribution you are using you might need to install `setuptools` separately ([read more here](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/)).
 
 ### Source Code
 
@@ -125,7 +125,7 @@ In this folder we have all the bindings for the kleinkram API. This includes:
 - `pagination.py` wrapper around the HTTP client that supports paginated requests via generators.
 - `deser.py` deserialization of the API responses (serialization should also go here).
 - `routes.py` all the api routes and low level functions that interact with those endpoints
-- `query.py` abstractions for specificying resources on the backend (e.g. querying projects, missions and files)
+- `query.py` abstractions for specifying resources on the backend (e.g. querying projects, missions and files)
 - `file_transfer.py` implementation of the uploading and downloading. For the uploads we use [`boto3`](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) to interact with the S3 compatible storage.
 
 #### `cli/`

--- a/docs/development/try-locally.md
+++ b/docs/development/try-locally.md
@@ -47,7 +47,7 @@ There are some known iessues related to Safari when running Kleinkram locally.
 By default we only offer fake-oauth for local development (this mocks the oauth flow) and allows you to choose between different users with
 different permissions.
 
-If you want to sign-in using GitHub or Google OAuth, you need to set the correspoding env variables in your `.env` file.
+If you want to sign-in using GitHub or Google OAuth, you need to set the corresponding env variables in your `.env` file.
 This is however not recommended for local development.
 :::
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6019,7 +6019,7 @@ packages:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
 
-  develop@1.1.0:
+  devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dezalgo@1.0.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6019,7 +6019,7 @@ packages:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
 
-  devlop@1.1.0:
+  develop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dezalgo@1.0.4:


### PR DESCRIPTION
Fixes 5 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, module paths, package names or proper nouns changed, and anything that was a valid word rather than a misspelling was left alone.