### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 # Kleinkram - Open Robotic Data Management
 
+[![Docker Image CI](https://github.com/leggedrobotics/kleinkram/actions/workflows/production-build.yml/badge.svg?branch=main)](https://github.com/leggedrobotics/kleinkram/actions/workflows/production-build.yml)
+[![PyPI](https://img.shields.io/pypi/v/kleinkram)](https://pypi.org/project/kleinkram/)
+[![License: MIT](https://img.shields.io/github/license/leggedrobotics/kleinkram)](https://github.com/leggedrobotics/kleinkram/blob/main/LICENSE)
+[![Docs](https://img.shields.io/badge/docs-online-blue)](https://docs.datasets.leggedrobotics.com/)
+
 Kleinkram is a self-hosted, open-source platform for managing and processing robotics data. It provides a structured way to store, organize, and act on your data.
 
 - **Organize**: Structure data in Projects and Missions.


### PR DESCRIPTION
The README has no badges, so build status, the released version and the licence are not visible without digging.

Added four: the production Docker build, the PyPI version of the `kleinkram` CLI, the MIT licence, and a link to the docs site the README already points at.

I fetched every workflow badge URL first and used only `production-build.yml`, which reports passing on `main`. `api-tests.yml`, `cli-tests.yml`, `check-migrations.yml`, `eslint.yml` and `python-lint.yml` all report "no status" there because they only trigger on pull requests, so a badge for them would render empty.

The PyPI name is from `cli/setup.cfg` (`name = kleinkram`), which is what `update-pypi.yml` publishes.