### PR TITLE
fix(frontend): consistent project and mission page headers

### DIFF
--- a/frontend/src/components/title-section.vue
+++ b/frontend/src/components/title-section.vue
@@ -2,7 +2,7 @@
     <div class="bg-white flex column" style="margin: 0 -24px; padding: 0 24px">
         <div style="padding: 24px 0; gap: 24px; padding-bottom: 10px">
             <div class="row justify-between items-center q-gutter-y-md">
-                <div class="col-12 col-md flex items-center">
+                <div class="col-12 col-md column">
                     <slot name="title">
                         <h1 class="text-h5 text-md-h3 q-ma-none ellipsis">
                             {{ title ?? '' }}
@@ -11,7 +11,7 @@
                             </q-tooltip>
                         </h1>
                     </slot>
-                    <div v-if="slots.subtitle" class="col-12 q-pt-md">
+                    <div v-if="slots.subtitle" class="q-pt-sm">
                         <slot name="subtitle" />
                     </div>
                 </div>

--- a/frontend/src/components/title-section.vue
+++ b/frontend/src/components/title-section.vue
@@ -1,15 +1,18 @@
 <template>
     <div class="bg-white flex column" style="margin: 0 -24px; padding: 0 24px">
         <div style="padding: 24px 0; gap: 24px; padding-bottom: 10px">
-            <div class="row justify-between items-center q-gutter-y-md">
+            <div class="row justify-between items-start q-gutter-y-md">
                 <div class="col-12 col-md column">
                     <slot name="title">
-                        <h1 class="text-h5 text-md-h3 q-ma-none ellipsis">
-                            {{ title ?? '' }}
-                            <q-tooltip v-if="title">
-                                {{ title }}
-                            </q-tooltip>
-                        </h1>
+                        <div class="row no-wrap items-center" style="gap: 16px">
+                            <h1 class="text-h5 text-md-h3 q-ma-none ellipsis">
+                                {{ title ?? '' }}
+                                <q-tooltip v-if="title">
+                                    {{ title }}
+                                </q-tooltip>
+                            </h1>
+                            <slot name="titleAppend" />
+                        </div>
                     </slot>
                     <div v-if="slots.subtitle" class="q-pt-sm">
                         <slot name="subtitle" />
@@ -43,6 +46,7 @@ const slots = useSlots();
 
 defineSlots<{
     title: string;
+    titleAppend: string;
     subtitle: string;
     buttons: string;
     tabs: string;

--- a/frontend/src/components/title-section.vue
+++ b/frontend/src/components/title-section.vue
@@ -14,7 +14,7 @@
                             <slot name="titleAppend" />
                         </div>
                     </slot>
-                    <div v-if="slots.subtitle" class="q-pt-sm">
+                    <div v-if="slots.subtitle" class="q-pt-md">
                         <slot name="subtitle" />
                     </div>
                 </div>

--- a/frontend/src/pages/files-explorer-page.vue
+++ b/frontend/src/pages/files-explorer-page.vue
@@ -1,58 +1,48 @@
 <template>
     <div>
         <title-section :title="mission?.name">
-            <template #title>
-                <div class="row no-wrap items-center q-gutter-x-md">
-                    <h1
-                        class="text-h5 text-md-h3 q-ma-none ellipsis"
-                        style="line-height: 1.2"
+            <template v-if="mission?.tags" #titleAppend>
+                <div class="q-shrink">
+                    <q-btn
+                        unelevated
+                        no-caps
+                        dense
+                        class="bg-grey-2 text-grey-9 q-px-sm"
+                        style="
+                            font-size: 12px;
+                            font-weight: 500;
+                            border-radius: 4px;
+                            min-height: 24px;
+                            padding-top: 2px;
+                            padding-bottom: 2px;
+                        "
+                        @click="openMetadataDrawer"
                     >
-                        {{ mission?.name ?? '' }}
-                        <q-tooltip v-if="mission?.name">
-                            {{ mission?.name }}
-                        </q-tooltip>
-                    </h1>
-                    <div v-if="mission?.tags" class="q-shrink">
-                        <q-btn
-                            unelevated
-                            no-caps
-                            dense
-                            class="bg-grey-2 text-grey-9 q-px-sm"
-                            style="
-                                font-size: 12px;
-                                font-weight: 500;
-                                border-radius: 4px;
-                                min-height: 24px;
-                                padding-top: 2px;
-                                padding-bottom: 2px;
-                            "
-                            @click="openMetadataDrawer"
+                        <span
+                            class="text-center col items-center justify-center row"
                         >
+                            <q-icon
+                                name="sym_o_sell"
+                                size="14px"
+                                class="q-mr-xs"
+                            />
                             <span
-                                class="text-center col items-center justify-center row"
+                                >{{ mission.tags.length }} metadata
+                                attributes</span
                             >
-                                <q-icon
-                                    name="sym_o_sell"
-                                    size="14px"
-                                    class="q-mr-xs"
-                                />
-                                <span
-                                    >{{ mission.tags.length }} metadata
-                                    attributes</span
-                                >
-                            </span>
-                        </q-btn>
-                    </div>
+                        </span>
+                    </q-btn>
                 </div>
             </template>
 
             <template #buttons>
-                <div class="row q-gutter-x-sm" style="height: 100%">
+                <button-group>
                     <q-btn
                         v-if="mission"
                         class="button-border"
                         flat
                         style="height: 100%"
+                        color="primary"
                         icon="sym_o_sell"
                         label="Metadata"
                         @click="openMetadataDrawer"
@@ -64,6 +54,7 @@
                         class="button-border"
                         flat
                         style="height: 100%"
+                        color="primary"
                     >
                         <q-tooltip> More Actions</q-tooltip>
 
@@ -152,7 +143,7 @@
                             </q-list>
                         </q-menu>
                     </q-btn>
-                </div>
+                </button-group>
             </template>
 
             <template #tabs>
@@ -199,6 +190,7 @@
 import DeleteMissionDialogOpener from 'components/button-wrapper/delete-mission-dialog-opener.vue';
 import EditMissionDialogOpener from 'components/button-wrapper/edit-mission-dialog-opener.vue';
 import MoveMissionDialogOpener from 'components/button-wrapper/move-mission-dialog-pener.vue';
+import ButtonGroup from 'components/buttons/button-group.vue';
 import KleinDownloadMission from 'components/cli-links/klein-download-mission.vue';
 import MissionActions from 'components/explorer-page/mission-actions.vue';
 import MissionFiles from 'components/explorer-page/mission-files.vue';

--- a/frontend/src/pages/missions-explorer-page.vue
+++ b/frontend/src/pages/missions-explorer-page.vue
@@ -1,10 +1,10 @@
 <template>
     <div>
         <title-section :title="project?.name">
-            <template #subtitle>
-                <span>
-                    {{ project?.description }}
-                </span>
+            <template v-if="project?.description" #subtitle>
+                <p class="text-body2 text-grey-8 q-ma-none">
+                    {{ project.description }}
+                </p>
             </template>
 
             <template #buttons>

--- a/frontend/src/pages/missions-explorer-page.vue
+++ b/frontend/src/pages/missions-explorer-page.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <title-section :title="project?.name">
-            <template v-if="project?.description" #subtitle>
+            <template v-if="project?.description.trim()" #subtitle>
                 <p class="text-body2 text-grey-8 q-ma-none">
                     {{ project.description }}
                 </p>


### PR DESCRIPTION
## Summary
- On the project page the description rendered inline right after the project name, making it unclear which was the title. `title-section.vue` now stacks the subtitle below the heading, and `missions-explorer-page.vue` renders the description as muted text under the name.
- The mission page header was shifted relative to the project page: its custom heading used a gutter class with a negative left margin, a different line-height, a different button wrapper and no primary color on the action buttons.
- `title-section.vue` gains a `titleAppend` slot (used for the mission's metadata chip) and top-aligns the title and button columns, so the heading and buttons start at the same vertical position on both pages.
- `files-explorer-page.vue` uses the shared heading, the `titleAppend` slot, and `button-group` with primary-colored buttons like the project page.

## Test plan
- [x] Open a project with a description: name on its own line, description in grey below it.
- [x] Open a project without a description: no empty gap below the name.
- [x] Open a mission: title left edge, heading size and action buttons match the project page.
- [ ] Metadata chip still opens the metadata drawer.
- [ ] File header and user profile pages (other users of the subtitle slot) look unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXQGxpkpiP2DL3T3cyQDoD