### PR TITLE
fix(frontend): topic previews no longer crash the file page; NavSatFix map

### DIFF
--- a/frontend/src/components/inspect-file/file-topic-table.vue
+++ b/frontend/src/components/inspect-file/file-topic-table.vue
@@ -69,7 +69,13 @@
                             <MessageViewer
                                 :topic-name="props.row.name"
                                 :message-type="props.row.type"
-                                :total-count="expectedCount(props.row)"
+                                :total-count="
+                                    expectedCount(
+                                        props.row,
+                                        previews[props.row.name]?.length ?? 0,
+                                        loadingState[props.row.name] || false,
+                                    )
+                                "
                                 :sample-stride="getSmartLoad(props.row).stride"
                                 :messages="previews[props.row.name] || []"
                                 :is-loading="
@@ -244,11 +250,19 @@ const getSmartLoad = (row: TopicRow): LoadPlan => {
 
 /**
  * Number of messages the viewer should expect once loading is done. For
- * sampled plot topics this is the sampled count, otherwise the topic size.
+ * sampled plot topics this is the sampled count while loading, and the
+ * actual count once loading finished (sampling per chunk can differ from
+ * the estimate by a few messages). Otherwise it is the topic size.
  */
-const expectedCount = (row: TopicRow): number => {
+const expectedCount = (
+    row: TopicRow,
+    loadedCount: number,
+    isLoading: boolean,
+): number => {
     const plan = getSmartLoad(row);
-    return plan.full ? plan.limit : row.nrMessages;
+    if (!plan.full) return row.nrMessages;
+    if (isLoading || loadedCount === 0) return plan.limit;
+    return loadedCount;
 };
 
 const toggleExpand = (props: { row: TopicRow; expand: boolean }): void => {
@@ -278,13 +292,21 @@ const loadData = (
     count: number,
     append = false,
     stride = 1,
+    progressive = false,
 ): void => {
-    emit('load-preview', topic, { limit: count, append, stride });
+    emit('load-preview', topic, {
+        limit: count,
+        append,
+        stride,
+        progressive,
+    });
 };
 
 const loadSmart = (row: TopicRow): void => {
     const plan = getSmartLoad(row);
-    loadData(row.name, plan.limit, false, plan.stride);
+    // Plot viewers show the whole recording: load it coarse-to-fine so the
+    // full time range is visible early and refines as data streams in.
+    loadData(row.name, plan.limit, false, plan.stride, plan.full);
 };
 
 // Incremental Load (Load More button)

--- a/frontend/src/components/inspect-file/file-topic-table.vue
+++ b/frontend/src/components/inspect-file/file-topic-table.vue
@@ -77,6 +77,7 @@
                                     )
                                 "
                                 :sample-stride="getSmartLoad(props.row).stride"
+                                :can-refine="canRefineImage(props.row)"
                                 :messages="previews[props.row.name] || []"
                                 :is-loading="
                                     loadingState[props.row.name] || false
@@ -191,6 +192,19 @@ interface LoadPlan {
  */
 const MAX_PLOT_MESSAGES = 5000;
 
+/**
+ * Image streams are shown as a sampled sequence covering the whole
+ * recording. The initial sample is bounded by a frame count and by a byte
+ * budget (raw images can be several MB each); "Load more frames" halves
+ * the sampling step, up to a hard frame cap.
+ */
+const INITIAL_IMAGE_FRAMES = 120;
+const MAX_IMAGE_FRAMES = 2000;
+const IMAGE_BYTE_BUDGET = 400 * 1024 * 1024;
+
+/** Refinement level per image topic: each level halves the stride. */
+const imageRefinement = ref<Record<string, number>>({});
+
 const PLOT_TYPES = new Set<PreviewType>([
     PreviewType.TWIST,
     PreviewType.TEMPERATURE,
@@ -204,11 +218,52 @@ const PLOT_TYPES = new Set<PreviewType>([
     PreviewType.POINT_STAMPED,
 ]);
 
+const imageStrideForLevel = (row: TopicRow, level: number): number => {
+    const bytesPerFrame =
+        row.size !== undefined && row.size > 0 && row.nrMessages > 0
+            ? row.size / row.nrMessages
+            : 0;
+    const framesWithinBudget =
+        bytesPerFrame > 0
+            ? Math.floor(IMAGE_BYTE_BUDGET / bytesPerFrame)
+            : MAX_IMAGE_FRAMES;
+    const targetFrames = Math.max(
+        1,
+        Math.min(
+            MAX_IMAGE_FRAMES,
+            framesWithinBudget,
+            INITIAL_IMAGE_FRAMES * 2 ** level,
+        ),
+    );
+    return Math.max(1, Math.ceil(row.nrMessages / targetFrames));
+};
+
+const getImageLoad = (row: TopicRow): LoadPlan => {
+    const stride = imageStrideForLevel(
+        row,
+        imageRefinement.value[row.name] ?? 0,
+    );
+    return { limit: Math.ceil(row.nrMessages / stride), stride, full: true };
+};
+
+/** Whether an image topic can still be refined with a smaller stride. */
+const canRefineImage = (row: TopicRow): boolean => {
+    const level = imageRefinement.value[row.name] ?? 0;
+    return (
+        imageStrideForLevel(row, level + 1) < imageStrideForLevel(row, level)
+    );
+};
+
 const getSmartLoad = (row: TopicRow): LoadPlan => {
     const type = detectPreviewType(row.type);
 
     if (type === PreviewType.CAMERA_INFO) {
         return { limit: 1, stride: 1, full: false };
+    }
+
+    // 0. Sampled sequence covering the whole recording (video)
+    if (type === PreviewType.IMAGE) {
+        return getImageLoad(row);
     }
 
     // 1. Full (sampled) Load for plot viewers
@@ -227,11 +282,6 @@ const getSmartLoad = (row: TopicRow): LoadPlan => {
     // 2. Medium Load (Logs)
     if (type === PreviewType.ROS_LOG || type === PreviewType.STRING) {
         return { limit: 100, stride: 1, full: false };
-    }
-
-    // 2.5 Sequence Viewer Streaming (Video)
-    if (type === PreviewType.IMAGE) {
-        return { limit: 1, stride: 1, full: false };
     }
 
     // 3. Light Load (TimeReference)
@@ -268,19 +318,13 @@ const expectedCount = (
 const toggleExpand = (props: { row: TopicRow; expand: boolean }): void => {
     props.expand = !props.expand;
     if (props.expand) {
-        const type = detectPreviewType(props.row.type);
         const hasData =
             properties.previews[props.row.name] &&
             (properties.previews[props.row.name]?.length ?? 0) > 0;
 
-        // Only resume fetching for video/image topics (buffering)
-        // For others, only fetch if no data exists (initial load)
-        if (type === PreviewType.IMAGE) {
-            emit('resume-preview', props.row.name, 50);
-            if (!hasData) loadSmart(props.row);
-        } else if (!hasData) {
-            loadSmart(props.row);
-        }
+        // Only fetch if no data exists (initial load). Sampled sequences
+        // (images, plots) stay in memory while collapsed.
+        if (!hasData) loadSmart(props.row);
     } else {
         emit('pause-preview', props.row.name);
     }
@@ -311,10 +355,26 @@ const loadSmart = (row: TopicRow): void => {
 
 // Incremental Load (Load More button)
 const loadMore = (topicName: string): void => {
-    // If it's an image stream, load a larger background buffer, else default back to 20
-    const t = properties.topics.find((x) => x.name === topicName);
-    const type = t ? detectPreviewType(t.type) : PreviewType.STRING;
-    const limit = type === PreviewType.IMAGE ? 50 : 20;
-    loadData(topicName, limit, true);
+    const row = properties.topics.find((x) => x.name === topicName);
+    const type = row ? detectPreviewType(row.type) : PreviewType.STRING;
+
+    // Image streams: refine the sampled sequence with a smaller stride,
+    // keeping the frames already loaded.
+    if (row && type === PreviewType.IMAGE) {
+        if (!canRefineImage(row)) return;
+        imageRefinement.value[row.name] =
+            (imageRefinement.value[row.name] ?? 0) + 1;
+        const plan = getImageLoad(row);
+        emit('load-preview', row.name, {
+            limit: plan.limit,
+            append: false,
+            stride: plan.stride,
+            progressive: true,
+            merge: true,
+        });
+        return;
+    }
+
+    loadData(topicName, 20, true);
 };
 </script>

--- a/frontend/src/components/inspect-file/file-topic-table.vue
+++ b/frontend/src/components/inspect-file/file-topic-table.vue
@@ -338,11 +338,13 @@ const loadData = (
     stride = 1,
     progressive = false,
 ): void => {
+    const row = properties.topics.find((x) => x.name === topic);
     emit('load-preview', topic, {
         limit: count,
         append,
         stride,
         progressive,
+        totalMessages: row?.nrMessages,
     });
 };
 
@@ -371,6 +373,7 @@ const loadMore = (topicName: string): void => {
             stride: plan.stride,
             progressive: true,
             merge: true,
+            totalMessages: row.nrMessages,
         });
         return;
     }

--- a/frontend/src/components/inspect-file/file-topic-table.vue
+++ b/frontend/src/components/inspect-file/file-topic-table.vue
@@ -69,7 +69,8 @@
                             <MessageViewer
                                 :topic-name="props.row.name"
                                 :message-type="props.row.type"
-                                :total-count="props.row.nrMessages"
+                                :total-count="expectedCount(props.row)"
+                                :sample-stride="getSmartLoad(props.row).stride"
                                 :messages="previews[props.row.name] || []"
                                 :is-loading="
                                     loadingState[props.row.name] || false
@@ -167,49 +168,87 @@ const columns: QTableColumn[] = [
     },
 ];
 
-const getSmartLimit = (row: TopicRow): number => {
+interface LoadPlan {
+    /** Number of messages to keep in memory */
+    limit: number;
+    /** Keep only every n-th message (1 = every message) */
+    stride: number;
+    /** Whether the plan covers the whole topic (possibly sampled) */
+    full: boolean;
+}
+
+/**
+ * Upper bound of messages kept for plot viewers. High-rate topics (e.g. a
+ * 400 Hz odometry with >100k messages) are sampled down to this many
+ * evenly spaced messages instead of being decoded in full, which would
+ * exhaust browser memory.
+ */
+const MAX_PLOT_MESSAGES = 5000;
+
+const PLOT_TYPES = new Set<PreviewType>([
+    PreviewType.TWIST,
+    PreviewType.TEMPERATURE,
+    PreviewType.IMU,
+    PreviewType.STATISTICS,
+    PreviewType.ODOMETRY,
+    PreviewType.POSE_STAMPED,
+    PreviewType.PATH,
+    PreviewType.TRANSFORM_STAMPED,
+    PreviewType.NAV_SAT_FIX,
+    PreviewType.POINT_STAMPED,
+]);
+
+const getSmartLoad = (row: TopicRow): LoadPlan => {
     const type = detectPreviewType(row.type);
 
-    // 1. Full Load (Visual Plots / Images)
     if (type === PreviewType.CAMERA_INFO) {
-        return 1;
+        return { limit: 1, stride: 1, full: false };
     }
-    // 1. Full Load (Visual Plots / Images)
-    if (
-        type === PreviewType.TWIST ||
-        type === PreviewType.TEMPERATURE ||
-        type === PreviewType.IMU ||
-        type === PreviewType.STATISTICS ||
-        type === PreviewType.ODOMETRY ||
-        type === PreviewType.POSE_STAMPED ||
-        type === PreviewType.PATH ||
-        type === PreviewType.TRANSFORM_STAMPED
-    ) {
-        return row.nrMessages;
+
+    // 1. Full (sampled) Load for plot viewers
+    if (PLOT_TYPES.has(type)) {
+        const stride = Math.max(
+            1,
+            Math.ceil(row.nrMessages / MAX_PLOT_MESSAGES),
+        );
+        return {
+            limit: Math.ceil(row.nrMessages / stride),
+            stride,
+            full: true,
+        };
     }
 
     // 2. Medium Load (Logs)
     if (type === PreviewType.ROS_LOG || type === PreviewType.STRING) {
-        return 100;
+        return { limit: 100, stride: 1, full: false };
     }
 
     // 2.5 Sequence Viewer Streaming (Video)
     if (type === PreviewType.IMAGE) {
-        return 1;
+        return { limit: 1, stride: 1, full: false };
     }
 
     // 3. Light Load (TimeReference)
     if (type === PreviewType.TIME_REFERENCE) {
-        return 20;
+        return { limit: 20, stride: 1, full: false };
     }
 
     // 3. Strict Load (Heavy Binary)
     if (type === PreviewType.POINT_CLOUD || type === PreviewType.GRID_MAP) {
-        return 1;
+        return { limit: 1, stride: 1, full: false };
     }
 
     // 4. Default
-    return 5;
+    return { limit: 5, stride: 1, full: false };
+};
+
+/**
+ * Number of messages the viewer should expect once loading is done. For
+ * sampled plot topics this is the sampled count, otherwise the topic size.
+ */
+const expectedCount = (row: TopicRow): number => {
+    const plan = getSmartLoad(row);
+    return plan.full ? plan.limit : row.nrMessages;
 };
 
 const toggleExpand = (props: { row: TopicRow; expand: boolean }): void => {
@@ -234,15 +273,18 @@ const toggleExpand = (props: { row: TopicRow; expand: boolean }): void => {
 };
 
 // Directly load specific count (Base function)
-const loadData = (topic: string, count: number, append = false): void => {
-    emit('load-preview', topic, { limit: count, append });
+const loadData = (
+    topic: string,
+    count: number,
+    append = false,
+    stride = 1,
+): void => {
+    emit('load-preview', topic, { limit: count, append, stride });
 };
 
-// In file-topic-table.vue > script > loadSmart
-
 const loadSmart = (row: TopicRow): void => {
-    const limit = getSmartLimit(row);
-    loadData(row.name, limit);
+    const plan = getSmartLoad(row);
+    loadData(row.name, plan.limit, false, plan.stride);
 };
 
 // Incremental Load (Load More button)

--- a/frontend/src/components/inspect-file/file-topic-table.vue
+++ b/frontend/src/components/inspect-file/file-topic-table.vue
@@ -218,11 +218,35 @@ const PLOT_TYPES = new Set<PreviewType>([
     PreviewType.POINT_STAMPED,
 ]);
 
+/**
+ * Bytes per frame of an image topic: from the topic size when the API
+ * provides it, otherwise measured on the frames loaded so far (the first
+ * sample is small, so its measurement bounds every refinement).
+ */
+const bytesPerImageFrame = (row: TopicRow): number => {
+    if (row.size !== undefined && row.size > 0 && row.nrMessages > 0) {
+        return row.size / row.nrMessages;
+    }
+    const loaded = properties.previews[row.name] ?? [];
+    if (loaded.length === 0) return 0;
+    let bytes = 0;
+    let counted = 0;
+    for (const message of loaded) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        const payload = message?.data?.data;
+        if (payload instanceof Uint8Array) {
+            bytes += payload.byteLength;
+            counted++;
+        } else if (Array.isArray(payload)) {
+            bytes += payload.length;
+            counted++;
+        }
+    }
+    return counted > 0 ? bytes / counted : 0;
+};
+
 const imageStrideForLevel = (row: TopicRow, level: number): number => {
-    const bytesPerFrame =
-        row.size !== undefined && row.size > 0 && row.nrMessages > 0
-            ? row.size / row.nrMessages
-            : 0;
+    const bytesPerFrame = bytesPerImageFrame(row);
     const framesWithinBudget =
         bytesPerFrame > 0
             ? Math.floor(IMAGE_BYTE_BUDGET / bytesPerFrame)

--- a/frontend/src/components/inspect-file/message-viewer.vue
+++ b/frontend/src/components/inspect-file/message-viewer.vue
@@ -8,17 +8,33 @@
                 </q-badge>
             </div>
 
-            <q-badge
-                color="orange-7"
-                text-color="white"
-                label="BETA"
-                class="text-weight-bold cursor-help"
-                style="font-size: 10px; padding: 2px 6px"
-            >
-                <q-tooltip>
-                    Preview functionality is currently in beta.
-                </q-tooltip>
-            </q-badge>
+            <div class="row items-center q-gutter-x-sm">
+                <q-badge
+                    v-if="(sampleStride ?? 1) > 1"
+                    color="grey-3"
+                    text-color="grey-9"
+                    class="cursor-help"
+                >
+                    <q-icon name="sym_o_filter_alt" size="xs" class="q-mr-xs" />
+                    Sampled: every {{ sampleStride }}th message
+                    <q-tooltip>
+                        This topic has {{ totalCount }} messages after sampling.
+                        Only every {{ sampleStride }}th message is loaded to
+                        keep the preview responsive.
+                    </q-tooltip>
+                </q-badge>
+                <q-badge
+                    color="orange-7"
+                    text-color="white"
+                    label="BETA"
+                    class="text-weight-bold cursor-help"
+                    style="font-size: 10px; padding: 2px 6px"
+                >
+                    <q-tooltip>
+                        Preview functionality is currently in beta.
+                    </q-tooltip>
+                </q-badge>
+            </div>
         </div>
 
         <div
@@ -50,8 +66,30 @@
                 class="absolute-top"
                 style="z-index: 1; height: 2px"
             />
+            <div
+                v-if="renderError"
+                class="q-pa-md bg-orange-1 text-orange-10 rounded-borders q-mb-sm row items-center q-gutter-x-sm"
+            >
+                <q-icon name="sym_o_warning" size="sm" />
+                <div class="col">
+                    <div class="text-weight-medium">
+                        The {{ messageType }} preview failed to render. Showing
+                        the raw messages instead.
+                    </div>
+                    <div class="text-caption ellipsis">{{ renderError }}</div>
+                </div>
+                <q-btn
+                    flat
+                    dense
+                    no-caps
+                    label="Retry"
+                    color="orange-10"
+                    @click="retryRender"
+                />
+            </div>
             <component
-                :is="activeComponent"
+                :is="renderError ? fallbackComponent : activeComponent"
+                :key="renderAttempt"
                 :messages="messages"
                 :topic-name="topicName"
                 :total-count="totalCount"
@@ -79,10 +117,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onErrorCaptured, ref, watch } from 'vue';
 import {
     detectPreviewType,
     getViewerComponent,
+    PreviewType,
 } from '../../services/message-factory';
 
 const properties = defineProps<{
@@ -95,6 +134,8 @@ const properties = defineProps<{
     error: string | null;
     protocol?: string;
     topicSize?: number;
+    /** Only every n-th message was loaded (1 = all messages) */
+    sampleStride?: number;
 }>();
 
 const emit = defineEmits(['load-more', 'load-required', 'pause-preview']);
@@ -114,6 +155,30 @@ const currentPreviewType = computed(() => {
 const activeComponent = computed(() => {
     return getViewerComponent(currentPreviewType.value);
 });
+const fallbackComponent = getViewerComponent(PreviewType.JSON);
+
+// --- Error Boundary ---
+// A viewer that throws while rendering must not take down the whole page.
+const renderError = ref<string | null>(null);
+const renderAttempt = ref(0);
+
+onErrorCaptured((error) => {
+    console.error(`Preview of ${properties.topicName} failed`, error);
+    renderError.value = error instanceof Error ? error.message : String(error);
+    return false;
+});
+
+const retryRender = (): void => {
+    renderError.value = null;
+    renderAttempt.value++;
+};
+
+watch(
+    () => properties.topicName,
+    () => {
+        renderError.value = null;
+    },
+);
 
 const loadRequired = (): void => {
     emit('load-required');

--- a/frontend/src/components/inspect-file/message-viewer.vue
+++ b/frontend/src/components/inspect-file/message-viewer.vue
@@ -94,6 +94,8 @@
                 :topic-name="topicName"
                 :total-count="totalCount"
                 :is-loading="isLoading"
+                :sample-stride="sampleStride ?? 1"
+                :can-refine="canRefine ?? false"
                 @load-required="loadRequired"
                 @load-more="loadMore"
                 @pause-preview="emitPausePreview"
@@ -136,6 +138,8 @@ const properties = defineProps<{
     topicSize?: number;
     /** Only every n-th message was loaded (1 = all messages) */
     sampleStride?: number;
+    /** Whether a sampled topic can be refined with more messages */
+    canRefine?: boolean;
 }>();
 
 const emit = defineEmits(['load-more', 'load-required', 'pause-preview']);

--- a/frontend/src/components/inspect-file/viewers/common/geo.ts
+++ b/frontend/src/components/inspect-file/viewers/common/geo.ts
@@ -1,0 +1,30 @@
+export interface GeoPoint {
+    lat: number;
+    lon: number;
+}
+
+export const toRadians = (degrees: number): number => (degrees * Math.PI) / 180;
+
+/** Great-circle distance between two points in metres (haversine formula). */
+export const haversineDistance = (a: GeoPoint, b: GeoPoint): number => {
+    const earthRadius = 6_371_000;
+    const dLat = toRadians(b.lat - a.lat);
+    const dLon = toRadians(b.lon - a.lon);
+    const h =
+        Math.sin(dLat / 2) ** 2 +
+        Math.cos(toRadians(a.lat)) *
+            Math.cos(toRadians(b.lat)) *
+            Math.sin(dLon / 2) ** 2;
+    return 2 * earthRadius * Math.asin(Math.min(1, Math.sqrt(h)));
+};
+
+/** Length of a polyline of geographic points in metres. */
+export const trackLengthMetres = (points: GeoPoint[]): number => {
+    let total = 0;
+    for (let index = 1; index < points.length; index++) {
+        const a = points[index - 1];
+        const b = points[index];
+        if (a && b) total += haversineDistance(a, b);
+    }
+    return total;
+};

--- a/frontend/src/components/inspect-file/viewers/common/geo.ts
+++ b/frontend/src/components/inspect-file/viewers/common/geo.ts
@@ -1,6 +1,12 @@
 export interface GeoPoint {
     lat: number;
     lon: number;
+    /**
+     * True when samples without a valid position were dropped between the
+     * previous point and this one; the connecting segment is then only an
+     * interpolation and is drawn differently.
+     */
+    gapBefore?: boolean;
 }
 
 export const toRadians = (degrees: number): number => (degrees * Math.PI) / 180;

--- a/frontend/src/components/inspect-file/viewers/common/track-map.vue
+++ b/frontend/src/components/inspect-file/viewers/common/track-map.vue
@@ -29,23 +29,40 @@
                 class="track-overlay absolute-full"
                 :viewBox="`0 0 ${String(size.width)} ${String(size.height)}`"
             >
+                <!-- Segments bridging samples without a fix -->
                 <polyline
-                    :points="trackPoints"
+                    v-for="(segment, index) in gapSegments"
+                    :key="`gap-${index}`"
+                    :points="segment"
                     fill="none"
-                    stroke="#ffffff"
-                    stroke-width="5"
-                    stroke-linejoin="round"
-                    stroke-linecap="round"
-                    opacity="0.9"
-                />
-                <polyline
-                    :points="trackPoints"
-                    fill="none"
-                    stroke="#1976d2"
-                    stroke-width="2.5"
-                    stroke-linejoin="round"
+                    stroke="#9e9e9e"
+                    stroke-width="2"
+                    stroke-dasharray="6 4"
                     stroke-linecap="round"
                 />
+                <!-- Track with a valid fix -->
+                <template
+                    v-for="(run, index) in trackRuns"
+                    :key="`run-${index}`"
+                >
+                    <polyline
+                        :points="run"
+                        fill="none"
+                        stroke="#ffffff"
+                        stroke-width="5"
+                        stroke-linejoin="round"
+                        stroke-linecap="round"
+                        opacity="0.9"
+                    />
+                    <polyline
+                        :points="run"
+                        fill="none"
+                        stroke="#1976d2"
+                        stroke-width="2.5"
+                        stroke-linejoin="round"
+                        stroke-linecap="round"
+                    />
+                </template>
                 <circle
                     v-if="startPixel"
                     :cx="startPixel.x"
@@ -124,6 +141,10 @@
                 Start
                 <span class="legend-dot" style="background: #f44336"></span>
                 End
+                <template v-if="gapSegments.length > 0">
+                    <span class="legend-dash"></span>
+                    No fix
+                </template>
             </div>
 
             <div class="map-attribution text-caption">
@@ -375,11 +396,39 @@ const screenPoints = computed(() =>
     validPoints.value.map((p) => toScreen(project(p, zoom.value))),
 );
 
-const trackPoints = computed(() =>
-    screenPoints.value
-        .map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`)
-        .join(' '),
-);
+const formatPoint = (p: { x: number; y: number }): string =>
+    `${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+
+// Runs of consecutive fixed positions (drawn as the track) and the
+// segments that bridge dropped samples (drawn grey and dashed).
+const trackRuns = computed(() => {
+    const runs: string[] = [];
+    let current: string[] = [];
+    for (const [position, p] of screenPoints.value.entries()) {
+        if (
+            validEntries.value[position]?.point.gapBefore &&
+            current.length > 0
+        ) {
+            runs.push(current.join(' '));
+            current = [];
+        }
+        current.push(formatPoint(p));
+    }
+    if (current.length > 0) runs.push(current.join(' '));
+    return runs;
+});
+
+const gapSegments = computed(() => {
+    const segments: string[] = [];
+    const points = screenPoints.value;
+    for (const [position, p] of points.entries()) {
+        const previous = points[position - 1];
+        if (previous && validEntries.value[position]?.point.gapBefore) {
+            segments.push(`${formatPoint(previous)} ${formatPoint(p)}`);
+        }
+    }
+    return segments;
+});
 
 const startPixel = computed(() => screenPoints.value[0]);
 const endPixel = computed(() => screenPoints.value.at(-1));
@@ -470,6 +519,12 @@ watch(
     background: rgba(255, 255, 255, 0.9);
     padding: 2px 8px;
     border-radius: 4px;
+}
+
+.legend-dash {
+    display: inline-block;
+    width: 14px;
+    border-top: 2px dashed #9e9e9e;
 }
 
 .legend-dot {

--- a/frontend/src/components/inspect-file/viewers/common/track-map.vue
+++ b/frontend/src/components/inspect-file/viewers/common/track-map.vue
@@ -1,0 +1,410 @@
+<template>
+    <div
+        ref="container"
+        class="track-map bg-grey-2 rounded-borders relative-position overflow-hidden non-selectable"
+        :class="{ dragging: isDragging }"
+        :style="{ height: `${String(height)}px` }"
+        @mousedown="onDragStart"
+        @mousemove="onDragMove"
+        @mouseup="onDragEnd"
+        @mouseleave="onDragEnd"
+        @wheel.prevent="onWheel"
+    >
+        <template v-if="hasPoints">
+            <img
+                v-for="tile in tiles"
+                :key="tile.key"
+                :src="tile.url"
+                class="map-tile"
+                :style="{
+                    left: `${String(tile.left)}px`,
+                    top: `${String(tile.top)}px`,
+                }"
+                alt=""
+                draggable="false"
+                loading="lazy"
+            />
+
+            <svg
+                class="track-overlay absolute-full"
+                :viewBox="`0 0 ${String(size.width)} ${String(size.height)}`"
+            >
+                <polyline
+                    :points="trackPoints"
+                    fill="none"
+                    stroke="#ffffff"
+                    stroke-width="5"
+                    stroke-linejoin="round"
+                    stroke-linecap="round"
+                    opacity="0.9"
+                />
+                <polyline
+                    :points="trackPoints"
+                    fill="none"
+                    stroke="#1976d2"
+                    stroke-width="2.5"
+                    stroke-linejoin="round"
+                    stroke-linecap="round"
+                />
+                <circle
+                    v-if="startPixel"
+                    :cx="startPixel.x"
+                    :cy="startPixel.y"
+                    r="5"
+                    fill="#4caf50"
+                    stroke="#fff"
+                    stroke-width="2"
+                />
+                <circle
+                    v-if="endPixel"
+                    :cx="endPixel.x"
+                    :cy="endPixel.y"
+                    r="6"
+                    fill="#f44336"
+                    stroke="#fff"
+                    stroke-width="2"
+                />
+            </svg>
+
+            <div class="map-controls column q-gutter-y-xs">
+                <q-btn
+                    dense
+                    unelevated
+                    size="sm"
+                    color="white"
+                    text-color="grey-9"
+                    icon="sym_o_add"
+                    @click.stop="zoomIn"
+                >
+                    <q-tooltip>Zoom in</q-tooltip>
+                </q-btn>
+                <q-btn
+                    dense
+                    unelevated
+                    size="sm"
+                    color="white"
+                    text-color="grey-9"
+                    icon="sym_o_remove"
+                    @click.stop="zoomOut"
+                >
+                    <q-tooltip>Zoom out</q-tooltip>
+                </q-btn>
+                <q-btn
+                    dense
+                    unelevated
+                    size="sm"
+                    color="white"
+                    text-color="grey-9"
+                    icon="sym_o_fit_screen"
+                    @click.stop="fitToTrack"
+                >
+                    <q-tooltip>Fit track</q-tooltip>
+                </q-btn>
+            </div>
+
+            <div class="map-legend row items-center q-gutter-x-sm text-caption">
+                <span class="legend-dot" style="background: #4caf50"></span>
+                Start
+                <span class="legend-dot" style="background: #f44336"></span>
+                End
+            </div>
+
+            <div class="map-attribution text-caption">
+                ©
+                <a
+                    href="https://www.openstreetmap.org/copyright"
+                    target="_blank"
+                    rel="noopener"
+                    >OpenStreetMap</a
+                >
+                contributors
+            </div>
+        </template>
+        <div v-else class="absolute-full flex flex-center text-grey-6">
+            No valid GNSS positions to display
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import type { GeoPoint } from './geo';
+
+/**
+ * Lightweight slippy map that renders OpenStreetMap tiles and a GNSS track
+ * on top, without any mapping library.
+ */
+
+const properties = withDefaults(
+    defineProps<{
+        points: GeoPoint[];
+        height?: number;
+    }>(),
+    { height: 320 },
+);
+
+const TILE_SIZE = 256;
+const MIN_ZOOM = 2;
+const MAX_ZOOM = 19;
+
+const container = ref<HTMLDivElement>();
+const size = ref({ width: 800, height: properties.height });
+
+// View state: zoom level and the world pixel coordinate at the view centre
+const zoom = ref(MIN_ZOOM);
+const center = ref({ x: 0, y: 0 });
+
+const validPoints = computed(() =>
+    properties.points.filter(
+        (p) =>
+            Number.isFinite(p.lat) &&
+            Number.isFinite(p.lon) &&
+            Math.abs(p.lat) <= 85 &&
+            Math.abs(p.lon) <= 180,
+    ),
+);
+const hasPoints = computed(() => validPoints.value.length > 0);
+
+// --- Web Mercator helpers (world pixels at a given zoom) ---
+const worldSize = (z: number): number => TILE_SIZE * 2 ** z;
+
+const project = (p: GeoPoint, z: number): { x: number; y: number } => {
+    const scale = worldSize(z);
+    const sinLat = Math.sin((p.lat * Math.PI) / 180);
+    return {
+        x: ((p.lon + 180) / 360) * scale,
+        y:
+            (0.5 - Math.log((1 + sinLat) / (1 - sinLat)) / (4 * Math.PI)) *
+            scale,
+    };
+};
+
+const toScreen = (world: {
+    x: number;
+    y: number;
+}): { x: number; y: number } => ({
+    x: world.x - center.value.x + size.value.width / 2,
+    y: world.y - center.value.y + size.value.height / 2,
+});
+
+// --- Fit the whole track into the view ---
+const fitToTrack = (): void => {
+    if (!hasPoints.value) return;
+    let minLat = Infinity;
+    let maxLat = -Infinity;
+    let minLon = Infinity;
+    let maxLon = -Infinity;
+    for (const p of validPoints.value) {
+        minLat = Math.min(minLat, p.lat);
+        maxLat = Math.max(maxLat, p.lat);
+        minLon = Math.min(minLon, p.lon);
+        maxLon = Math.max(maxLon, p.lon);
+    }
+
+    const padding = 40;
+    const availableWidth = Math.max(1, size.value.width - 2 * padding);
+    const availableHeight = Math.max(1, size.value.height - 2 * padding);
+
+    let bestZoom = MIN_ZOOM;
+    for (let z = MAX_ZOOM; z >= MIN_ZOOM; z--) {
+        const a = project({ lat: maxLat, lon: minLon }, z);
+        const b = project({ lat: minLat, lon: maxLon }, z);
+        if (b.x - a.x <= availableWidth && b.y - a.y <= availableHeight) {
+            bestZoom = z;
+            break;
+        }
+    }
+    // A stationary receiver would otherwise zoom to the maximum level
+    zoom.value = Math.min(bestZoom, 18);
+
+    const a = project({ lat: maxLat, lon: minLon }, zoom.value);
+    const b = project({ lat: minLat, lon: maxLon }, zoom.value);
+    center.value = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+};
+
+const zoomBy = (delta: number): void => {
+    const next = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom.value + delta));
+    if (next === zoom.value) return;
+    const factor = 2 ** (next - zoom.value);
+    center.value = { x: center.value.x * factor, y: center.value.y * factor };
+    zoom.value = next;
+};
+
+const zoomIn = (): void => {
+    zoomBy(1);
+};
+
+const zoomOut = (): void => {
+    zoomBy(-1);
+};
+
+const onWheel = (event: WheelEvent): void => {
+    zoomBy(event.deltaY < 0 ? 1 : -1);
+};
+
+// --- Dragging ---
+const isDragging = ref(false);
+let dragLast = { x: 0, y: 0 };
+
+const onDragStart = (event: MouseEvent): void => {
+    if (!hasPoints.value) return;
+    isDragging.value = true;
+    dragLast = { x: event.clientX, y: event.clientY };
+};
+
+const onDragMove = (event: MouseEvent): void => {
+    if (!isDragging.value) return;
+    center.value = {
+        x: center.value.x - (event.clientX - dragLast.x),
+        y: center.value.y - (event.clientY - dragLast.y),
+    };
+    dragLast = { x: event.clientX, y: event.clientY };
+};
+
+const onDragEnd = (): void => {
+    isDragging.value = false;
+};
+
+// --- Tiles visible in the current view ---
+const tiles = computed(() => {
+    if (!hasPoints.value) return [];
+    const z = zoom.value;
+    const tileCount = 2 ** z;
+    const left = center.value.x - size.value.width / 2;
+    const top = center.value.y - size.value.height / 2;
+
+    const firstX = Math.floor(left / TILE_SIZE);
+    const lastX = Math.floor((left + size.value.width) / TILE_SIZE);
+    const firstY = Math.max(0, Math.floor(top / TILE_SIZE));
+    const lastY = Math.min(
+        tileCount - 1,
+        Math.floor((top + size.value.height) / TILE_SIZE),
+    );
+
+    const result: { key: string; url: string; left: number; top: number }[] =
+        [];
+    for (let tx = firstX; tx <= lastX; tx++) {
+        // Wrap horizontally across the antimeridian
+        const wrappedX = ((tx % tileCount) + tileCount) % tileCount;
+        for (let ty = firstY; ty <= lastY; ty++) {
+            result.push({
+                key: `${String(z)}/${String(tx)}/${String(ty)}`,
+                url: `https://tile.openstreetmap.org/${String(z)}/${String(wrappedX)}/${String(ty)}.png`,
+                left: tx * TILE_SIZE - left,
+                top: ty * TILE_SIZE - top,
+            });
+        }
+    }
+    return result;
+});
+
+// --- Track in screen coordinates ---
+const screenPoints = computed(() =>
+    validPoints.value.map((p) => toScreen(project(p, zoom.value))),
+);
+
+const trackPoints = computed(() =>
+    screenPoints.value
+        .map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`)
+        .join(' '),
+);
+
+const startPixel = computed(() => screenPoints.value[0]);
+const endPixel = computed(() => screenPoints.value.at(-1));
+
+// --- Sizing ---
+let resizeObserver: ResizeObserver | undefined;
+
+const measure = (): void => {
+    if (!container.value) return;
+    size.value = {
+        width: container.value.clientWidth || 800,
+        height: container.value.clientHeight || properties.height,
+    };
+};
+
+onMounted(() => {
+    measure();
+    fitToTrack();
+    if (typeof ResizeObserver !== 'undefined' && container.value) {
+        resizeObserver = new ResizeObserver(() => {
+            measure();
+        });
+        resizeObserver.observe(container.value);
+    }
+});
+
+onBeforeUnmount(() => {
+    resizeObserver?.disconnect();
+});
+
+// Re-fit when the first points arrive (streaming load) and when the point
+// count grows substantially, but leave the view alone while the user pans.
+let fittedCount = 0;
+watch(
+    () => validPoints.value.length,
+    (count) => {
+        if (count === 0) return;
+        if (fittedCount === 0 || count > fittedCount * 2) {
+            fitToTrack();
+            fittedCount = count;
+        }
+    },
+    { immediate: true },
+);
+</script>
+
+<style scoped>
+.track-map {
+    cursor: grab;
+    border: 1px solid #e0e0e0;
+}
+
+.track-map.dragging {
+    cursor: grabbing;
+}
+
+.map-tile {
+    position: absolute;
+    width: 256px;
+    height: 256px;
+    pointer-events: none;
+}
+
+.track-overlay {
+    pointer-events: none;
+}
+
+.map-controls {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+}
+
+.map-legend {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    background: rgba(255, 255, 255, 0.9);
+    padding: 2px 8px;
+    border-radius: 4px;
+}
+
+.legend-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 1.5px solid #fff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.map-attribution {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    background: rgba(255, 255, 255, 0.8);
+    padding: 1px 6px;
+    font-size: 10px;
+}
+</style>

--- a/frontend/src/components/inspect-file/viewers/common/track-map.vue
+++ b/frontend/src/components/inspect-file/viewers/common/track-map.vue
@@ -5,9 +5,9 @@
         :class="{ dragging: isDragging }"
         :style="{ height: `${String(height)}px` }"
         @mousedown="onDragStart"
-        @mousemove="onDragMove"
+        @mousemove="onMouseMove"
         @mouseup="onDragEnd"
-        @mouseleave="onDragEnd"
+        @mouseleave="onMouseLeave"
         @wheel.prevent="onWheel"
     >
         <template v-if="hasPoints">
@@ -64,6 +64,23 @@
                     stroke="#fff"
                     stroke-width="2"
                 />
+                <template v-if="highlightPixel">
+                    <circle
+                        :cx="highlightPixel.x"
+                        :cy="highlightPixel.y"
+                        r="11"
+                        fill="#ff9800"
+                        opacity="0.3"
+                    />
+                    <circle
+                        :cx="highlightPixel.x"
+                        :cy="highlightPixel.y"
+                        r="6"
+                        fill="#ff9800"
+                        stroke="#fff"
+                        stroke-width="2"
+                    />
+                </template>
             </svg>
 
             <div class="map-controls column q-gutter-y-xs">
@@ -139,9 +156,17 @@ const properties = withDefaults(
     defineProps<{
         points: GeoPoint[];
         height?: number;
+        /** Index into `points` of a sample highlighted from outside the map */
+        // eslint-disable-next-line vue/require-default-prop
+        highlightIndex?: number | null;
     }>(),
     { height: 320 },
 );
+
+const emit = defineEmits<{
+    /** Index of the track point under the cursor, or null */
+    hover: [index: number | null];
+}>();
 
 const TILE_SIZE = 256;
 const MIN_ZOOM = 2;
@@ -154,14 +179,21 @@ const size = ref({ width: 800, height: properties.height });
 const zoom = ref(MIN_ZOOM);
 const center = ref({ x: 0, y: 0 });
 
+const isValidPoint = (p: GeoPoint): boolean =>
+    Number.isFinite(p.lat) &&
+    Number.isFinite(p.lon) &&
+    Math.abs(p.lat) <= 85 &&
+    Math.abs(p.lon) <= 180;
+
+// Valid points together with their index in the `points` prop, so that
+// hover events refer to the caller's indices.
+const validEntries = computed(() =>
+    properties.points
+        .map((point, index) => ({ point, index }))
+        .filter((entry) => isValidPoint(entry.point)),
+);
 const validPoints = computed(() =>
-    properties.points.filter(
-        (p) =>
-            Number.isFinite(p.lat) &&
-            Number.isFinite(p.lon) &&
-            Math.abs(p.lat) <= 85 &&
-            Math.abs(p.lon) <= 180,
-    ),
+    validEntries.value.map((entry) => entry.point),
 );
 const hasPoints = computed(() => validPoints.value.length > 0);
 
@@ -265,6 +297,46 @@ const onDragEnd = (): void => {
     isDragging.value = false;
 };
 
+// --- Hover: nearest track point to the cursor ---
+const HOVER_RADIUS_PX = 20;
+const hoveredIndex = ref<number | null>(null);
+
+const onMouseMove = (event: MouseEvent): void => {
+    if (isDragging.value) {
+        onDragMove(event);
+        return;
+    }
+    if (!container.value || !hasPoints.value) return;
+    const rect = container.value.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+
+    let best: number | null = null;
+    let bestDistance = HOVER_RADIUS_PX * HOVER_RADIUS_PX;
+    const points = screenPoints.value;
+    for (const [position, p] of points.entries()) {
+        const dx = p.x - x;
+        const dy = p.y - y;
+        const distance = dx * dx + dy * dy;
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            best = validEntries.value[position]?.index ?? null;
+        }
+    }
+    if (best !== hoveredIndex.value) {
+        hoveredIndex.value = best;
+        emit('hover', best);
+    }
+};
+
+const onMouseLeave = (): void => {
+    onDragEnd();
+    if (hoveredIndex.value !== null) {
+        hoveredIndex.value = null;
+        emit('hover', null);
+    }
+};
+
 // --- Tiles visible in the current view ---
 const tiles = computed(() => {
     if (!hasPoints.value) return [];
@@ -311,6 +383,16 @@ const trackPoints = computed(() =>
 
 const startPixel = computed(() => screenPoints.value[0]);
 const endPixel = computed(() => screenPoints.value.at(-1));
+
+const highlightPixel = computed(() => {
+    const index = properties.highlightIndex ?? hoveredIndex.value;
+    if (index === null) return;
+    const position = validEntries.value.findIndex(
+        (entry) => entry.index === index,
+    );
+    if (position === -1) return;
+    return screenPoints.value[position];
+});
 
 // --- Sizing ---
 let resizeObserver: ResizeObserver | undefined;

--- a/frontend/src/components/inspect-file/viewers/common/track-map.vue
+++ b/frontend/src/components/inspect-file/viewers/common/track-map.vue
@@ -12,7 +12,7 @@
     >
         <template v-if="hasPoints">
             <img
-                v-for="tile in tiles"
+                v-for="tile in showTiles ? tiles : []"
                 :key="tile.key"
                 :src="tile.url"
                 class="map-tile"
@@ -134,7 +134,24 @@
                 >
                     <q-tooltip>Fit track</q-tooltip>
                 </q-btn>
+                <q-btn
+                    dense
+                    unelevated
+                    size="sm"
+                    :color="showTiles ? 'primary' : 'white'"
+                    :text-color="showTiles ? 'white' : 'grey-9'"
+                    icon="sym_o_map"
+                    @click.stop="toggleTiles"
+                >
+                    <q-tooltip>
+                        {{ showTiles ? 'Hide' : 'Show' }} map background. Map
+                        tiles are fetched from openstreetmap.org, which reveals
+                        the approximate area of this track to that service.
+                    </q-tooltip>
+                </q-btn>
             </div>
+
+            <div v-if="!showTiles" class="absolute-full tile-placeholder" />
 
             <div class="map-legend row items-center q-gutter-x-sm text-caption">
                 <span class="legend-dot" style="background: #4caf50"></span>
@@ -147,7 +164,7 @@
                 </template>
             </div>
 
-            <div class="map-attribution text-caption">
+            <div v-if="showTiles" class="map-attribution text-caption">
                 ©
                 <a
                     href="https://www.openstreetmap.org/copyright"
@@ -218,6 +235,52 @@ const validPoints = computed(() =>
 );
 const hasPoints = computed(() => validPoints.value.length > 0);
 
+/**
+ * A track crossing the antimeridian has raw longitudes near both +180 and
+ * -180. Shifting the negative ones by 360° keeps it contiguous; tiles
+ * wrap horizontally, so projected x may exceed the world width.
+ */
+const crossesAntimeridian = computed(() => {
+    let minLon = Infinity;
+    let maxLon = -Infinity;
+    for (const p of validPoints.value) {
+        minLon = Math.min(minLon, p.lon);
+        maxLon = Math.max(maxLon, p.lon);
+    }
+    if (maxLon - minLon <= 180) return false;
+    // Compare the raw span with the span of the unwrapped longitudes
+    let minUnwrapped = Infinity;
+    let maxUnwrapped = -Infinity;
+    for (const p of validPoints.value) {
+        const lon = p.lon < 0 ? p.lon + 360 : p.lon;
+        minUnwrapped = Math.min(minUnwrapped, lon);
+        maxUnwrapped = Math.max(maxUnwrapped, lon);
+    }
+    return maxUnwrapped - minUnwrapped < maxLon - minLon;
+});
+
+const effectiveLon = (lon: number): number =>
+    crossesAntimeridian.value && lon < 0 ? lon + 360 : lon;
+
+// --- Map background (OpenStreetMap tiles) ---
+const TILES_STORAGE_KEY = 'kleinkram.trackMap.showTiles';
+const readTilePreference = (): boolean => {
+    try {
+        return localStorage.getItem(TILES_STORAGE_KEY) !== 'false';
+    } catch {
+        return true;
+    }
+};
+const showTiles = ref(readTilePreference());
+const toggleTiles = (): void => {
+    showTiles.value = !showTiles.value;
+    try {
+        localStorage.setItem(TILES_STORAGE_KEY, String(showTiles.value));
+    } catch {
+        // Preference cannot be persisted; keep it for this view only
+    }
+};
+
 // --- Web Mercator helpers (world pixels at a given zoom) ---
 const worldSize = (z: number): number => TILE_SIZE * 2 ** z;
 
@@ -225,7 +288,7 @@ const project = (p: GeoPoint, z: number): { x: number; y: number } => {
     const scale = worldSize(z);
     const sinLat = Math.sin((p.lat * Math.PI) / 180);
     return {
-        x: ((p.lon + 180) / 360) * scale,
+        x: ((effectiveLon(p.lon) + 180) / 360) * scale,
         y:
             (0.5 - Math.log((1 + sinLat) / (1 - sinLat)) / (4 * Math.PI)) *
             scale,
@@ -252,6 +315,19 @@ const fitToTrack = (): void => {
         maxLat = Math.max(maxLat, p.lat);
         minLon = Math.min(minLon, p.lon);
         maxLon = Math.max(maxLon, p.lon);
+    }
+    if (crossesAntimeridian.value) {
+        // Bounds in unwrapped longitudes; project() applies the same shift
+        minLon = Infinity;
+        maxLon = -Infinity;
+        for (const p of validPoints.value) {
+            const lon = p.lon < 0 ? p.lon + 360 : p.lon;
+            minLon = Math.min(minLon, lon);
+            maxLon = Math.max(maxLon, lon);
+        }
+        // Undo the shift so project() can re-apply it consistently
+        minLon = minLon > 180 ? minLon - 360 : minLon;
+        maxLon = maxLon > 180 ? maxLon - 360 : maxLon;
     }
 
     const padding = 40;
@@ -510,6 +586,15 @@ watch(
     position: absolute;
     top: 8px;
     right: 8px;
+}
+
+.tile-placeholder {
+    background-color: #eceff1;
+    background-image:
+        linear-gradient(rgba(0, 0, 0, 0.05) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 0, 0, 0.05) 1px, transparent 1px);
+    background-size: 32px 32px;
+    pointer-events: none;
 }
 
 .map-legend {

--- a/frontend/src/components/inspect-file/viewers/image-sequence-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/image-sequence-viewer.vue
@@ -61,14 +61,27 @@
             <div v-if="frameSize">Size: {{ frameSize }}</div>
         </div>
 
-        <div v-if="messages.length < totalCount" class="text-center q-mt-md">
+        <div
+            v-if="messages.length < totalCount || isLoading"
+            class="text-center q-mt-md"
+        >
             <SmoothLoading
                 :current="messages.length"
                 :total="totalCount"
-                message="Showing {current} / {total} frames."
+                message="Loaded {current} / {total} frames."
             />
+        </div>
+        <div
+            v-else-if="sampleStride > 1"
+            class="row items-center justify-center q-gutter-x-sm q-mt-md text-caption text-grey-7"
+        >
+            <span>
+                Showing every {{ sampleStride }}th frame ({{ messages.length }}
+                frames across the recording).
+            </span>
             <q-btn
-                label="Load More"
+                v-if="canRefine"
+                label="Load more frames"
                 icon="sym_o_download"
                 size="sm"
                 flat
@@ -85,12 +98,19 @@ import { useImageDecoder } from '../../../composables/use-image-decoder';
 import SmoothLoading from '../../common/smooth-loading.vue';
 import PlaybackControls from './playback-controls.vue';
 
-const properties = defineProps<{
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    messages: any[];
-    totalCount: number;
-    isLoading?: boolean;
-}>();
+const properties = withDefaults(
+    defineProps<{
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        messages: any[];
+        totalCount: number;
+        isLoading?: boolean;
+        /** Only every n-th frame is loaded (1 = all frames) */
+        sampleStride?: number;
+        /** Whether "Load more frames" can still reduce the sampling step */
+        canRefine?: boolean;
+    }>(),
+    { isLoading: false, sampleStride: 1, canRefine: false },
+);
 
 const emit = defineEmits(['load-more', 'pause-preview']);
 
@@ -164,24 +184,6 @@ watch(
     },
 );
 
-// Auto-buffer continuously in the background
-// We watch isLoading transitioning to false (a fetch finished), or the initial state
-watch(
-    () => properties.isLoading,
-    (loading) => {
-        /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
-        if (
-            loading === false &&
-            properties.messages.length > 0 &&
-            properties.messages.length < properties.totalCount
-        ) {
-            emitLoadMore();
-        }
-        /* eslint-enable @typescript-eslint/no-unnecessary-boolean-literal-compare */
-    },
-    { immediate: true },
-);
-
 watch(renderError, (error) => {
     if (error) {
         emit('pause-preview');
@@ -210,6 +212,9 @@ const inferredInterval = computed(() => {
     }
 
     if (count === 0) return 100;
+
+    // A sampled sequence plays back as a time-lapse rather than in real time
+    if (properties.sampleStride > 1) return 100;
 
     const avgNano = Number(totalDiff) / count;
     const avgMs = avgNano / 1_000_000;

--- a/frontend/src/components/inspect-file/viewers/image-sequence-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/image-sequence-viewer.vue
@@ -18,10 +18,12 @@
 
             <div
                 v-if="renderError"
-                class="absolute-center text-negative bg-white q-pa-sm rounded-borders"
+                class="absolute-center text-negative bg-white q-pa-md rounded-borders text-center"
+                style="max-width: 80%"
                 @click.stop
             >
-                <q-icon name="sym_o_warning" /> {{ renderError }}
+                <q-icon name="sym_o_warning" size="sm" />
+                <div class="q-mt-xs">{{ renderError }}</div>
             </div>
             <div
                 v-else-if="messages.length === 0"
@@ -306,6 +308,8 @@ const tick = (now: number): void => {
 
 const play = (): void => {
     if (isPlaying.value || properties.messages.length === 0) return;
+    // Nothing to show yet (or nothing decodable): do not start the clock
+    if (!isDecoded.value || renderError.value) return;
     isPlaying.value = true;
     lastTick = performance.now();
     animationFrame = requestAnimationFrame(tick);

--- a/frontend/src/components/inspect-file/viewers/image-sequence-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/image-sequence-viewer.vue
@@ -1,15 +1,14 @@
 <template>
     <div
-        class="image-sequence-viewer bg-white shadow-1 rounded-borders q-pa-md"
+        class="image-sequence-viewer rounded-borders overflow-hidden"
+        tabindex="0"
+        @keydown="onKeyDown"
     >
-        <!-- Canvas Viewport -->
+        <!-- Viewport -->
         <div
-            class="relative-position flex flex-center bg-grey-3"
-            :class="{
-                'overflow-auto': isUltraWide,
-                'overflow-hidden': !isUltraWide,
-            }"
-            style="min-height: 300px"
+            class="viewport relative-position flex flex-center"
+            :class="{ 'overflow-auto': isUltraWide }"
+            @click="togglePlay"
         >
             <canvas
                 ref="canvasReference"
@@ -17,36 +16,165 @@
                 :class="{ 'ultra-wide': isUltraWide }"
             />
 
-            <!-- Overlays -->
             <div
                 v-if="renderError"
                 class="absolute-center text-negative bg-white q-pa-sm rounded-borders"
+                @click.stop
             >
                 <q-icon name="sym_o_warning" /> {{ renderError }}
+            </div>
+            <div
+                v-else-if="messages.length === 0"
+                class="absolute-center column items-center text-grey-5"
+            >
+                <q-spinner-dots size="2em" color="white" />
+                <div class="q-mt-sm text-caption">Loading frames…</div>
+            </div>
+
+            <div
+                v-if="isLoading && messages.length > 0"
+                class="loading-indicator text-caption"
+            >
+                <q-spinner size="12px" color="white" class="q-mr-xs" />
+                Loading frames · {{ messages.length }} / {{ totalCount }}
             </div>
         </div>
 
         <!-- Controls -->
-        <div class="q-mt-md">
-            <PlaybackControls
-                v-model="currentIndex"
-                :max="messages.length - 1"
-                :is-playing="isPlaying"
-                @toggle="togglePlay"
-                @next="increment"
-                @prev="decrement"
-            />
+        <div class="controls">
+            <div
+                ref="timelineReference"
+                class="timeline"
+                @pointerdown="onScrubStart"
+                @pointermove="onScrubMove"
+                @pointerup="onScrubEnd"
+                @pointercancel="onScrubEnd"
+            >
+                <svg
+                    class="timeline-svg"
+                    :viewBox="`0 0 1000 12`"
+                    preserveAspectRatio="none"
+                >
+                    <!-- Loaded frames -->
+                    <line
+                        v-for="(x, index) in loadedTicks"
+                        :key="index"
+                        :x1="x"
+                        :x2="x"
+                        y1="2"
+                        y2="10"
+                        class="tick"
+                    />
+                    <!-- Played portion -->
+                    <rect
+                        x="0"
+                        y="5"
+                        :width="playedFraction * 1000"
+                        height="2"
+                        class="played"
+                    />
+                </svg>
+                <div
+                    class="playhead"
+                    :style="{ left: `${(playedFraction * 100).toFixed(3)}%` }"
+                />
+            </div>
+
+            <div class="row items-center no-wrap q-gutter-x-xs">
+                <q-btn
+                    flat
+                    dense
+                    round
+                    color="white"
+                    :icon="isPlaying ? 'sym_o_pause' : 'sym_o_play_arrow'"
+                    @click="togglePlay"
+                >
+                    <q-tooltip
+                        >{{ isPlaying ? 'Pause' : 'Play' }} (space)</q-tooltip
+                    >
+                </q-btn>
+                <q-btn
+                    flat
+                    dense
+                    round
+                    size="sm"
+                    color="white"
+                    icon="sym_o_skip_previous"
+                    @click="previousFrame"
+                >
+                    <q-tooltip>Previous frame (←)</q-tooltip>
+                </q-btn>
+                <q-btn
+                    flat
+                    dense
+                    round
+                    size="sm"
+                    color="white"
+                    icon="sym_o_skip_next"
+                    @click="nextFrame"
+                >
+                    <q-tooltip>Next frame (→)</q-tooltip>
+                </q-btn>
+
+                <div class="time-display text-caption q-ml-sm">
+                    {{ formatDuration(playhead) }}
+                    <span class="text-grey-5">
+                        / {{ formatDuration(duration) }}
+                    </span>
+                </div>
+
+                <q-space />
+
+                <div class="text-caption text-grey-5 q-mr-sm gt-xs">
+                    Frame {{ currentIndex + 1 }} / {{ messages.length }}
+                    <template v-if="sampleStride > 1">
+                        · every {{ sampleStride }}th
+                    </template>
+                </div>
+
+                <q-btn-dropdown
+                    flat
+                    dense
+                    no-caps
+                    color="white"
+                    :label="`${formatSpeed(speed)}×`"
+                    content-class="speed-menu"
+                >
+                    <q-list dense>
+                        <q-item
+                            v-for="option in SPEED_OPTIONS"
+                            :key="option"
+                            v-close-popup
+                            clickable
+                            :active="option === speed"
+                            @click="() => setSpeed(option)"
+                        >
+                            <q-item-section>
+                                {{ formatSpeed(option) }}×
+                                <span
+                                    v-if="option === 1"
+                                    class="text-caption text-grey-6"
+                                >
+                                    capture speed
+                                </span>
+                            </q-item-section>
+                        </q-item>
+                    </q-list>
+                    <q-tooltip>Playback speed</q-tooltip>
+                </q-btn-dropdown>
+            </div>
         </div>
 
         <!-- Metadata Footer -->
-        <div class="row justify-between q-mt-sm text-caption text-grey-6">
-            <div>Time: {{ formatTime(currentMessage?.logTime) }}</div>
+        <div
+            class="row justify-between q-px-md q-py-xs text-caption text-grey-6"
+        >
+            <div>{{ formatWallTime(currentMessage?.logTime) }}</div>
             <div>
-                Encoding:
                 {{
                     currentMessage?.data?.encoding ||
                     currentMessage?.data?.format ||
-                    'unknown'
+                    'unknown encoding'
                 }}
                 <q-tooltip
                     v-if="
@@ -58,36 +186,7 @@
                     Magic bytes: {{ magicBytes }}
                 </q-tooltip>
             </div>
-            <div v-if="frameSize">Size: {{ frameSize }}</div>
-        </div>
-
-        <div
-            v-if="messages.length < totalCount || isLoading"
-            class="text-center q-mt-md"
-        >
-            <SmoothLoading
-                :current="messages.length"
-                :total="totalCount"
-                message="Loaded {current} / {total} frames."
-            />
-        </div>
-        <div
-            v-else-if="sampleStride > 1"
-            class="row items-center justify-center q-gutter-x-sm q-mt-md text-caption text-grey-7"
-        >
-            <span>
-                Showing every {{ sampleStride }}th frame ({{ messages.length }}
-                frames across the recording).
-            </span>
-            <q-btn
-                v-if="canRefine"
-                label="Load more frames"
-                icon="sym_o_download"
-                size="sm"
-                flat
-                color="primary"
-                @click="emitLoadMore"
-            />
+            <div v-if="frameSize">{{ frameSize }}</div>
         </div>
     </div>
 </template>
@@ -95,8 +194,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useImageDecoder } from '../../../composables/use-image-decoder';
-import SmoothLoading from '../../common/smooth-loading.vue';
-import PlaybackControls from './playback-controls.vue';
 
 const properties = withDefaults(
     defineProps<{
@@ -106,7 +203,7 @@ const properties = withDefaults(
         isLoading?: boolean;
         /** Only every n-th frame is loaded (1 = all frames) */
         sampleStride?: number;
-        /** Whether "Load more frames" can still reduce the sampling step */
+        /** Whether more frames can still be loaded in the background */
         canRefine?: boolean;
     }>(),
     { isLoading: false, sampleStride: 1, canRefine: false },
@@ -114,66 +211,194 @@ const properties = withDefaults(
 
 const emit = defineEmits(['load-more', 'pause-preview']);
 
-// --- State ---
-const canvasReference = ref<HTMLCanvasElement | null>(null);
-const currentIndex = ref(0);
-const isPlaying = ref(false);
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let intervalId: any = null;
+const SPEED_OPTIONS = [0.25, 0.5, 1, 2, 4, 8];
 
-// --- Data Access ---
+// --- Recording time base ---
+const startTime = computed<bigint>(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+    () => properties.messages[0]?.logTime ?? 0n,
+);
+
+const frameTimes = computed<number[]>(() =>
+    properties.messages.map(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        (message) => Number(message.logTime - startTime.value) / 1e9,
+    ),
+);
+
+/** Duration of the recording in seconds (first to last loaded frame) */
+const duration = computed(() => frameTimes.value.at(-1) ?? 0);
+
+// --- Playback state ---
+const playhead = ref(0); // seconds since the first frame
+const isPlaying = ref(false);
+const speed = ref(1);
+
+/** Index of the last loaded frame at or before the playhead */
+const currentIndex = computed(() => {
+    const times = frameTimes.value;
+    if (times.length === 0) return 0;
+    let low = 0;
+    let high = times.length - 1;
+    while (low < high) {
+        const mid = Math.ceil((low + high) / 2);
+        if ((times[mid] ?? 0) <= playhead.value) low = mid;
+        else high = mid - 1;
+    }
+    return low;
+});
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
 const currentMessage = computed(() => properties.messages[currentIndex.value]);
-const frameSize = computed(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const data = currentMessage.value?.data?.data;
-    if (!data) return null;
-    let bytes = 0;
-    if (data instanceof Uint8Array) {
-        bytes = data.byteLength;
-    } else if (Array.isArray(data)) {
-        // Fallback for array of numbers
-        bytes = data.length;
-    }
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-});
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
 const currentData = computed(() => currentMessage.value?.data);
-const magicBytes = computed(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const data = currentData.value?.data;
-    if (!data) return '';
-    let bytes: Uint8Array | number[] = [];
-    if (data instanceof Uint8Array) {
-        bytes = data.slice(0, 4);
-    } else if (Array.isArray(data)) {
-        bytes = data.slice(0, 4);
-    } else {
-        return '';
-    }
 
-    return [...bytes]
-        .map((b) => `0x${b.toString(16).toUpperCase().padStart(2, '0')}`)
-        .join(' ');
+const playedFraction = computed(() =>
+    duration.value > 0 ? Math.min(1, playhead.value / duration.value) : 0,
+);
+
+const loadedTicks = computed(() => {
+    if (duration.value <= 0) return [];
+    return frameTimes.value.map((t) => (t / duration.value) * 1000);
 });
 
+// --- Playback loop (real time × speed) ---
+let animationFrame: number | null = null;
+let lastTick = 0;
+
+const tick = (now: number): void => {
+    if (!isPlaying.value) return;
+    const elapsed = (now - lastTick) / 1000;
+    lastTick = now;
+    let next = playhead.value + elapsed * speed.value;
+    if (next > duration.value) next = 0; // loop
+    playhead.value = next;
+    animationFrame = requestAnimationFrame(tick);
+};
+
+const play = (): void => {
+    if (isPlaying.value || properties.messages.length === 0) return;
+    isPlaying.value = true;
+    lastTick = performance.now();
+    animationFrame = requestAnimationFrame(tick);
+};
+
+const pause = (): void => {
+    isPlaying.value = false;
+    if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+    animationFrame = null;
+};
+
+const togglePlay = (): void => {
+    if (isPlaying.value) pause();
+    else play();
+};
+
+const setSpeed = (value: number): void => {
+    speed.value = value;
+};
+
+const stepFrame = (direction: 1 | -1): void => {
+    pause();
+    const times = frameTimes.value;
+    if (times.length === 0) return;
+    const next = Math.min(
+        times.length - 1,
+        Math.max(0, currentIndex.value + direction),
+    );
+    playhead.value = times[next] ?? 0;
+};
+
+// --- Scrubbing ---
+const timelineReference = ref<HTMLDivElement | null>(null);
+let scrubbing = false;
+let wasPlaying = false;
+
+const seekToEvent = (event: PointerEvent): void => {
+    if (!timelineReference.value) return;
+    const rect = timelineReference.value.getBoundingClientRect();
+    const fraction = Math.min(
+        1,
+        Math.max(0, (event.clientX - rect.left) / rect.width),
+    );
+    playhead.value = fraction * duration.value;
+};
+
+const onScrubStart = (event: PointerEvent): void => {
+    scrubbing = true;
+    wasPlaying = isPlaying.value;
+    pause();
+    timelineReference.value?.setPointerCapture(event.pointerId);
+    seekToEvent(event);
+};
+
+const onScrubMove = (event: PointerEvent): void => {
+    if (scrubbing) seekToEvent(event);
+};
+
+const onScrubEnd = (): void => {
+    if (!scrubbing) return;
+    scrubbing = false;
+    if (wasPlaying) play();
+};
+
+// --- Keyboard ---
+const onKeyDown = (event: KeyboardEvent): void => {
+    const target = event.target as HTMLElement | null;
+    if (target && ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)) {
+        return;
+    }
+    switch (event.key) {
+        case ' ': {
+            event.preventDefault();
+            togglePlay();
+            break;
+        }
+        case 'ArrowRight': {
+            stepFrame(1);
+            break;
+        }
+        case 'ArrowLeft': {
+            stepFrame(-1);
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+};
+
+const previousFrame = (): void => {
+    stepFrame(-1);
+};
+
+const nextFrame = (): void => {
+    stepFrame(1);
+};
+
 // --- Rendering ---
+const canvasReference = ref<HTMLCanvasElement | null>(null);
 const { draw, renderError, isDecoded, isUltraWide } = useImageDecoder(
     canvasReference,
     currentData,
 );
 
-// Ensure we draw the first frame when mounted/data loaded
 onMounted(() => {
-    if (currentData.value) {
-        draw();
+    if (currentData.value) draw();
+    // Re-expanded with a finished sampled load: continue refining
+    if (
+        !properties.isLoading &&
+        properties.canRefine &&
+        properties.messages.length > 0
+    ) {
+        emit('load-more');
     }
 });
 
-// Watch for timeout condition: >100 messages and still no first frame decoded
+onUnmounted(() => {
+    pause();
+});
+
 watch(
     () => properties.messages.length,
     (count) => {
@@ -186,106 +411,170 @@ watch(
 
 watch(renderError, (error) => {
     if (error) {
+        pause();
         emit('pause-preview');
     }
 });
 
-// --- Playback Logic ---
-const inferredInterval = computed(() => {
-    if (properties.messages.length < 2) return 100;
-
-    let totalDiff = 0n;
-    let count = 0;
-    // Check up to first 20 frames to estimate FPS
-    const limit = Math.min(properties.messages.length - 1, 20);
-
-    for (let index = 0; index < limit; index++) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        const t1 = properties.messages[index]?.logTime;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        const t2 = properties.messages[index + 1]?.logTime;
-
-        if (typeof t1 === 'bigint' && typeof t2 === 'bigint' && t2 > t1) {
-            totalDiff += t2 - t1;
-            count++;
+// --- Background refinement ---
+// Once a load finished, ask for the next (denser) sample until every frame
+// (or the frame budget) is loaded. The playback keeps running meanwhile.
+watch(
+    () => properties.isLoading,
+    (loading, wasLoading) => {
+        if (
+            wasLoading &&
+            !loading &&
+            !renderError.value &&
+            properties.canRefine &&
+            properties.messages.length > 0
+        ) {
+            setTimeout(() => {
+                if (properties.canRefine && !properties.isLoading) {
+                    emit('load-more');
+                }
+            }, 250);
         }
+    },
+);
+
+// --- Formatting ---
+const formatDuration = (seconds: number): string => {
+    if (!Number.isFinite(seconds) || seconds < 0) return '0:00.0';
+    const minutes = Math.floor(seconds / 60);
+    const rest = seconds - minutes * 60;
+    return `${String(minutes)}:${rest.toFixed(1).padStart(4, '0')}`;
+};
+
+const formatSpeed = (value: number): string =>
+    Number.isInteger(value)
+        ? String(value)
+        : value.toFixed(2).replace(/0$/, '');
+
+const formatWallTime = (nano: bigint | undefined): string => {
+    if (nano === undefined) return '';
+    const date = new Date(Number(nano / 1_000_000n));
+    if (Number.isNaN(date.getTime())) return 'Invalid time';
+    return date.toISOString().replace('T', ' ').replace('Z', ' UTC');
+};
+
+const frameSize = computed(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const data = currentMessage.value?.data?.data;
+    if (!data) return null;
+    let bytes = 0;
+    if (data instanceof Uint8Array) {
+        bytes = data.byteLength;
+    } else if (Array.isArray(data)) {
+        bytes = data.length;
     }
-
-    if (count === 0) return 100;
-
-    // A sampled sequence plays back as a time-lapse rather than in real time
-    if (properties.sampleStride > 1) return 100;
-
-    const avgNano = Number(totalDiff) / count;
-    const avgMs = avgNano / 1_000_000;
-
-    // Clamp to reasonable values (e.g., 1fps to 60fps -> 1000ms to 16ms)
-    // If it's too fast, we might not want to render that fast anyway, but let's stick to a reasonable lower bound.
-    return Math.max(16, Math.min(1000, avgMs));
+    if (bytes < 1024) return `${String(bytes)} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 });
 
-const togglePlay = (): void => {
-    isPlaying.value = !isPlaying.value;
-    if (isPlaying.value) {
-        intervalId = setInterval(() => {
-            step(1);
-        }, inferredInterval.value);
+const magicBytes = computed(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const data = currentData.value?.data;
+    if (!data) return '';
+    let bytes: Uint8Array | number[] = [];
+    if (data instanceof Uint8Array) {
+        bytes = data.slice(0, 4);
+    } else if (Array.isArray(data)) {
+        bytes = data.slice(0, 4);
     } else {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        clearInterval(intervalId);
+        return '';
     }
-};
-
-const increment = (): void => {
-    step(1);
-};
-
-const decrement = (): void => {
-    step(-1);
-};
-
-const step = (direction: number): void => {
-    let next = currentIndex.value + direction;
-    if (next >= properties.messages.length) {
-        next = 0; // Loop
-    } else if (next < 0) {
-        next = properties.messages.length - 1;
-    }
-    currentIndex.value = next;
-};
-
-const formatTime = (nano: bigint): string => {
-    const ms = Number(nano / 1_000_000n);
-    const date = new Date(ms);
-
-    if (Number.isNaN(date.getTime())) {
-        return 'Invalid Time';
-    }
-
-    const timePart = date.toISOString().split('T')[1];
-    return timePart?.replace('Z', '') ?? 'Invalid Time';
-};
-
-onUnmounted(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    clearInterval(intervalId);
+    return [...bytes]
+        .map((b) => `0x${b.toString(16).toUpperCase().padStart(2, '0')}`)
+        .join(' ');
 });
-
-function emitLoadMore() {
-    emit('load-more');
-}
 </script>
 
 <style scoped>
+.image-sequence-viewer {
+    background: #111;
+    color: #fff;
+    border: 1px solid #333;
+    outline: none;
+}
+
+.image-sequence-viewer:focus-visible {
+    box-shadow: 0 0 0 2px #1976d2;
+}
+
+.viewport {
+    height: 420px;
+    background: #000;
+    cursor: pointer;
+}
+
 .preview-canvas {
     max-width: 100%;
-    max-height: 400px;
+    max-height: 100%;
     object-fit: contain;
 }
 
 .preview-canvas.ultra-wide {
     max-width: none;
     width: auto;
-    object-fit: cover; /* or none, but cover ensures it fills height */
+    height: 100%;
+    object-fit: cover;
+}
+
+.loading-indicator {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 2px 8px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+}
+
+.controls {
+    padding: 6px 12px 4px;
+    background: #1c1c1c;
+}
+
+.timeline {
+    position: relative;
+    height: 14px;
+    cursor: pointer;
+    touch-action: none;
+    margin-bottom: 4px;
+}
+
+.timeline-svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.tick {
+    stroke: rgba(255, 255, 255, 0.25);
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
+}
+
+.played {
+    fill: #1976d2;
+}
+
+.playhead {
+    position: absolute;
+    top: 1px;
+    width: 3px;
+    height: 12px;
+    margin-left: -1.5px;
+    background: #fff;
+    border-radius: 2px;
+    pointer-events: none;
+}
+
+.time-display {
+    font-variant-numeric: tabular-nums;
+    min-width: 110px;
 }
 </style>

--- a/frontend/src/components/inspect-file/viewers/image-sequence-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/image-sequence-viewer.vue
@@ -27,7 +27,7 @@
                 v-else-if="messages.length === 0"
                 class="absolute-center column items-center text-grey-5"
             >
-                <q-spinner-dots size="2em" color="white" />
+                <q-spinner-dots size="2em" color="primary" />
                 <div class="q-mt-sm text-caption">Loading frames…</div>
             </div>
 
@@ -35,7 +35,7 @@
                 v-if="isLoading && messages.length > 0"
                 class="loading-indicator text-caption"
             >
-                <q-spinner size="12px" color="white" class="q-mr-xs" />
+                <q-spinner size="12px" color="primary" class="q-mr-xs" />
                 Loading frames · {{ messages.length }} / {{ totalCount }}
             </div>
         </div>
@@ -55,22 +55,23 @@
                     :viewBox="`0 0 1000 12`"
                     preserveAspectRatio="none"
                 >
-                    <!-- Loaded frames -->
-                    <line
-                        v-for="(x, index) in loadedTicks"
+                    <rect x="0" y="4" width="1000" height="4" class="track" />
+                    <!-- Time ranges covered by loaded frames -->
+                    <rect
+                        v-for="(segment, index) in coverage"
                         :key="index"
-                        :x1="x"
-                        :x2="x"
-                        y1="2"
-                        y2="10"
-                        class="tick"
+                        :x="segment.x"
+                        y="4"
+                        :width="segment.width"
+                        height="4"
+                        class="buffered"
                     />
                     <!-- Played portion -->
                     <rect
                         x="0"
-                        y="5"
+                        y="4"
                         :width="playedFraction * 1000"
-                        height="2"
+                        height="4"
                         class="played"
                     />
                 </svg>
@@ -85,7 +86,7 @@
                     flat
                     dense
                     round
-                    color="white"
+                    color="primary"
                     :icon="isPlaying ? 'sym_o_pause' : 'sym_o_play_arrow'"
                     @click="togglePlay"
                 >
@@ -98,7 +99,7 @@
                     dense
                     round
                     size="sm"
-                    color="white"
+                    color="grey-8"
                     icon="sym_o_skip_previous"
                     @click="previousFrame"
                 >
@@ -109,7 +110,7 @@
                     dense
                     round
                     size="sm"
-                    color="white"
+                    color="grey-8"
                     icon="sym_o_skip_next"
                     @click="nextFrame"
                 >
@@ -118,14 +119,14 @@
 
                 <div class="time-display text-caption q-ml-sm">
                     {{ formatDuration(playhead) }}
-                    <span class="text-grey-5">
+                    <span class="text-grey-6">
                         / {{ formatDuration(duration) }}
                     </span>
                 </div>
 
                 <q-space />
 
-                <div class="text-caption text-grey-5 q-mr-sm gt-xs">
+                <div class="text-caption text-grey-6 q-mr-sm gt-xs">
                     Frame {{ currentIndex + 1 }} / {{ messages.length }}
                     <template v-if="sampleStride > 1">
                         · every {{ sampleStride }}th
@@ -136,7 +137,7 @@
                     flat
                     dense
                     no-caps
-                    color="white"
+                    color="grey-8"
                     :label="`${formatSpeed(speed)}×`"
                     content-class="speed-menu"
                 >
@@ -257,9 +258,36 @@ const playedFraction = computed(() =>
     duration.value > 0 ? Math.min(1, playhead.value / duration.value) : 0,
 );
 
-const loadedTicks = computed(() => {
-    if (duration.value <= 0) return [];
-    return frameTimes.value.map((t) => (t / duration.value) * 1000);
+/**
+ * Time ranges (in timeline units, 0..1000) that are covered by loaded
+ * frames. Two consecutive frames are considered contiguous when their
+ * spacing is at most twice the typical spacing of the loaded sample, so
+ * gaps that still have to be filled show as holes in the buffered bar.
+ */
+const coverage = computed(() => {
+    const times = frameTimes.value;
+    if (duration.value <= 0 || times.length < 2) return [];
+    const typicalGap = duration.value / (times.length - 1);
+    const maxGap = typicalGap * 2;
+    const scale = 1000 / duration.value;
+    const segments: { x: number; width: number }[] = [];
+    let segmentStart = times[0] ?? 0;
+    let previous = segmentStart;
+    for (const t of times.slice(1)) {
+        if (t - previous > maxGap) {
+            segments.push({
+                x: segmentStart * scale,
+                width: Math.max(2, (previous - segmentStart) * scale),
+            });
+            segmentStart = t;
+        }
+        previous = t;
+    }
+    segments.push({
+        x: segmentStart * scale,
+        width: Math.max(2, (previous - segmentStart) * scale),
+    });
+    return segments;
 });
 
 // --- Playback loop (real time × speed) ---
@@ -493,9 +521,8 @@ const magicBytes = computed(() => {
 
 <style scoped>
 .image-sequence-viewer {
-    background: #111;
-    color: #fff;
-    border: 1px solid #333;
+    background: #fff;
+    border: 1px solid #e0e0e0;
     outline: none;
 }
 
@@ -505,7 +532,7 @@ const magicBytes = computed(() => {
 
 .viewport {
     height: 420px;
-    background: #000;
+    background: #f5f5f5;
     cursor: pointer;
 }
 
@@ -526,7 +553,8 @@ const magicBytes = computed(() => {
     position: absolute;
     top: 8px;
     left: 8px;
-    background: rgba(0, 0, 0, 0.6);
+    background: rgba(255, 255, 255, 0.9);
+    color: #424242;
     padding: 2px 8px;
     border-radius: 4px;
     display: flex;
@@ -534,8 +562,8 @@ const magicBytes = computed(() => {
 }
 
 .controls {
-    padding: 6px 12px 4px;
-    background: #1c1c1c;
+    padding: 8px 12px 4px;
+    border-top: 1px solid #e0e0e0;
 }
 
 .timeline {
@@ -552,10 +580,12 @@ const magicBytes = computed(() => {
     display: block;
 }
 
-.tick {
-    stroke: rgba(255, 255, 255, 0.25);
-    stroke-width: 1;
-    vector-effect: non-scaling-stroke;
+.track {
+    fill: #e0e0e0;
+}
+
+.buffered {
+    fill: #bdbdbd;
 }
 
 .played {
@@ -564,17 +594,20 @@ const magicBytes = computed(() => {
 
 .playhead {
     position: absolute;
-    top: 1px;
-    width: 3px;
+    top: 0;
+    width: 12px;
     height: 12px;
-    margin-left: -1.5px;
-    background: #fff;
-    border-radius: 2px;
+    margin-left: -6px;
+    background: #1976d2;
+    border: 2px solid #fff;
+    border-radius: 50%;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
     pointer-events: none;
 }
 
 .time-display {
     font-variant-numeric: tabular-nums;
     min-width: 110px;
+    color: #424242;
 }
 </style>

--- a/frontend/src/components/inspect-file/viewers/imu-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/imu-viewer.vue
@@ -121,7 +121,7 @@ const duration = computed(() => {
     const start = properties.messages[0].logTime;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     const end = properties.messages.at(-1).logTime;
-    return (end - start) / 1_000_000_000;
+    return Number((end as bigint) - (start as bigint)) / 1_000_000_000;
 });
 
 const accelSeries = shallowRef<ChartSeries[]>([]);
@@ -152,7 +152,8 @@ const updateCharts = debounce(() => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const message = properties.messages[index];
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        t[index] = (message.logTime - startTime) / 1_000_000_000;
+        const logTime = message.logTime as bigint;
+        t[index] = Number(logTime - (startTime as bigint)) / 1_000_000_000;
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         const accumulator = message.data.linear_acceleration ?? {};

--- a/frontend/src/components/inspect-file/viewers/nav-sat-fix-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/nav-sat-fix-viewer.vue
@@ -1,112 +1,202 @@
 <template>
-    <div class="nav-sat-fix-viewer">
-        <div class="bg-white rounded-borders border-color q-pa-md">
-            <div class="row items-center q-mb-md q-gutter-x-sm">
-                <q-badge color="blue-3" text-color="blue-9">
-                    <q-icon name="sym_o_timeline" size="xs" class="q-mr-xs" />
-                    {{ duration.toFixed(2) }}s
-                </q-badge>
-                <q-badge color="blue-1" text-color="blue-9">
-                    {{ messages.length }} Messages
-                </q-badge>
-                <q-spinner-dots v-if="isLoading" color="primary" size="1em" />
-                <q-space />
-                <q-btn
-                    icon="sym_o_content_copy"
-                    flat
-                    round
-                    dense
-                    size="sm"
-                    color="grey-7"
-                    @click="copyRaw"
-                >
-                    <q-tooltip>Copy JSON</q-tooltip>
-                </q-btn>
+    <ViewerLayout
+        :messages="messages"
+        :total-count="totalCount"
+        :is-loading="isLoading"
+    >
+        <template #header-extra>
+            <q-badge v-if="latest" :color="statusColor" text-color="white">
+                {{ statusText }}
+            </q-badge>
+            <q-badge v-if="trackLength > 0" color="grey-2" text-color="grey-9">
+                <q-icon name="sym_o_route" size="xs" class="q-mr-xs" />
+                {{ formatDistance(trackLength) }}
+            </q-badge>
+            <q-badge
+                v-if="droppedCount > 0"
+                color="orange-1"
+                text-color="orange-10"
+                class="cursor-help"
+            >
+                {{ droppedCount }} without position
+                <q-tooltip>
+                    {{ droppedCount }} messages report no position (all-zero or
+                    invalid coordinates) and are not plotted.
+                </q-tooltip>
+            </q-badge>
+        </template>
+
+        <div class="row q-col-gutter-md">
+            <div class="col-12">
+                <TrackMap :points="track" :height="340" />
             </div>
 
-            <div v-if="latestMessage" class="row q-col-gutter-md">
-                <div class="col-12 col-md-4">
-                    <div class="text-caption text-grey-7">Latitude</div>
-                    <div class="text-h6">
-                        {{ latestMessage.latitude.toFixed(6) }}°
+            <div v-if="latest" class="col-12">
+                <div class="row q-col-gutter-md">
+                    <div class="col-6 col-md-3">
+                        <div class="text-caption text-grey-7">Latitude</div>
+                        <div class="text-subtitle1 text-weight-medium">
+                            {{ formatCoordinate(latest.latitude, 6) }}°
+                        </div>
                     </div>
-                </div>
-                <div class="col-12 col-md-4">
-                    <div class="text-caption text-grey-7">Longitude</div>
-                    <div class="text-h6">
-                        {{ latestMessage.longitude.toFixed(6) }}°
+                    <div class="col-6 col-md-3">
+                        <div class="text-caption text-grey-7">Longitude</div>
+                        <div class="text-subtitle1 text-weight-medium">
+                            {{ formatCoordinate(latest.longitude, 6) }}°
+                        </div>
                     </div>
-                </div>
-                <div class="col-12 col-md-4">
-                    <div class="text-caption text-grey-7">Altitude</div>
-                    <div class="text-h6">
-                        {{ latestMessage.altitude.toFixed(2) }}m
+                    <div class="col-6 col-md-3">
+                        <div class="text-caption text-grey-7">Altitude</div>
+                        <div class="text-subtitle1 text-weight-medium">
+                            {{ formatCoordinate(latest.altitude, 2) }} m
+                        </div>
                     </div>
-                </div>
-                <div class="col-12">
-                    <div class="text-caption text-grey-7">Status</div>
-                    <div>
-                        <q-chip
-                            :color="statusColor"
-                            text-color="white"
-                            size="sm"
-                            class="q-ma-none"
-                        >
-                            {{ statusText }}
-                        </q-chip>
-                        <span class="text-grey-6 q-ml-sm text-caption">
-                            Service: {{ latestMessage.status.service }}
-                        </span>
+                    <div class="col-6 col-md-3">
+                        <div class="text-caption text-grey-7">Covariance</div>
+                        <div class="text-subtitle1 text-weight-medium">
+                            {{ covarianceType }}
+                        </div>
+                        <div class="text-caption text-grey-6">
+                            Service: {{ serviceText }}
+                        </div>
                     </div>
-                </div>
-                <div class="col-12">
-                    <div class="text-caption text-grey-7">
-                        Position Covariance Type
-                    </div>
-                    <div>{{ covarianceType }}</div>
                 </div>
             </div>
-            <div v-else class="text-center text-grey-5 q-pa-lg">
-                No data available
+
+            <div class="col-12">
+                <SimpleTimeChart
+                    title="Altitude (m)"
+                    :series="altitudeSeries"
+                    y-axis-label="m"
+                    :height="160"
+                    :start-time="startTime"
+                />
+            </div>
+
+            <div v-if="statusCounts.length > 1" class="col-12">
+                <div class="text-caption text-grey-7 q-mb-xs">
+                    Fix status over the recording
+                </div>
+                <div class="row q-gutter-x-sm">
+                    <q-badge
+                        v-for="entry in statusCounts"
+                        :key="entry.status"
+                        :color="statusColorFor(entry.status)"
+                        text-color="white"
+                    >
+                        {{ statusTextFor(entry.status) }}: {{ entry.count }}
+                    </q-badge>
+                </div>
             </div>
         </div>
-    </div>
+    </ViewerLayout>
 </template>
 
 <script setup lang="ts">
-import { Notify, copyToClipboard as quasarCopy } from 'quasar';
-import { computed } from 'vue';
+import { computed, onMounted } from 'vue';
+import { GeoPoint, trackLengthMetres } from './common/geo';
+import TrackMap from './common/track-map.vue';
+import { BaseMessage, useViewer } from './common/use-viewer';
+import ViewerLayout from './common/viewer-layout.vue';
+import SimpleTimeChart, { ChartSeries } from './simple-time-chart.vue';
+
+interface NavSatFixData {
+    latitude?: number;
+    longitude?: number;
+    altitude?: number;
+    status?: { status?: number; service?: number };
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    position_covariance_type?: number;
+}
+
+interface NavSatFixMessage extends BaseMessage {
+    data?: NavSatFixData;
+}
 
 const properties = defineProps<{
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    messages: any[];
+    messages: NavSatFixMessage[];
     totalCount: number;
     topicName: string;
 }>();
+
+const emit = defineEmits(['load-required']);
+
+onMounted(() => {
+    if (properties.messages.length === 0) emit('load-required');
+});
+
+const { startTime, getNormalizedTime } = useViewer(() => properties.messages);
 
 const isLoading = computed(
     () => properties.messages.length < properties.totalCount,
 );
 
-const duration = computed(() => {
-    if (properties.messages.length < 2) return 0;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const start = properties.messages[0].logTime;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const end = properties.messages.at(-1).logTime;
-    return (end - start) / 1_000_000_000;
+/**
+ * Receivers without a fix report all-zero coordinates (or NaN). Those
+ * samples carry no position information and are excluded from the map,
+ * the altitude chart and the coordinate display.
+ */
+const hasValidPosition = (data: NavSatFixData | undefined): boolean =>
+    data !== undefined &&
+    typeof data.latitude === 'number' &&
+    typeof data.longitude === 'number' &&
+    Number.isFinite(data.latitude) &&
+    Number.isFinite(data.longitude) &&
+    !(data.latitude === 0 && data.longitude === 0);
+
+const validMessages = computed(() =>
+    properties.messages.filter((message) => hasValidPosition(message.data)),
+);
+
+const latest = computed(
+    () => validMessages.value.at(-1)?.data ?? properties.messages.at(-1)?.data,
+);
+
+const track = computed<GeoPoint[]>(() =>
+    validMessages.value.map((message) => ({
+        lat: message.data?.latitude ?? 0,
+        lon: message.data?.longitude ?? 0,
+    })),
+);
+
+const trackLength = computed(() => trackLengthMetres(track.value));
+
+const droppedCount = computed(
+    () => properties.messages.length - validMessages.value.length,
+);
+
+const formatDistance = (metres: number): string =>
+    metres >= 1000
+        ? `${(metres / 1000).toFixed(2)} km`
+        : `${metres.toFixed(0)} m`;
+
+const formatCoordinate = (value: number | undefined, digits: number): string =>
+    typeof value === 'number' && Number.isFinite(value)
+        ? value.toFixed(digits)
+        : '-';
+
+const altitudeSeries = computed<ChartSeries[]>(() => {
+    const data: { time: number; value: number }[] = [];
+    for (const message of validMessages.value) {
+        const altitude = message.data?.altitude;
+        // An exact 0 altitude is a placeholder from receivers without a fix
+        if (
+            typeof altitude !== 'number' ||
+            !Number.isFinite(altitude) ||
+            altitude === 0
+        ) {
+            continue;
+        }
+        data.push({
+            time: getNormalizedTime(message.logTime),
+            value: altitude,
+        });
+    }
+    return [{ name: 'Altitude', color: '#2196F3', data }];
 });
 
-const latestMessage = computed(() => {
-    if (properties.messages.length === 0) return null;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
-    return properties.messages.at(-1).data;
-});
-
-const statusText = computed(() => {
-    if (!latestMessage.value) return 'Unknown';
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const status = latestMessage.value.status.status;
+// --- Status decoding (sensor_msgs/NavSatStatus) ---
+const statusTextFor = (status: number | undefined): string => {
     switch (status) {
         case -1: {
             return 'NO_FIX';
@@ -121,16 +211,14 @@ const statusText = computed(() => {
             return 'GBAS_FIX';
         }
         default: {
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            return `Unknown (${status})`;
+            return status === undefined
+                ? 'Unknown'
+                : `Unknown (${String(status)})`;
         }
     }
-});
+};
 
-const statusColor = computed(() => {
-    if (!latestMessage.value) return 'grey';
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const status = latestMessage.value.status.status;
+const statusColorFor = (status: number | undefined): string => {
     switch (status) {
         case -1: {
             return 'red';
@@ -148,13 +236,26 @@ const statusColor = computed(() => {
             return 'grey';
         }
     }
+};
+
+const statusText = computed(() => statusTextFor(latest.value?.status?.status));
+const statusColor = computed(() =>
+    statusColorFor(latest.value?.status?.status),
+);
+
+const serviceText = computed(() => {
+    const service = latest.value?.status?.service;
+    if (service === undefined) return '-';
+    const names: string[] = [];
+    if (service & 1) names.push('GPS');
+    if (service & 2) names.push('GLONASS');
+    if (service & 4) names.push('COMPASS');
+    if (service & 8) names.push('GALILEO');
+    return names.length > 0 ? names.join(', ') : String(service);
 });
 
 const covarianceType = computed(() => {
-    if (!latestMessage.value) return 'Unknown';
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const type = latestMessage.value.position_covariance_type;
-    switch (type) {
+    switch (latest.value?.position_covariance_type) {
         case 0: {
             return 'UNKNOWN';
         }
@@ -168,25 +269,20 @@ const covarianceType = computed(() => {
             return 'KNOWN';
         }
         default: {
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            return `Unknown (${type})`;
+            return '-';
         }
     }
 });
 
-async function copyRaw(): Promise<void> {
-    if (!latestMessage.value) return;
-    await quasarCopy(JSON.stringify(latestMessage.value, null, 2));
-    Notify.create({
-        message: 'Latest message copied',
-        color: 'positive',
-        timeout: 1000,
-    });
-}
+const statusCounts = computed(() => {
+    const counts = new Map<number, number>();
+    for (const message of properties.messages) {
+        const status = message.data?.status?.status;
+        if (status === undefined) continue;
+        counts.set(status, (counts.get(status) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+        .map(([status, count]) => ({ status, count }))
+        .toSorted((a, b) => b.count - a.count);
+});
 </script>
-
-<style scoped>
-.border-color {
-    border: 1px solid #e0e0e0;
-}
-</style>

--- a/frontend/src/components/inspect-file/viewers/nav-sat-fix-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/nav-sat-fix-viewer.vue
@@ -18,10 +18,10 @@
                 text-color="orange-10"
                 class="cursor-help"
             >
-                {{ droppedCount }} without position
+                {{ droppedCount }} without fix
                 <q-tooltip>
-                    {{ droppedCount }} messages report no position (all-zero or
-                    invalid coordinates) and are not plotted.
+                    {{ droppedCount }} messages report no fix (zero or invalid
+                    coordinates or altitude) and are not plotted.
                 </q-tooltip>
             </q-badge>
         </template>
@@ -139,9 +139,10 @@ const isLoading = computed(
 );
 
 /**
- * Receivers without a fix report all-zero coordinates (or NaN). Those
- * samples carry no position information and are excluded from the map,
- * the altitude chart and the coordinate display.
+ * Receivers without a fix report all-zero coordinates and altitude (or
+ * NaN). Those samples carry no position information and are excluded
+ * consistently from the map, the track length, the altitude chart and the
+ * coordinate display, and counted in the "without fix" badge.
  */
 const hasValidPosition = (data: NavSatFixData | undefined): boolean =>
     data !== undefined &&
@@ -149,7 +150,8 @@ const hasValidPosition = (data: NavSatFixData | undefined): boolean =>
     typeof data.longitude === 'number' &&
     Number.isFinite(data.latitude) &&
     Number.isFinite(data.longitude) &&
-    !(data.latitude === 0 && data.longitude === 0);
+    !(data.latitude === 0 && data.longitude === 0) &&
+    data.altitude !== 0;
 
 // Valid messages together with their index in the full message list, so
 // that gaps (dropped samples between two valid ones) can be detected.
@@ -248,12 +250,7 @@ const altitudeSeries = computed<ChartSeries[]>(() => {
     const data: { time: number; value: number }[] = [];
     for (const message of validMessages.value) {
         const altitude = message.data?.altitude;
-        // An exact 0 altitude is a placeholder from receivers without a fix
-        if (
-            typeof altitude !== 'number' ||
-            !Number.isFinite(altitude) ||
-            altitude === 0
-        ) {
+        if (typeof altitude !== 'number' || !Number.isFinite(altitude)) {
             continue;
         }
         data.push({

--- a/frontend/src/components/inspect-file/viewers/nav-sat-fix-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/nav-sat-fix-viewer.vue
@@ -151,8 +151,16 @@ const hasValidPosition = (data: NavSatFixData | undefined): boolean =>
     Number.isFinite(data.longitude) &&
     !(data.latitude === 0 && data.longitude === 0);
 
+// Valid messages together with their index in the full message list, so
+// that gaps (dropped samples between two valid ones) can be detected.
+const validEntries = computed(() =>
+    properties.messages
+        .map((message, index) => ({ message, index }))
+        .filter((entry) => hasValidPosition(entry.message.data)),
+);
+
 const validMessages = computed(() =>
-    properties.messages.filter((message) => hasValidPosition(message.data)),
+    validEntries.value.map((entry) => entry.message),
 );
 
 // --- Linked hover between the map and the altitude chart ---
@@ -209,10 +217,15 @@ const latest = computed(() => {
 });
 
 const track = computed<GeoPoint[]>(() =>
-    validMessages.value.map((message) => ({
-        lat: message.data?.latitude ?? 0,
-        lon: message.data?.longitude ?? 0,
-    })),
+    validEntries.value.map((entry, position, entries) => {
+        const previous = entries[position - 1];
+        return {
+            lat: entry.message.data?.latitude ?? 0,
+            lon: entry.message.data?.longitude ?? 0,
+            gapBefore:
+                previous !== undefined && previous.index !== entry.index - 1,
+        };
+    }),
 );
 
 const trackLength = computed(() => trackLengthMetres(track.value));

--- a/frontend/src/components/inspect-file/viewers/nav-sat-fix-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/nav-sat-fix-viewer.vue
@@ -28,7 +28,12 @@
 
         <div class="row q-col-gutter-md">
             <div class="col-12">
-                <TrackMap :points="track" :height="340" />
+                <TrackMap
+                    :points="track"
+                    :height="340"
+                    :highlight-index="hoveredIndex"
+                    @hover="onMapHover"
+                />
             </div>
 
             <div v-if="latest" class="col-12">
@@ -70,6 +75,8 @@
                     y-axis-label="m"
                     :height="160"
                     :start-time="startTime"
+                    :highlight-time="hoveredTime"
+                    @hover="onChartHover"
                 />
             </div>
 
@@ -93,7 +100,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { GeoPoint, trackLengthMetres } from './common/geo';
 import TrackMap from './common/track-map.vue';
 import { BaseMessage, useViewer } from './common/use-viewer';
@@ -148,9 +155,58 @@ const validMessages = computed(() =>
     properties.messages.filter((message) => hasValidPosition(message.data)),
 );
 
-const latest = computed(
-    () => validMessages.value.at(-1)?.data ?? properties.messages.at(-1)?.data,
-);
+// --- Linked hover between the map and the altitude chart ---
+// Index into validMessages (and therefore into `track`) of the hovered sample
+const hoveredIndex = ref<number | null>(null);
+
+const hoveredTime = computed(() => {
+    if (hoveredIndex.value === null) return null;
+    const message = validMessages.value[hoveredIndex.value];
+    return message ? getNormalizedTime(message.logTime) : null;
+});
+
+const onMapHover = (index: number | null): void => {
+    hoveredIndex.value = index;
+};
+
+const onChartHover = (time: number | null): void => {
+    if (time === null) {
+        hoveredIndex.value = null;
+        return;
+    }
+    // Binary search for the sample closest in time
+    const messages = validMessages.value;
+    let low = 0;
+    let high = messages.length - 1;
+    while (low < high) {
+        const mid = Math.floor((low + high) / 2);
+        const midMessage = messages[mid];
+        if (midMessage && getNormalizedTime(midMessage.logTime) < time) {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+    const previous = messages[low - 1];
+    const candidate = messages[low];
+    if (
+        previous &&
+        candidate &&
+        Math.abs(time - getNormalizedTime(previous.logTime)) <
+            Math.abs(time - getNormalizedTime(candidate.logTime))
+    ) {
+        low--;
+    }
+    hoveredIndex.value = messages.length > 0 ? low : null;
+};
+
+const latest = computed(() => {
+    if (hoveredIndex.value !== null) {
+        const hovered = validMessages.value[hoveredIndex.value];
+        if (hovered) return hovered.data;
+    }
+    return validMessages.value.at(-1)?.data ?? properties.messages.at(-1)?.data;
+});
 
 const track = computed<GeoPoint[]>(() =>
     validMessages.value.map((message) => ({

--- a/frontend/src/components/inspect-file/viewers/odometry-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/odometry-viewer.vue
@@ -136,7 +136,7 @@ const duration = computed(() => {
     const start = properties.messages[0].logTime;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     const end = properties.messages.at(-1).logTime;
-    return (end - start) / 1_000_000_000;
+    return Number((end as bigint) - (start as bigint)) / 1_000_000_000;
 });
 
 const startTime = computed(() => {
@@ -187,7 +187,8 @@ const updateCharts = debounce(() => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const message = properties.messages[index];
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        t[index] = (message.logTime - logStartTime) / 1_000_000_000;
+        const logTime = message.logTime as bigint;
+        t[index] = Number(logTime - (logStartTime as bigint)) / 1_000_000_000;
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         const pos = message.data.pose?.pose?.position ?? {};

--- a/frontend/src/components/inspect-file/viewers/point-stamped-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/point-stamped-viewer.vue
@@ -80,7 +80,7 @@ const duration = computed(() => {
     const start = properties.messages[0].logTime;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     const end = properties.messages.at(-1).logTime;
-    return (end - start) / 1_000_000_000;
+    return Number((end as bigint) - (start as bigint)) / 1_000_000_000;
 });
 
 const latestMessage = computed(() => {

--- a/frontend/src/components/inspect-file/viewers/pose-stamped-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/pose-stamped-viewer.vue
@@ -95,7 +95,8 @@ const updateCharts = debounce(() => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const message = properties.messages[index];
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        t[index] = (message.logTime - logStartTime) / 1_000_000_000;
+        const logTime = message.logTime as bigint;
+        t[index] = Number(logTime - (logStartTime as bigint)) / 1_000_000_000;
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         const pos = message.data.pose?.position ?? {};

--- a/frontend/src/components/inspect-file/viewers/simple-time-chart.vue
+++ b/frontend/src/components/inspect-file/viewers/simple-time-chart.vue
@@ -51,14 +51,26 @@
 
                 <!-- Cursor Line -->
                 <line
-                    v-if="hoverX !== null"
-                    :x1="hoverX"
+                    v-if="cursorX !== null"
+                    :x1="cursorX"
                     :y1="0"
-                    :x2="hoverX"
+                    :x2="cursorX"
                     :y2="height"
                     stroke="#666"
                     stroke-width="1"
                     stroke-dasharray="2"
+                />
+                <!-- Externally highlighted sample -->
+                <circle
+                    v-for="m in highlightMarkers"
+                    :key="m.name"
+                    :cx="m.x"
+                    :cy="m.y"
+                    r="4"
+                    :fill="m.color"
+                    stroke="#fff"
+                    stroke-width="1.5"
+                    vector-effect="non-scaling-stroke"
                 />
             </svg>
 
@@ -127,6 +139,9 @@ const properties = withDefaults(
         width?: number;
         // eslint-disable-next-line vue/require-default-prop
         startTime?: bigint; // Absolute start time in nanoseconds
+        /** Relative time (s) of a sample highlighted from outside the chart */
+        // eslint-disable-next-line vue/require-default-prop
+        highlightTime?: number | null;
     }>(),
     {
         title: '',
@@ -134,6 +149,11 @@ const properties = withDefaults(
         width: 1000,
     },
 );
+
+const emit = defineEmits<{
+    /** Relative time (s) under the cursor, or null when the cursor leaves */
+    hover: [time: number | null];
+}>();
 
 const SUBSAMPLE_THRESHOLD = 10_000;
 const TARGET_POINTS = 2000;
@@ -236,6 +256,56 @@ const getPoints = (data: (DataPoint | undefined)[]): string => {
 
 const fmt = (n: number): string => n.toFixed(2);
 
+// --- External highlight (e.g. hovering a linked map) ---
+const timeToX = (time: number): number =>
+    (time / maxTime.value) * properties.width;
+
+const findClosest = (data: DataPoint[], t: number): DataPoint | undefined => {
+    if (data.length === 0) return;
+    let low = 0;
+    let high = data.length - 1;
+    while (low < high) {
+        const mid = Math.floor((low + high) / 2);
+        if ((data[mid]?.time ?? 0) < t) low = mid + 1;
+        else high = mid;
+    }
+    const candidate = data[low];
+    const previous = data[low - 1];
+    if (
+        previous &&
+        candidate &&
+        Math.abs(t - previous.time) < Math.abs(t - candidate.time)
+    ) {
+        return previous;
+    }
+    return candidate;
+};
+
+const highlightMarkers = computed(() => {
+    const t = properties.highlightTime;
+    if (t === null || t === undefined) return [];
+    const markers: { name: string; color: string; x: number; y: number }[] = [];
+    for (const s of properties.series) {
+        const p = findClosest(s.data, t);
+        if (p) {
+            markers.push({
+                name: s.name,
+                color: s.color,
+                x: timeToX(p.time),
+                y: getY(p.value),
+            });
+        }
+    }
+    return markers;
+});
+
+const cursorX = computed(() => {
+    if (hoverX.value !== null) return hoverX.value;
+    const t = properties.highlightTime;
+    if (t === null || t === undefined) return null;
+    return timeToX(t);
+});
+
 // --- Inspection Logic ---
 const graphContainer = ref<HTMLElement | null>(null);
 const hoverX = ref<number | null>(null);
@@ -272,6 +342,7 @@ const onMouseMove = (event: MouseEvent) => {
     // Calculate time
     const t = (svgX / properties.width) * maxTime.value;
     hoverTime.value = t;
+    emit('hover', t);
 
     // Find closest points
     const points: { name: string; color: string; value: number }[] = [];
@@ -352,6 +423,7 @@ const onMouseLeave = () => {
     hoverX.value = null;
     hoverTime.value = null;
     hoverPoints.value = [];
+    emit('hover', null);
 };
 </script>
 

--- a/frontend/src/components/inspect-file/viewers/statistics-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/statistics-viewer.vue
@@ -107,8 +107,10 @@ watch(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         const logStartTime = properties.messages[0].logTime;
         const data = properties.messages.map((message) => ({
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            time: (message.logTime - logStartTime) / 1_000_000_000,
+            time:
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                Number((message.logTime as bigint) - (logStartTime as bigint)) /
+                1_000_000_000,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
             value: message.data.pointcloud_process_fps ?? 0,
         }));

--- a/frontend/src/composables/use-image-decoder.ts
+++ b/frontend/src/composables/use-image-decoder.ts
@@ -54,12 +54,35 @@ export function useImageDecoder(
 
         renderError.value = undefined;
         const canvas = canvasReference.value;
+
+        const onError = (error: Error): void => {
+            renderError.value = error.message;
+            if (isCompressed) parallelRequests.value--;
+        };
+
+        try {
+            renderMessageToCanvas(
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                messageData.value,
+                canvas,
+                () => {
+                    onRendered(canvas, isCompressed);
+                },
+                onError,
+            );
+        } catch (error) {
+            onError(error instanceof Error ? error : new Error(String(error)));
+        }
+    };
+
+    // Callback after rendering (async for compressed images)
+    const onRendered = (
+        canvas: HTMLCanvasElement,
+        isCompressed: boolean,
+    ): void => {
         const targetWidth = 600;
         const targetHeight = 400;
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        renderMessageToCanvas(messageData.value, canvas, () => {
-            // Callback after rendering (async for compressed images)
+        {
             const aspectRatio = canvas.width / canvas.height;
             isUltraWide.value = aspectRatio > 2.5;
 
@@ -108,7 +131,7 @@ export function useImageDecoder(
                 // Decrement parallel request count after completion
                 parallelRequests.value--;
             }
-        });
+        }
     };
 
     // Automatically redraw when data changes

--- a/frontend/src/composables/use-rosmsg-preview.ts
+++ b/frontend/src/composables/use-rosmsg-preview.ts
@@ -6,6 +6,22 @@ import { McapStrategy } from '../services/decoding-strategies/mcap-strategy';
 import { RosbagStrategy } from '../services/decoding-strategies/rosbag-strategy';
 import { formatPayload } from './rosmsg-utilities.ts';
 
+export interface FetchOptions {
+    limit?: number;
+    /** Continue after the last loaded message (paging) */
+    append?: boolean;
+    /** Keep only every n-th message */
+    stride?: number;
+    /** Read chunks coarse-to-fine so the whole recording is covered early */
+    progressive?: boolean;
+    /**
+     * Keep the messages already loaded and add the new ones in time order,
+     * skipping messages that are already present. Used to refine a sampled
+     * topic with a smaller stride.
+     */
+    merge?: boolean;
+}
+
 /**
  * Inserts a message keeping the array ordered by log time. Appending is the
  * fast path; progressive (coarse-to-fine) loading delivers messages out of
@@ -14,7 +30,7 @@ import { formatPayload } from './rosmsg-utilities.ts';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function insertSorted(messages: any[], message: { logTime: bigint }): void {
     const last = messages.at(-1) as { logTime: bigint } | undefined;
-    if (last === undefined || last.logTime <= message.logTime) {
+    if (last === undefined || last.logTime < message.logTime) {
         messages.push(message);
         return;
     }
@@ -23,9 +39,12 @@ function insertSorted(messages: any[], message: { logTime: bigint }): void {
     while (low < high) {
         const mid = Math.floor((low + high) / 2);
         const midMessage = messages[mid] as { logTime: bigint };
-        if (midMessage.logTime <= message.logTime) low = mid + 1;
+        if (midMessage.logTime < message.logTime) low = mid + 1;
         else high = mid;
     }
+    // Ignore exact duplicates (same log time) when merging refinements
+    const existing = messages[low] as { logTime: bigint } | undefined;
+    if (existing?.logTime === message.logTime) return;
     messages.splice(low, 0, message);
 }
 
@@ -43,12 +62,7 @@ export function useRosmsgPreview(): {
     ) => Promise<void>;
     fetchTopicMessages: (
         topicName: string,
-        options?: {
-            limit?: number;
-            append?: boolean;
-            stride?: number;
-            progressive?: boolean;
-        },
+        options?: FetchOptions,
     ) => Promise<void>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     formatPayload: (data: any) => string;
@@ -135,12 +149,7 @@ export function useRosmsgPreview(): {
      */
     async function fetchTopicMessages(
         topicName: string,
-        options?: {
-            limit?: number;
-            append?: boolean;
-            stride?: number;
-            progressive?: boolean;
-        },
+        options?: FetchOptions,
     ): Promise<void> {
         if (!strategy.value) return;
 
@@ -157,6 +166,7 @@ export function useRosmsgPreview(): {
         const append = options?.append ?? false;
         const stride = options?.stride ?? 1;
         const progressive = options?.progressive ?? false;
+        const merge = options?.merge ?? false;
 
         let startTime: bigint | undefined;
 
@@ -170,10 +180,20 @@ export function useRosmsgPreview(): {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
                 startTime = BigInt(lastMessage.logTime) + 1n;
             }
-        } else {
+        } else if (!merge) {
             // Reset the array so it can be filled from scratch
             topicPreviews[topicName] = [];
         }
+
+        // When merging, do not decode messages that are already loaded
+        const loadedTimes = merge
+            ? new Set<bigint>(
+                  (topicPreviews[topicName] ?? []).map(
+                      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+                      (message) => message.logTime,
+                  ),
+              )
+            : undefined;
 
         try {
             // We ignore the return value (full array) because we populate
@@ -191,7 +211,13 @@ export function useRosmsgPreview(): {
                 },
                 controller.signal,
                 startTime,
-                { stride, progressive },
+                loadedTimes
+                    ? {
+                          stride,
+                          progressive,
+                          skip: (logTime): boolean => loadedTimes.has(logTime),
+                      }
+                    : { stride, progressive },
             );
         } catch (error: unknown) {
             if (controller.signal.aborted) return; // Ignore abort errors

--- a/frontend/src/composables/use-rosmsg-preview.ts
+++ b/frontend/src/composables/use-rosmsg-preview.ts
@@ -4,6 +4,7 @@ import { DecodingStrategy } from '../services/decoding-strategies';
 import { Db3Strategy } from '../services/decoding-strategies/db3-strategy';
 import { McapStrategy } from '../services/decoding-strategies/mcap-strategy';
 import { RosbagStrategy } from '../services/decoding-strategies/rosbag-strategy';
+import type { ReadOptions } from '../services/decoding-strategies/utilities';
 import { formatPayload } from './rosmsg-utilities.ts';
 
 export interface FetchOptions {
@@ -20,6 +21,8 @@ export interface FetchOptions {
      * topic with a smaller stride.
      */
     merge?: boolean;
+    /** Total number of messages of the topic, for uniform sampling */
+    totalMessages?: number;
 }
 
 /**
@@ -167,6 +170,10 @@ export function useRosmsgPreview(): {
         const stride = options?.stride ?? 1;
         const progressive = options?.progressive ?? false;
         const merge = options?.merge ?? false;
+        const readOptions: ReadOptions = { stride, progressive };
+        if (options?.totalMessages !== undefined) {
+            readOptions.totalMessages = options.totalMessages;
+        }
 
         let startTime: bigint | undefined;
 
@@ -213,11 +220,10 @@ export function useRosmsgPreview(): {
                 startTime,
                 loadedTimes
                     ? {
-                          stride,
-                          progressive,
+                          ...readOptions,
                           skip: (logTime): boolean => loadedTimes.has(logTime),
                       }
-                    : { stride, progressive },
+                    : readOptions,
             );
         } catch (error: unknown) {
             if (controller.signal.aborted) return; // Ignore abort errors

--- a/frontend/src/composables/use-rosmsg-preview.ts
+++ b/frontend/src/composables/use-rosmsg-preview.ts
@@ -6,6 +6,29 @@ import { McapStrategy } from '../services/decoding-strategies/mcap-strategy';
 import { RosbagStrategy } from '../services/decoding-strategies/rosbag-strategy';
 import { formatPayload } from './rosmsg-utilities.ts';
 
+/**
+ * Inserts a message keeping the array ordered by log time. Appending is the
+ * fast path; progressive (coarse-to-fine) loading delivers messages out of
+ * order and falls back to a binary search for the insertion point.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function insertSorted(messages: any[], message: { logTime: bigint }): void {
+    const last = messages.at(-1) as { logTime: bigint } | undefined;
+    if (last === undefined || last.logTime <= message.logTime) {
+        messages.push(message);
+        return;
+    }
+    let low = 0;
+    let high = messages.length;
+    while (low < high) {
+        const mid = Math.floor((low + high) / 2);
+        const midMessage = messages[mid] as { logTime: bigint };
+        if (midMessage.logTime <= message.logTime) low = mid + 1;
+        else high = mid;
+    }
+    messages.splice(low, 0, message);
+}
+
 export function useRosmsgPreview(): {
     isReaderReady: Ref<boolean, boolean>;
     readerError: Ref<string | null, string | null>;
@@ -20,7 +43,12 @@ export function useRosmsgPreview(): {
     ) => Promise<void>;
     fetchTopicMessages: (
         topicName: string,
-        options?: { limit?: number; append?: boolean; stride?: number },
+        options?: {
+            limit?: number;
+            append?: boolean;
+            stride?: number;
+            progressive?: boolean;
+        },
     ) => Promise<void>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     formatPayload: (data: any) => string;
@@ -107,7 +135,12 @@ export function useRosmsgPreview(): {
      */
     async function fetchTopicMessages(
         topicName: string,
-        options?: { limit?: number; append?: boolean; stride?: number },
+        options?: {
+            limit?: number;
+            append?: boolean;
+            stride?: number;
+            progressive?: boolean;
+        },
     ): Promise<void> {
         if (!strategy.value) return;
 
@@ -123,6 +156,7 @@ export function useRosmsgPreview(): {
         const limit = options?.limit ?? 10;
         const append = options?.append ?? false;
         const stride = options?.stride ?? 1;
+        const progressive = options?.progressive ?? false;
 
         let startTime: bigint | undefined;
 
@@ -150,11 +184,14 @@ export function useRosmsgPreview(): {
                 (message) => {
                     if (controller.signal.aborted) return;
                     // Use markRaw to prevent deep reactivity overhead
-                    (topicPreviews[topicName] ??= []).push(markRaw(message));
+                    insertSorted(
+                        (topicPreviews[topicName] ??= []),
+                        markRaw(message),
+                    );
                 },
                 controller.signal,
                 startTime,
-                stride,
+                { stride, progressive },
             );
         } catch (error: unknown) {
             if (controller.signal.aborted) return; // Ignore abort errors

--- a/frontend/src/composables/use-rosmsg-preview.ts
+++ b/frontend/src/composables/use-rosmsg-preview.ts
@@ -20,7 +20,7 @@ export function useRosmsgPreview(): {
     ) => Promise<void>;
     fetchTopicMessages: (
         topicName: string,
-        options?: { limit?: number; append?: boolean },
+        options?: { limit?: number; append?: boolean; stride?: number },
     ) => Promise<void>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     formatPayload: (data: any) => string;
@@ -107,7 +107,7 @@ export function useRosmsgPreview(): {
      */
     async function fetchTopicMessages(
         topicName: string,
-        options?: { limit?: number; append?: boolean },
+        options?: { limit?: number; append?: boolean; stride?: number },
     ): Promise<void> {
         if (!strategy.value) return;
 
@@ -122,6 +122,7 @@ export function useRosmsgPreview(): {
 
         const limit = options?.limit ?? 10;
         const append = options?.append ?? false;
+        const stride = options?.stride ?? 1;
 
         let startTime: bigint | undefined;
 
@@ -153,6 +154,7 @@ export function useRosmsgPreview(): {
                 },
                 controller.signal,
                 startTime,
+                stride,
             );
         } catch (error: unknown) {
             if (controller.signal.aborted) return; // Ignore abort errors

--- a/frontend/src/composables/use-rosmsg-preview.ts
+++ b/frontend/src/composables/use-rosmsg-preview.ts
@@ -30,8 +30,12 @@ export interface FetchOptions {
  * fast path; progressive (coarse-to-fine) loading delivers messages out of
  * order and falls back to a binary search for the insertion point.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function insertSorted(messages: any[], message: { logTime: bigint }): void {
+function insertSorted(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    messages: any[],
+    message: { logTime: bigint },
+    dedupeByTime: boolean,
+): void {
     const last = messages.at(-1) as { logTime: bigint } | undefined;
     if (last === undefined || last.logTime < message.logTime) {
         messages.push(message);
@@ -45,9 +49,13 @@ function insertSorted(messages: any[], message: { logTime: bigint }): void {
         if (midMessage.logTime < message.logTime) low = mid + 1;
         else high = mid;
     }
-    // Ignore exact duplicates (same log time) when merging refinements
-    const existing = messages[low] as { logTime: bigint } | undefined;
-    if (existing?.logTime === message.logTime) return;
+    // When merging a refinement, a message with the same log time is one
+    // that was loaded before; distinct records with equal timestamps are
+    // kept during ordinary loads.
+    if (dedupeByTime) {
+        const existing = messages[low] as { logTime: bigint } | undefined;
+        if (existing?.logTime === message.logTime) return;
+    }
     messages.splice(low, 0, message);
 }
 
@@ -214,6 +222,7 @@ export function useRosmsgPreview(): {
                     insertSorted(
                         (topicPreviews[topicName] ??= []),
                         markRaw(message),
+                        merge,
                     );
                 },
                 controller.signal,

--- a/frontend/src/services/decoding-strategies/db3-strategy.ts
+++ b/frontend/src/services/decoding-strategies/db3-strategy.ts
@@ -40,7 +40,9 @@ export class Db3Strategy extends DecodingStrategy {
 
                 if (name && row_data) {
                     try {
-                        const parsedDefs = parseMessageDefer(row_data);
+                        const parsedDefs = parseMessageDefer(row_data, {
+                            ros2: true,
+                        });
                         this.definitions.set(name, parsedDefs);
                     } catch (error) {
                         console.warn(
@@ -62,8 +64,10 @@ export class Db3Strategy extends DecodingStrategy {
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         startTime?: bigint,
+        stride = 1,
     ): Promise<LogMessage[]> {
         if (!this.db) return [];
+        const keepEvery = Math.max(1, Math.floor(stride));
 
         // Find topic_id
         const topicStmt = this.db.prepare(
@@ -117,13 +121,16 @@ export class Db3Strategy extends DecodingStrategy {
             query += ` AND timestamp >= ${startTime}`;
         }
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        query += ` ORDER BY timestamp ASC LIMIT ${limit}`;
+        query += ` ORDER BY timestamp ASC LIMIT ${limit * keepEvery}`;
 
         const stmt = this.db.prepare(query);
         const msgs: LogMessage[] = [];
+        let seen = 0;
 
         while (stmt.step()) {
             if (signal?.aborted) break;
+            if (msgs.length >= limit) break;
+            if (seen++ % keepEvery !== 0) continue;
             const row = stmt.getAsObject();
             const timestamp = BigInt(row.timestamp_str as string);
             let data = row.data as Uint8Array;
@@ -173,7 +180,9 @@ export class Db3Strategy extends DecodingStrategy {
 
         if (!defs && STANDARD_ROS2_DEFINITIONS[type]) {
             try {
-                defs = parseMessageDefer(STANDARD_ROS2_DEFINITIONS[type]);
+                defs = parseMessageDefer(STANDARD_ROS2_DEFINITIONS[type], {
+                    ros2: true,
+                });
                 this.definitions.set(type, defs);
             } catch (error) {
                 console.warn(

--- a/frontend/src/services/decoding-strategies/db3-strategy.ts
+++ b/frontend/src/services/decoding-strategies/db3-strategy.ts
@@ -6,7 +6,11 @@ import * as fzstd from 'fzstd';
 import lz4js from 'lz4js';
 import initSqlJs, { Database } from 'sql.js';
 import { DecodingStrategy } from './index';
-import { LogMessage, STANDARD_ROS2_DEFINITIONS } from './utilities';
+import {
+    LogMessage,
+    ReadOptions,
+    STANDARD_ROS2_DEFINITIONS,
+} from './utilities';
 
 export class Db3Strategy extends DecodingStrategy {
     private db: Database | null = null;
@@ -64,10 +68,10 @@ export class Db3Strategy extends DecodingStrategy {
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         startTime?: bigint,
-        stride = 1,
+        options: ReadOptions = {},
     ): Promise<LogMessage[]> {
         if (!this.db) return [];
-        const keepEvery = Math.max(1, Math.floor(stride));
+        const keepEvery = Math.max(1, Math.floor(options.stride ?? 1));
 
         // Find topic_id
         const topicStmt = this.db.prepare(

--- a/frontend/src/services/decoding-strategies/image-decoders.ts
+++ b/frontend/src/services/decoding-strategies/image-decoders.ts
@@ -5,6 +5,7 @@ export function renderCompressed(
     bytes: Uint8Array,
     canvas: HTMLCanvasElement,
     onRender?: () => void,
+    onError?: (error: Error) => void,
 ): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const blob = new Blob([bytes as any]);
@@ -30,6 +31,11 @@ export function renderCompressed(
     img.onerror = (): void => {
         URL.revokeObjectURL(url);
         console.error('Failed to decode compressed image blob');
+        onError?.(
+            new Error(
+                'The browser could not decode this compressed image (unsupported or corrupt format)',
+            ),
+        );
     };
 
     img.src = url;

--- a/frontend/src/services/decoding-strategies/image-utilities.ts
+++ b/frontend/src/services/decoding-strategies/image-utilities.ts
@@ -25,11 +25,25 @@ import {
  * Renders a ROS message directly onto a specific HTML Canvas.
  // eslint-disable-next-line complexity
  */
-// eslint-disable-next-line complexity
+
+/**
+ * Formats of sensor_msgs/CompressedImage that are video codec packets rather
+ * than self-contained pictures. A single packet cannot be decoded without
+ * the surrounding stream, so the preview reports them as unsupported.
+ */
+const VIDEO_STREAM_FORMATS = ['h264', 'h265', 'hevc', 'av1', 'vp8', 'vp9'];
+
+export const isVideoStreamFormat = (format: string | undefined): boolean => {
+    if (!format) return false;
+    const lower = format.toLowerCase();
+    return VIDEO_STREAM_FORMATS.some((codec) => lower.includes(codec));
+};
+
 export function renderMessageToCanvas(
     message: RosImageMessage,
     canvas: HTMLCanvasElement,
     onRender?: () => void,
+    onError?: (error: Error) => void,
 ): void {
     const context = canvas.getContext('2d', {
         alpha: false,
@@ -49,9 +63,14 @@ export function renderMessageToCanvas(
         (!message.encoding && !message.width && !message.height);
 
     if (isCompressed) {
+        if (isVideoStreamFormat(message.format)) {
+            throw new Error(
+                `This topic is a ${message.format ?? 'video'} stream. Single video packets cannot be shown as images; the preview supports JPEG/PNG compressed and raw images.`,
+            );
+        }
         // We cannot calculate scale yet because we don't know the dimensions.
         // Pass the canvas element directly to resize it after load.
-        renderCompressed(context, bytes, canvas, onRender);
+        renderCompressed(context, bytes, canvas, onRender, onError);
         return;
     }
 

--- a/frontend/src/services/decoding-strategies/index.ts
+++ b/frontend/src/services/decoding-strategies/index.ts
@@ -9,6 +9,11 @@ export abstract class DecodingStrategy {
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         startTime?: bigint,
+        /**
+         * Keep only every n-th message of the topic (1 = keep all). Used to
+         * bound memory and decoding work for very high-rate topics.
+         */
+        stride?: number,
     ): Promise<LogMessage[]>;
 
     getSchema(): string | null {

--- a/frontend/src/services/decoding-strategies/index.ts
+++ b/frontend/src/services/decoding-strategies/index.ts
@@ -1,5 +1,5 @@
 import { UniversalHttpReader } from '@kleinkram/shared';
-import { LogMessage } from './utilities';
+import { LogMessage, ReadOptions } from './utilities';
 
 export abstract class DecodingStrategy {
     abstract init(reader: UniversalHttpReader): Promise<void>;
@@ -9,11 +9,7 @@ export abstract class DecodingStrategy {
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         startTime?: bigint,
-        /**
-         * Keep only every n-th message of the topic (1 = keep all). Used to
-         * bound memory and decoding work for very high-rate topics.
-         */
-        stride?: number,
+        options?: ReadOptions,
     ): Promise<LogMessage[]>;
 
     getSchema(): string | null {

--- a/frontend/src/services/decoding-strategies/mcap-strategy.ts
+++ b/frontend/src/services/decoding-strategies/mcap-strategy.ts
@@ -8,6 +8,14 @@ import lz4js from 'lz4js';
 import { DecodingStrategy } from './index';
 import { coarseToFineOrder, LogMessage, ReadOptions } from './utilities';
 
+/** Identity of a message record, used to drop duplicates from overlapping chunks */
+const messageIdentity = (message: {
+    logTime: bigint;
+    publishTime: bigint;
+    sequence: number;
+}): string =>
+    `${String(message.logTime)}:${String(message.publishTime)}:${String(message.sequence)}`;
+
 export class McapStrategy extends DecodingStrategy {
     private reader: McapIndexedReader | null = null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -43,6 +51,7 @@ export class McapStrategy extends DecodingStrategy {
             return this.getMessagesProgressive(
                 topic,
                 keepEvery,
+                limit,
                 onMessage,
                 signal,
                 options.skip,
@@ -121,6 +130,7 @@ export class McapStrategy extends DecodingStrategy {
     private async getMessagesProgressive(
         topic: string,
         keepEvery: number,
+        limit: number,
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         skip?: (logTime: bigint) => boolean,
@@ -128,6 +138,9 @@ export class McapStrategy extends DecodingStrategy {
     ): Promise<LogMessage[]> {
         if (!this.reader || !this.httpReader) return [];
         const reader = this.reader;
+        // Sampling positions are estimated for MCAP, so allow a little
+        // headroom before stopping hard at the requested count.
+        const hardLimit = Math.ceil(limit * 1.1) + 1;
         const httpReader = this.httpReader;
         const msgs: LogMessage[] = [];
 
@@ -153,13 +166,15 @@ export class McapStrategy extends DecodingStrategy {
                 : 1;
 
         // Adjacent chunks can overlap in time, so the same message may be
-        // yielded twice; a topic rarely has two messages with the same
-        // log time, so the log time is a sufficient identity for previews.
-        const emittedTimes = new Set<bigint>();
+        // yielded twice. Log time, publish time and sequence number
+        // together identify a message record well enough to drop only
+        // true duplicates.
+        const emitted = new Set<string>();
 
         const PREFETCH_AHEAD = 3;
         for (const [position, chunkIndex] of order.entries()) {
             if (signal?.aborted) break;
+            if (msgs.length >= hardLimit) break;
             const chunk = chunks[chunkIndex];
             if (!chunk) continue;
 
@@ -181,9 +196,11 @@ export class McapStrategy extends DecodingStrategy {
                 endTime: chunk.messageEndTime,
             })) {
                 if (signal?.aborted) break;
+                if (msgs.length >= hardLimit) break;
                 if ((chunkOffset + seen++) % keepEvery !== 0) continue;
-                if (emittedTimes.has(message.logTime)) continue;
-                emittedTimes.add(message.logTime);
+                const key = messageIdentity(message);
+                if (emitted.has(key)) continue;
+                emitted.add(key);
                 if (skip?.(message.logTime)) continue;
 
                 let data = message.data;

--- a/frontend/src/services/decoding-strategies/mcap-strategy.ts
+++ b/frontend/src/services/decoding-strategies/mcap-strategy.ts
@@ -34,9 +34,12 @@ export class McapStrategy extends DecodingStrategy {
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         startTime?: bigint,
+        stride = 1,
     ): Promise<LogMessage[]> {
         if (!this.reader || !this.httpReader) return [];
         const msgs: LogMessage[] = [];
+        const keepEvery = Math.max(1, Math.floor(stride));
+        let seen = 0;
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const options: any = { topics: [topic] };
@@ -82,6 +85,8 @@ export class McapStrategy extends DecodingStrategy {
         for await (const message of this.reader.readMessages(options)) {
             if (signal?.aborted) break;
             if (msgs.length >= limit) break;
+            // Skip (without decoding) messages that fall between samples
+            if (seen++ % keepEvery !== 0) continue;
             let data = message.data;
             const channel = this.reader.channelsById.get(message.channelId);
             if (channel) {
@@ -106,15 +111,22 @@ export class McapStrategy extends DecodingStrategy {
             const schema = this.reader.schemasById.get(schemaId);
             if (!schema) return;
             try {
+                const isRos1 = schema.encoding.includes('ros1');
+                // ROS 2 definitions use a different grammar (e.g. constants
+                // with negative values), so the parser must know the dialect.
                 const defs = parseMessageDefer(
                     new TextDecoder().decode(schema.data),
+                    { ros2: !isRos1 },
                 );
-                if (schema.encoding.includes('ros1'))
-                    decoder = new Ros1Reader(defs);
+                if (isRos1) decoder = new Ros1Reader(defs);
                 else if (['cdr', 'ros2msg'].includes(schema.encoding))
                     decoder = new CdrReader(defs);
                 if (decoder) this.decoders.set(schemaId, decoder);
-            } catch {
+            } catch (error) {
+                console.warn(
+                    `Failed to parse schema ${schema.name} (${schema.encoding})`,
+                    error,
+                );
                 return;
             }
         }

--- a/frontend/src/services/decoding-strategies/mcap-strategy.ts
+++ b/frontend/src/services/decoding-strategies/mcap-strategy.ts
@@ -10,11 +10,12 @@ import { coarseToFineOrder, LogMessage, ReadOptions } from './utilities';
 
 /** Identity of a message record, used to drop duplicates from overlapping chunks */
 const messageIdentity = (message: {
+    channelId: number;
     logTime: bigint;
     publishTime: bigint;
     sequence: number;
 }): string =>
-    `${String(message.logTime)}:${String(message.publishTime)}:${String(message.sequence)}`;
+    `${String(message.channelId)}:${String(message.logTime)}:${String(message.publishTime)}:${String(message.sequence)}`;
 
 export class McapStrategy extends DecodingStrategy {
     private reader: McapIndexedReader | null = null;

--- a/frontend/src/services/decoding-strategies/mcap-strategy.ts
+++ b/frontend/src/services/decoding-strategies/mcap-strategy.ts
@@ -45,6 +45,7 @@ export class McapStrategy extends DecodingStrategy {
                 keepEvery,
                 onMessage,
                 signal,
+                options.skip,
             );
         }
 
@@ -121,6 +122,7 @@ export class McapStrategy extends DecodingStrategy {
         keepEvery: number,
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
+        skip?: (logTime: bigint) => boolean,
     ): Promise<LogMessage[]> {
         if (!this.reader || !this.httpReader) return [];
         const reader = this.reader;
@@ -170,6 +172,7 @@ export class McapStrategy extends DecodingStrategy {
                 if (seen++ % keepEvery !== 0) continue;
                 if (emittedTimes.has(message.logTime)) continue;
                 emittedTimes.add(message.logTime);
+                if (skip?.(message.logTime)) continue;
 
                 let data = message.data;
                 const channel = reader.channelsById.get(message.channelId);

--- a/frontend/src/services/decoding-strategies/mcap-strategy.ts
+++ b/frontend/src/services/decoding-strategies/mcap-strategy.ts
@@ -46,6 +46,7 @@ export class McapStrategy extends DecodingStrategy {
                 onMessage,
                 signal,
                 options.skip,
+                options.totalMessages,
             );
         }
 
@@ -123,6 +124,7 @@ export class McapStrategy extends DecodingStrategy {
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         skip?: (logTime: bigint) => boolean,
+        totalMessages?: number,
     ): Promise<LogMessage[]> {
         if (!this.reader || !this.httpReader) return [];
         const reader = this.reader;
@@ -140,6 +142,15 @@ export class McapStrategy extends DecodingStrategy {
                 .some((id: number) => channelIds.has(id)),
         );
         const order = coarseToFineOrder(chunks.length);
+
+        // The chunk index does not store per-chunk message counts, so the
+        // global position of a message is estimated from the average number
+        // of messages per chunk. Sampling on that global position keeps the
+        // samples uniform even when every chunk holds a single image.
+        const averagePerChunk =
+            totalMessages !== undefined && chunks.length > 0
+                ? Math.max(1, totalMessages / chunks.length)
+                : 1;
 
         // Adjacent chunks can overlap in time, so the same message may be
         // yielded twice; a topic rarely has two messages with the same
@@ -163,13 +174,14 @@ export class McapStrategy extends DecodingStrategy {
             }
 
             let seen = 0;
+            const chunkOffset = Math.round(chunkIndex * averagePerChunk);
             for await (const message of reader.readMessages({
                 topics: [topic],
                 startTime: chunk.messageStartTime,
                 endTime: chunk.messageEndTime,
             })) {
                 if (signal?.aborted) break;
-                if (seen++ % keepEvery !== 0) continue;
+                if ((chunkOffset + seen++) % keepEvery !== 0) continue;
                 if (emittedTimes.has(message.logTime)) continue;
                 emittedTimes.add(message.logTime);
                 if (skip?.(message.logTime)) continue;

--- a/frontend/src/services/decoding-strategies/mcap-strategy.ts
+++ b/frontend/src/services/decoding-strategies/mcap-strategy.ts
@@ -6,7 +6,7 @@ import { McapIndexedReader } from '@mcap/core';
 import * as fzstd from 'fzstd';
 import lz4js from 'lz4js';
 import { DecodingStrategy } from './index';
-import { LogMessage } from './utilities';
+import { coarseToFineOrder, LogMessage, ReadOptions } from './utilities';
 
 export class McapStrategy extends DecodingStrategy {
     private reader: McapIndexedReader | null = null;
@@ -34,17 +34,27 @@ export class McapStrategy extends DecodingStrategy {
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         startTime?: bigint,
-        stride = 1,
+        options: ReadOptions = {},
     ): Promise<LogMessage[]> {
         if (!this.reader || !this.httpReader) return [];
+        const keepEvery = Math.max(1, Math.floor(options.stride ?? 1));
+
+        if (options.progressive && startTime === undefined) {
+            return this.getMessagesProgressive(
+                topic,
+                keepEvery,
+                onMessage,
+                signal,
+            );
+        }
+
         const msgs: LogMessage[] = [];
-        const keepEvery = Math.max(1, Math.floor(stride));
         let seen = 0;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const options: any = { topics: [topic] };
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (startTime !== undefined) options.startTime = startTime;
+        const readArguments: { topics: string[]; startTime?: bigint } = {
+            topics: [topic],
+        };
+        if (startTime !== undefined) readArguments.startTime = startTime;
 
         // Prefetch chunks
         // We need to access private chunkIndexes, but McapIndexedReader exposes them publicly in recent versions
@@ -81,8 +91,7 @@ export class McapStrategy extends DecodingStrategy {
             }
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        for await (const message of this.reader.readMessages(options)) {
+        for await (const message of this.reader.readMessages(readArguments)) {
             if (signal?.aborted) break;
             if (msgs.length >= limit) break;
             // Skip (without decoding) messages that fall between samples
@@ -98,6 +107,84 @@ export class McapStrategy extends DecodingStrategy {
             const messageObject = { logTime: message.logTime, data };
             if (onMessage) onMessage(messageObject);
             msgs.push(messageObject);
+        }
+        return msgs;
+    }
+
+    /**
+     * Reads the chunks containing `topic` coarse-to-fine so that the whole
+     * recording is covered early. Within each chunk only every
+     * `keepEvery`-th message is decoded.
+     */
+    private async getMessagesProgressive(
+        topic: string,
+        keepEvery: number,
+        onMessage?: (message: LogMessage) => void,
+        signal?: AbortSignal,
+    ): Promise<LogMessage[]> {
+        if (!this.reader || !this.httpReader) return [];
+        const reader = this.reader;
+        const httpReader = this.httpReader;
+        const msgs: LogMessage[] = [];
+
+        const channelIds = new Set(
+            [...reader.channelsById.values()]
+                .filter((channel) => channel.topic === topic)
+                .map((channel) => channel.id),
+        );
+        const chunks = reader.chunkIndexes.filter((chunk) =>
+            chunk.messageIndexOffsets
+                .keys()
+                .some((id: number) => channelIds.has(id)),
+        );
+        const order = coarseToFineOrder(chunks.length);
+
+        // Adjacent chunks can overlap in time, so the same message may be
+        // yielded twice; a topic rarely has two messages with the same
+        // log time, so the log time is a sufficient identity for previews.
+        const emittedTimes = new Set<bigint>();
+
+        const PREFETCH_AHEAD = 3;
+        for (const [position, chunkIndex] of order.entries()) {
+            if (signal?.aborted) break;
+            const chunk = chunks[chunkIndex];
+            if (!chunk) continue;
+
+            for (let ahead = 0; ahead < PREFETCH_AHEAD; ahead++) {
+                const upcoming = chunks[order[position + ahead] ?? -1];
+                if (upcoming) {
+                    httpReader.prefetch(
+                        upcoming.chunkStartOffset,
+                        upcoming.chunkLength,
+                    );
+                }
+            }
+
+            let seen = 0;
+            for await (const message of reader.readMessages({
+                topics: [topic],
+                startTime: chunk.messageStartTime,
+                endTime: chunk.messageEndTime,
+            })) {
+                if (signal?.aborted) break;
+                if (seen++ % keepEvery !== 0) continue;
+                if (emittedTimes.has(message.logTime)) continue;
+                emittedTimes.add(message.logTime);
+
+                let data = message.data;
+                const channel = reader.channelsById.get(message.channelId);
+                if (channel) {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    data =
+                        (await this.tryDecode(
+                            channel.schemaId,
+                            message.data,
+                        )) ?? message.data;
+                }
+                const messageObject = { logTime: message.logTime, data };
+                if (onMessage) onMessage(messageObject);
+                msgs.push(messageObject);
+            }
         }
         return msgs;
     }

--- a/frontend/src/services/decoding-strategies/rosbag-strategy.ts
+++ b/frontend/src/services/decoding-strategies/rosbag-strategy.ts
@@ -105,6 +105,17 @@ export class RosbagStrategy extends DecodingStrategy {
             );
         const order = coarseToFineOrder(chunkIndexes.length);
 
+        // Exact global position of each chunk's first message of the topic,
+        // so that sampling stays uniform across chunks of any size.
+        const chunkOffsets: number[] = [];
+        let cumulative = 0;
+        for (const { chunk } of chunkIndexes) {
+            chunkOffsets.push(cumulative);
+            for (const c of chunk.connections) {
+                if (connectionIds.has(c.conn)) cumulative += c.count;
+            }
+        }
+
         const PREFETCH_AHEAD = 3;
         for (const [position, entryIndex] of order.entries()) {
             if (signal?.aborted) break;
@@ -125,9 +136,10 @@ export class RosbagStrategy extends DecodingStrategy {
             );
 
             let seen = 0;
+            const chunkOffset = chunkOffsets[entryIndex] ?? 0;
             for (const record of records) {
                 if (signal?.aborted) break;
-                if (seen++ % keepEvery !== 0) continue;
+                if ((chunkOffset + seen++) % keepEvery !== 0) continue;
                 if (!record.data) continue;
                 const logTime = toNano(record.time);
                 if (skip?.(logTime)) continue;

--- a/frontend/src/services/decoding-strategies/rosbag-strategy.ts
+++ b/frontend/src/services/decoding-strategies/rosbag-strategy.ts
@@ -71,12 +71,14 @@ export class RosbagStrategy extends DecodingStrategy {
     private async getMessagesProgressive(
         topic: string,
         keepEvery: number,
+        limit: number,
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         skip?: (logTime: bigint) => boolean,
     ): Promise<LogMessage[]> {
         if (!this.bag || !this.httpReader) return [];
         const bag = this.bag;
+        const hardLimit = Math.ceil(limit * 1.1) + 1;
         const msgs: LogMessage[] = [];
 
         const connections = [...bag.connections.values()].filter(
@@ -119,6 +121,7 @@ export class RosbagStrategy extends DecodingStrategy {
         const PREFETCH_AHEAD = 3;
         for (const [position, entryIndex] of order.entries()) {
             if (signal?.aborted) break;
+            if (msgs.length >= hardLimit) break;
             const entry = chunkIndexes[entryIndex];
             if (!entry) continue;
 
@@ -139,6 +142,7 @@ export class RosbagStrategy extends DecodingStrategy {
             const chunkOffset = chunkOffsets[entryIndex] ?? 0;
             for (const record of records) {
                 if (signal?.aborted) break;
+                if (msgs.length >= hardLimit) break;
                 if ((chunkOffset + seen++) % keepEvery !== 0) continue;
                 if (!record.data) continue;
                 const logTime = toNano(record.time);
@@ -173,6 +177,7 @@ export class RosbagStrategy extends DecodingStrategy {
             return this.getMessagesProgressive(
                 topic,
                 keepEvery,
+                limit,
                 onMessage,
                 signal,
                 options.skip,

--- a/frontend/src/services/decoding-strategies/rosbag-strategy.ts
+++ b/frontend/src/services/decoding-strategies/rosbag-strategy.ts
@@ -73,6 +73,7 @@ export class RosbagStrategy extends DecodingStrategy {
         keepEvery: number,
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
+        skip?: (logTime: bigint) => boolean,
     ): Promise<LogMessage[]> {
         if (!this.bag || !this.httpReader) return [];
         const bag = this.bag;
@@ -128,9 +129,11 @@ export class RosbagStrategy extends DecodingStrategy {
                 if (signal?.aborted) break;
                 if (seen++ % keepEvery !== 0) continue;
                 if (!record.data) continue;
+                const logTime = toNano(record.time);
+                if (skip?.(logTime)) continue;
                 const reader = readers.get(record.conn);
                 const messageObject: LogMessage = {
-                    logTime: toNano(record.time),
+                    logTime,
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     data: reader
                         ? reader.readMessage(record.data)
@@ -160,6 +163,7 @@ export class RosbagStrategy extends DecodingStrategy {
                 keepEvery,
                 onMessage,
                 signal,
+                options.skip,
             );
         }
 

--- a/frontend/src/services/decoding-strategies/rosbag-strategy.ts
+++ b/frontend/src/services/decoding-strategies/rosbag-strategy.ts
@@ -33,9 +33,12 @@ export class RosbagStrategy extends DecodingStrategy {
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         startTime?: bigint,
+        stride = 1,
     ): Promise<LogMessage[]> {
         if (!this.bag || !this.httpReader) return [];
         const msgs: LogMessage[] = [];
+        const keepEvery = Math.max(1, Math.floor(stride));
+        let seen = 0;
 
         // eslint-disable-next-line unicorn/consistent-function-scoping
         const toNano = (t: { sec: number; nsec: number }) =>
@@ -110,6 +113,7 @@ export class RosbagStrategy extends DecodingStrategy {
         for await (const result of iterator) {
             if (signal?.aborted) break;
             if (msgs.length >= limit) break;
+            if (seen++ % keepEvery !== 0) continue;
             const messageObject = {
                 logTime: toNano(result.timestamp),
                 data: result.message,

--- a/frontend/src/services/decoding-strategies/rosbag-strategy.ts
+++ b/frontend/src/services/decoding-strategies/rosbag-strategy.ts
@@ -1,9 +1,24 @@
 import { Bag } from '@foxglove/rosbag';
+import { parse as parseMessageDefinition } from '@foxglove/rosmsg';
+import { MessageReader } from '@foxglove/rosmsg-serialization';
 import { UniversalHttpReader } from '@kleinkram/shared';
 import * as fzstd from 'fzstd';
 import lz4js from 'lz4js';
 import { DecodingStrategy } from './index';
-import { LogMessage } from './utilities';
+import { coarseToFineOrder, LogMessage, ReadOptions } from './utilities';
+
+const decompress = {
+    zstd: (buffer: Uint8Array): Uint8Array => fzstd.decompress(buffer),
+    lz4: (buffer: Uint8Array): Uint8Array => lz4js.decompress(buffer),
+};
+
+const toNano = (t: { sec: number; nsec: number }): bigint =>
+    BigInt(t.sec) * 1_000_000_000n + BigInt(t.nsec);
+
+const compareTime = (
+    a: { sec: number; nsec: number },
+    b: { sec: number; nsec: number },
+): number => (a.sec === b.sec ? a.nsec - b.nsec : a.sec - b.sec);
 
 export class RosbagStrategy extends DecodingStrategy {
     private bag: Bag | undefined = undefined;
@@ -17,14 +32,115 @@ export class RosbagStrategy extends DecodingStrategy {
                     httpReader.read(BigInt(offset), BigInt(length)),
                 size: (): number => httpReader.sizeBytes,
             },
-            {
-                decompress: {
-                    zstd: (buffer): Uint8Array => fzstd.decompress(buffer),
-                    lz4: (buffer): Uint8Array => lz4js.decompress(buffer),
-                },
-            },
+            { decompress },
         );
         await this.bag.open();
+    }
+
+    /**
+     * Byte length of a chunk record, derived from the position of the next
+     * chunk (or of the index section for the last chunk).
+     */
+    private chunkByteLength(chunkIndex: number): bigint {
+        if (!this.bag) return 0n;
+        const chunkInfos = this.bag.chunkInfos;
+        const chunk = chunkInfos[chunkIndex];
+        if (!chunk) return 0n;
+        const next = chunkInfos[chunkIndex + 1];
+        if (next) return BigInt(next.chunkPosition - chunk.chunkPosition);
+        if (this.bag.header) {
+            return BigInt(this.bag.header.indexPosition - chunk.chunkPosition);
+        }
+        return 0n;
+    }
+
+    private prefetchChunk(chunkIndex: number): void {
+        if (!this.bag || !this.httpReader) return;
+        const chunk = this.bag.chunkInfos[chunkIndex];
+        const size = this.chunkByteLength(chunkIndex);
+        if (chunk && size > 0n) {
+            this.httpReader.prefetch(BigInt(chunk.chunkPosition), size);
+        }
+    }
+
+    /**
+     * Reads the chunks containing `topic` coarse-to-fine (first, last,
+     * middle, ...) directly through the bag reader, one chunk per request,
+     * so a preview covering the whole recording appears early.
+     */
+    private async getMessagesProgressive(
+        topic: string,
+        keepEvery: number,
+        onMessage?: (message: LogMessage) => void,
+        signal?: AbortSignal,
+    ): Promise<LogMessage[]> {
+        if (!this.bag || !this.httpReader) return [];
+        const bag = this.bag;
+        const msgs: LogMessage[] = [];
+
+        const connections = [...bag.connections.values()].filter(
+            (connection) => connection.topic === topic,
+        );
+        const connectionIds = new Set(connections.map((c) => c.conn));
+        if (connectionIds.size === 0) return [];
+
+        // Lazily create one decoder per connection (same as the bag does)
+        for (const connection of connections) {
+            connection.reader ??= new MessageReader(
+                parseMessageDefinition(connection.messageDefinition),
+            );
+        }
+        const readers = new Map(
+            connections.map((connection) => [
+                connection.conn,
+                connection.reader,
+            ]),
+        );
+
+        const chunkIndexes = bag.chunkInfos
+            .map((chunk, index) => ({ chunk, index }))
+            .filter(({ chunk }) =>
+                chunk.connections.some((c) => connectionIds.has(c.conn)),
+            );
+        const order = coarseToFineOrder(chunkIndexes.length);
+
+        const PREFETCH_AHEAD = 3;
+        for (const [position, entryIndex] of order.entries()) {
+            if (signal?.aborted) break;
+            const entry = chunkIndexes[entryIndex];
+            if (!entry) continue;
+
+            for (let ahead = 0; ahead < PREFETCH_AHEAD; ahead++) {
+                const upcoming = chunkIndexes[order[position + ahead] ?? -1];
+                if (upcoming) this.prefetchChunk(upcoming.index);
+            }
+
+            const records = await bag.reader.readChunkMessages(
+                entry.chunk,
+                [...connectionIds],
+                entry.chunk.startTime,
+                entry.chunk.endTime,
+                decompress,
+            );
+
+            let seen = 0;
+            for (const record of records) {
+                if (signal?.aborted) break;
+                if (seen++ % keepEvery !== 0) continue;
+                if (!record.data) continue;
+                const reader = readers.get(record.conn);
+                const messageObject: LogMessage = {
+                    logTime: toNano(record.time),
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    data: reader
+                        ? reader.readMessage(record.data)
+                        : record.data,
+                };
+                if (onMessage) onMessage(messageObject);
+                msgs.push(messageObject);
+            }
+        }
+        return msgs;
     }
 
     async getMessages(
@@ -33,16 +149,22 @@ export class RosbagStrategy extends DecodingStrategy {
         onMessage?: (message: LogMessage) => void,
         signal?: AbortSignal,
         startTime?: bigint,
-        stride = 1,
+        options: ReadOptions = {},
     ): Promise<LogMessage[]> {
         if (!this.bag || !this.httpReader) return [];
-        const msgs: LogMessage[] = [];
-        const keepEvery = Math.max(1, Math.floor(stride));
-        let seen = 0;
+        const keepEvery = Math.max(1, Math.floor(options.stride ?? 1));
 
-        // eslint-disable-next-line unicorn/consistent-function-scoping
-        const toNano = (t: { sec: number; nsec: number }) =>
-            BigInt(t.sec) * 1_000_000_000n + BigInt(t.nsec);
+        if (options.progressive && startTime === undefined) {
+            return this.getMessagesProgressive(
+                topic,
+                keepEvery,
+                onMessage,
+                signal,
+            );
+        }
+
+        const msgs: LogMessage[] = [];
+        let seen = 0;
 
         let start: { sec: number; nsec: number } | undefined;
         if (startTime !== undefined) {
@@ -51,64 +173,25 @@ export class RosbagStrategy extends DecodingStrategy {
             start = { sec, nsec };
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const options: any = { topics: [topic] };
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (start) options.startTime = start;
+        const iteratorOptions: {
+            topics: string[];
+            start?: { sec: number; nsec: number };
+        } = { topics: [topic] };
+        if (start) iteratorOptions.start = start;
 
-        // Prefetch chunks
+        // Prefetch the first few chunks that can contain messages of interest
         const chunkInfos = this.bag.chunkInfos;
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (chunkInfos) {
-            // Helper to compare ros times
-            const compareTime = (
-                a: { sec: number; nsec: number },
-                b: { sec: number; nsec: number },
-            ) => {
-                if (a.sec !== b.sec) return a.sec - b.sec;
-                return a.nsec - b.nsec;
-            };
-
-            const relevantChunks = chunkInfos.filter(
-                (c) =>
-                    // Check if chunk overlaps with our interest
-                    // If start is set, chunk must end after it
-                    start === undefined || compareTime(c.endTime, start) >= 0,
-            );
-
-            // Prefetch the first few chunks
-            const chunksToPrefetch = relevantChunks.slice(0, 5);
-
-            for (const chunk of chunksToPrefetch) {
-                let size = 0n;
-                const index = chunkInfos.indexOf(chunk);
-
-                if (index !== -1 && index < chunkInfos.length - 1) {
-                    const nextChunk = chunkInfos[index + 1];
-                    if (nextChunk) {
-                        size = BigInt(
-                            nextChunk.chunkPosition - chunk.chunkPosition,
-                        );
-                    }
-                } else if (this.bag.header) {
-                    // Last chunk, ends at indexPosition
-                    size = BigInt(
-                        this.bag.header.indexPosition - chunk.chunkPosition,
-                    );
-                }
-
-                // If we couldn't determine size or it's suspiciously small/large, maybe default to something?
-                // But usually the above logic covers it.
-                // Note: chunkPosition includes the header, so fetching from chunkPosition with size
-                // should cover the whole chunk record + data.
-                if (size > 0n) {
-                    this.httpReader.prefetch(BigInt(chunk.chunkPosition), size);
-                }
+        let prefetched = 0;
+        for (const [index, chunk] of chunkInfos.entries()) {
+            if (prefetched >= 5) break;
+            if (start !== undefined && compareTime(chunk.endTime, start) < 0) {
+                continue;
             }
+            this.prefetchChunk(index);
+            prefetched++;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        const iterator = this.bag.messageIterator(options);
+        const iterator = this.bag.messageIterator(iteratorOptions);
 
         for await (const result of iterator) {
             if (signal?.aborted) break;

--- a/frontend/src/services/decoding-strategies/utilities.ts
+++ b/frontend/src/services/decoding-strategies/utilities.ts
@@ -4,6 +4,45 @@ export interface LogMessage {
     data: any;
 }
 
+export interface ReadOptions {
+    /** Keep only every n-th message of the topic (1 = keep all). */
+    stride?: number;
+    /**
+     * Read the file's chunks coarse-to-fine (first, last, middle, quarters,
+     * ...) instead of front-to-back, so that a preview covering the whole
+     * recording appears after the first few chunks and refines as more data
+     * streams in. Messages are then emitted out of time order.
+     */
+    progressive?: boolean;
+}
+
+/**
+ * Returns the indices 0..count-1 in a coarse-to-fine order: the two ends
+ * first, then the middle, then the quarter points, and so on. Reading
+ * chunks in this order makes partial data cover the whole time range.
+ */
+export const coarseToFineOrder = (count: number): number[] => {
+    if (count <= 0) return [];
+    if (count === 1) return [0];
+    const order: number[] = [0, count - 1];
+    const taken = new Set(order);
+    // Breadth-first bisection of the remaining intervals
+    const queue: [number, number][] = [[0, count - 1]];
+    while (queue.length > 0) {
+        const interval = queue.shift();
+        if (!interval) break;
+        const [low, high] = interval;
+        if (high - low < 2) continue;
+        const mid = Math.floor((low + high) / 2);
+        if (!taken.has(mid)) {
+            taken.add(mid);
+            order.push(mid);
+        }
+        queue.push([low, mid], [mid, high]);
+    }
+    return order;
+};
+
 export const STANDARD_ROS2_DEFINITIONS: Record<string, string> = {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     'sensor_msgs/msg/Image': `

--- a/frontend/src/services/decoding-strategies/utilities.ts
+++ b/frontend/src/services/decoding-strategies/utilities.ts
@@ -20,6 +20,12 @@ export interface ReadOptions {
      * that are in memory already are not decoded a second time.
      */
     skip?: (logTime: bigint) => boolean;
+    /**
+     * Total number of messages of the topic in the file, if known. Lets
+     * progressive reading sample uniformly across chunks even when a chunk
+     * holds only one message of the topic (typical for images).
+     */
+    totalMessages?: number;
 }
 
 /**

--- a/frontend/src/services/decoding-strategies/utilities.ts
+++ b/frontend/src/services/decoding-strategies/utilities.ts
@@ -14,6 +14,12 @@ export interface ReadOptions {
      * streams in. Messages are then emitted out of time order.
      */
     progressive?: boolean;
+    /**
+     * Messages for which this returns true are skipped before decoding.
+     * Used when refining an already loaded sampled topic, so that frames
+     * that are in memory already are not decoded a second time.
+     */
+    skip?: (logTime: bigint) => boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Page crash on odometry topics.** The odometry viewer (plus IMU, pose, point, statistics and NavSatFix) divided a bigint log-time difference by a number, which throws during render. The half-mounted tree then broke all further navigation ("Cannot read properties of null (reading 'parentNode')"). Fixed by converting to a number first.
- **NavSatFix decoded as raw bytes.** ROS 2 message definitions were parsed with the ROS 1 grammar, which rejects `NavSatStatus`'s negative constants, so decoding silently fell back to `Uint8Array` and the viewer read undefined fields. MCAP and db3 strategies now parse `ros2msg`/`cdr` schemas in ROS 2 mode.
- **High-rate topics.** Plot viewers loaded every message; `/dlio/odom_node/odom` has 116k messages at 400 Hz. A new `stride` option in the decoding strategies keeps only every n-th message so plot topics are capped at 5000 evenly spaced samples. The viewer header shows a "Sampled: every Nth message" badge.
- **Error boundary.** `message-viewer.vue` catches render errors of any viewer and falls back to the raw JSON viewer with a retry button, so a bad message can never take down the page again.
- **NavSatFix viewer rework.** OpenStreetMap track map (no new dependency: tiles + SVG overlay, zoom/pan/fit), start/end markers, track length, altitude chart, fix status summary, GNSS service decoding. Samples without a fix (all-zero or invalid coordinates, zero altitude) are excluded and counted in a badge.

## Test plan
- [ ] Open `/dlio/odom_node/odom` on the 2 GB dlidar mcap: charts render, no console error, header shows the sampling badge, navigation afterwards works.
- [ ] Open `/navsatfix` on the swiftnav mcap: map with the track, altitude chart, status badges. Zero-position messages are not plotted.
- [ ] Open an IMU or pose topic: duration badge shows seconds instead of crashing.
- [ ] Break a viewer on purpose (or open a malformed topic): the orange fallback banner appears and the page stays navigable.
- [ ] Log/string/image previews behave as before (no sampling badge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXQGxpkpiP2DL3T3cyQDoD