### PR TITLE
feat(frontend): mobile design for all pages

### DIFF
--- a/frontend/src/components/actions/action-configuration.vue
+++ b/frontend/src/components/actions/action-configuration.vue
@@ -2,19 +2,19 @@
     <q-drawer
         v-model="_open"
         side="right"
-        :width="1000"
+        :width="$q.screen.lt.md ? $q.screen.width : 1000"
         style="bottom: 0 !important"
         bordered
-        behavior="desktop"
+        :behavior="$q.screen.lt.md ? 'mobile' : 'desktop'"
     >
         <div class="q-pa-lg flex row justify-between" style="height: 84px">
-            <h3 class="text-h4 q-ma-none">
+            <h3 class="q-ma-none" :class="$q.screen.xs ? 'text-h5' : 'text-h4'">
                 {{ selectedTemplate ? 'Configure Action' : 'Create Action' }}
             </h3>
             <q-btn
                 flat
                 dense
-                padding="6px"
+                :padding="$q.screen.xs ? '10px' : '6px'"
                 class="button-border"
                 icon="sym_o_close"
                 @click="closeDrawer"
@@ -23,7 +23,7 @@
 
         <q-separator />
 
-        <div class="q-pa-lg">
+        <div :class="$q.screen.xs ? 'q-pa-md' : 'q-pa-lg'">
             <span class="help-text">
                 Actions are used to verify mission data or to generate derived
                 files.
@@ -160,7 +160,7 @@
                     Compute Resources
                 </span>
                 <div style="margin-top: 16px" class="row q-col-gutter-sm">
-                    <div class="col-6">
+                    <div class="col-12 col-sm-6">
                         <label for="memory">Memory Allocation (GB)</label>
                         <q-input
                             v-model="editingTemplate.cpuMemory"
@@ -171,7 +171,7 @@
                             dense
                         />
                     </div>
-                    <div class="col-6">
+                    <div class="col-12 col-sm-6">
                         <label for="cpu">CPU Core Allocation</label>
                         <q-input
                             v-model="editingTemplate.cpuCores"
@@ -182,7 +182,7 @@
                             dense
                         />
                     </div>
-                    <div class="col-6">
+                    <div class="col-12 col-sm-6">
                         <label for="gpu">GPU Memory (-1 for no GPU)</label>
                         <q-input
                             v-if="editingTemplate"
@@ -195,7 +195,7 @@
                             dense
                         />
                     </div>
-                    <div class="col-6">
+                    <div class="col-12 col-sm-6">
                         <label for="maxRuntime">Max Runtime (h)</label>
                         <q-input
                             v-if="editingTemplate"

--- a/frontend/src/components/actions/action-definition-drawer.vue
+++ b/frontend/src/components/actions/action-definition-drawer.vue
@@ -2,16 +2,16 @@
     <q-drawer
         v-model="_open"
         side="right"
-        :width="800"
+        :width="$q.screen.lt.md ? $q.screen.width : 800"
         style="bottom: 0 !important"
         bordered
-        behavior="desktop"
+        :behavior="$q.screen.lt.md ? 'mobile' : 'desktop'"
     >
         <div
             class="q-pa-lg flex row justify-between items-center"
             style="height: 84px"
         >
-            <h3 class="text-h4 q-ma-none">
+            <h3 class="q-ma-none" :class="$q.screen.xs ? 'text-h5' : 'text-h4'">
                 {{
                     mode === ActionDrawerMode.ACTION_RESTORE
                         ? 'Restore Action Template Version'
@@ -23,7 +23,7 @@
             <q-btn
                 flat
                 dense
-                padding="6px"
+                :padding="$q.screen.xs ? '10px' : '6px'"
                 class="button-border"
                 icon="sym_o_close"
                 @click="closeDrawer"
@@ -32,7 +32,7 @@
 
         <q-separator />
 
-        <div class="q-pa-lg">
+        <div :class="$q.screen.xs ? 'q-pa-md' : 'q-pa-lg'">
             <span class="help-text">
                 Define the technical specifications for an action. These
                 settings serve as the blueprint for future executions.

--- a/frontend/src/components/actions/action-details-execution-tab.vue
+++ b/frontend/src/components/actions/action-details-execution-tab.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="q-pa-md">
+    <div :class="$q.screen.xs ? 'q-py-md' : 'q-pa-md'">
         <div class="row q-col-gutter-md">
             <!-- State Info -->
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput label="State" :model-value="action.state" readonly>
                     <template
                         v-if="
@@ -15,7 +15,7 @@
                     </template>
                 </AppInput>
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="State Reason"
                     :model-value="action.stateCause || 'N/A'"
@@ -24,7 +24,7 @@
             </div>
 
             <!-- Execution Info -->
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <template
                     v-if="action.triggerSource === ActionTriggerSource.MANUAL"
                 >
@@ -55,7 +55,7 @@
                     </AppInput>
                 </template>
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Submitted At"
                     :model-value="
@@ -64,7 +64,7 @@
                     readonly
                 />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Last Updated At"
                     :model-value="
@@ -73,10 +73,10 @@
                     readonly
                 />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <ActionRuntime :action="action" />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Project / Mission"
                     :model-value="`${action.mission?.project?.name} / ${action.mission?.name}`"
@@ -141,7 +141,7 @@
             <!-- Technical Details -->
             <div class="col-12 text-h6">Technical Details</div>
 
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Docker Image"
                     :model-value="action.template.imageName"
@@ -162,7 +162,7 @@
                 </AppInput>
             </div>
 
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Image ID"
                     :model-value="action.image.sha || 'N/A'"
@@ -194,7 +194,7 @@
                     </template>
                 </AppInput>
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Image Source"
                     :model-value="
@@ -302,7 +302,7 @@
                 </AppInput>
             </div>
 
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Repo Digest"
                     :model-value="action.image.repoDigests?.[0] || 'N/A'"
@@ -335,14 +335,14 @@
                 </AppInput>
             </div>
 
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Runner CPU Model"
                     :model-value="action.worker?.cpuModel || 'N/A'"
                     readonly
                 />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Runner Hostname"
                     :model-value="action.worker?.hostname || 'N/A'"

--- a/frontend/src/components/actions/action-details-resources-tab.vue
+++ b/frontend/src/components/actions/action-details-resources-tab.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="q-pa-md">
+    <div :class="$q.screen.xs ? 'q-py-md' : 'q-pa-md'">
         <div class="row q-col-gutter-md">
             <!-- Summary Cards -->
             <div class="col-12 col-md-4">
@@ -332,6 +332,13 @@ const cpuChartOption = computed(() => {
 .chart {
     height: 300px;
     width: 100%;
+}
+
+/* Charts are unreadable when they keep their desktop height on a phone */
+@media (max-width: 599px) {
+    .chart {
+        height: 220px;
+    }
 }
 .my-card {
     height: 100%;

--- a/frontend/src/components/actions/action-details-template-tab.vue
+++ b/frontend/src/components/actions/action-details-template-tab.vue
@@ -1,28 +1,28 @@
 <template>
-    <div class="q-pa-md">
+    <div :class="$q.screen.xs ? 'q-py-md' : 'q-pa-md'">
         <div class="row q-col-gutter-md">
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Template Name"
                     :model-value="template.name"
                     readonly
                 />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Version"
                     :model-value="template.version"
                     readonly
                 />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Creator"
                     :model-value="template.creator?.name || 'N/A'"
                     readonly
                 />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Created At"
                     :model-value="formatDate(template.createdAt)"
@@ -30,7 +30,7 @@
                 />
             </div>
 
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Docker Image"
                     :model-value="template.imageName"
@@ -50,21 +50,21 @@
                     </template>
                 </AppInput>
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Command"
                     :model-value="template.command || 'Default'"
                     readonly
                 />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Entrypoint"
                     :model-value="template.entrypoint || 'Default'"
                     readonly
                 />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     label="Access Rights"
                     :model-value="

--- a/frontend/src/components/actions/action-executions.vue
+++ b/frontend/src/components/actions/action-executions.vue
@@ -1,25 +1,44 @@
 <template>
     <div class="column q-gutter-y-md">
-        <div class="flex justify-between items-center">
-            <div class="row q-gutter-x-md items-center">
+        <!--
+            Below `md` the filters do not fit next to each other, so they stack
+            into a single full width column.
+        -->
+        <div
+            :class="
+                $q.screen.lt.md
+                    ? 'column q-gutter-y-sm'
+                    : 'flex justify-between items-center'
+            "
+        >
+            <div
+                :class="
+                    $q.screen.lt.md
+                        ? 'column q-gutter-y-sm'
+                        : 'row q-gutter-x-md items-center'
+                "
+            >
                 <ScopeSelector
-                    layout="row"
+                    :layout="$q.screen.lt.md ? 'column' : 'row'"
                     mode="filter"
                     :show-labels="false"
                     project-placeholder="All Projects"
                     mission-placeholder="All Missions"
-                    select-width="220px"
+                    :select-width="$q.screen.lt.md ? undefined : '220px'"
                     bg-color="transparent"
                 />
 
                 <AppSearchBar
                     v-model="searchName"
                     placeholder="Filter by Action Name"
-                    style="min-width: 200px"
+                    :style="$q.screen.lt.md ? undefined : 'min-width: 200px'"
                 />
             </div>
 
-            <app-refresh-button @click="refetchData" />
+            <app-refresh-button
+                :class="$q.screen.lt.md ? 'self-end' : ''"
+                @click="refetchData"
+            />
         </div>
 
         <ActionsTable :handler="handler" />

--- a/frontend/src/components/actions/action-launch-drawer.vue
+++ b/frontend/src/components/actions/action-launch-drawer.vue
@@ -2,10 +2,10 @@
     <q-drawer
         v-model="_open"
         side="right"
-        :width="1000"
+        :width="$q.screen.lt.md ? $q.screen.width : 1000"
         style="bottom: 0 !important"
         bordered
-        behavior="desktop"
+        :behavior="$q.screen.lt.md ? 'mobile' : 'desktop'"
     >
         <DrawerHeader
             title="Launch Action"
@@ -17,7 +17,7 @@
 
         <q-separator />
 
-        <div class="q-pa-lg">
+        <div :class="$q.screen.xs ? 'q-pa-md' : 'q-pa-lg'">
             <InfoBanner
                 text="Need a different action configuration?"
                 button-label="Create New Action"

--- a/frontend/src/components/actions/action-revisions-drawer.vue
+++ b/frontend/src/components/actions/action-revisions-drawer.vue
@@ -2,20 +2,22 @@
     <q-drawer
         v-model="_open"
         side="right"
-        :width="500"
+        :width="$q.screen.lt.md ? $q.screen.width : 500"
         bordered
-        behavior="desktop"
+        :behavior="$q.screen.lt.md ? 'mobile' : 'desktop'"
         overlay
     >
         <div
             class="q-pa-lg flex row justify-between items-center"
             style="height: 84px"
         >
-            <h3 class="text-h4 q-ma-none">Version History</h3>
+            <h3 class="q-ma-none" :class="$q.screen.xs ? 'text-h5' : 'text-h4'">
+                Version History
+            </h3>
             <q-btn
                 flat
                 dense
-                padding="6px"
+                :padding="$q.screen.xs ? '10px' : '6px'"
                 class="button-border"
                 icon="sym_o_close"
                 @click="closeDrawer"
@@ -68,7 +70,7 @@
                             {{ ver.description }}
                         </div>
                         <q-separator class="q-my-xs" />
-                        <div>
+                        <div class="version-image">
                             <code>{{ ver.imageName }}</code>
                         </div>
                     </div>
@@ -87,7 +89,7 @@
                     >
                         <q-btn
                             outline
-                            size="sm"
+                            :size="$q.screen.xs ? 'md' : 'sm'"
                             color="primary"
                             label="Restore this version"
                             icon="sym_o_restore"
@@ -144,3 +146,10 @@ const closeDrawer = (): void => {
     _open.value = false;
 };
 </script>
+
+<style scoped>
+/* Image names are long and unbreakable; they must not widen the drawer */
+.version-image code {
+    overflow-wrap: anywhere;
+}
+</style>

--- a/frontend/src/components/actions/action-store.vue
+++ b/frontend/src/components/actions/action-store.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="h-full column">
-        <div class="flex justify-between items-center q-mb-lg">
+        <div class="flex justify-between items-center q-mb-lg store-toolbar">
             <ButtonGroup>
                 <q-toggle
                     v-model="showArchived"
@@ -12,7 +12,7 @@
                 />
             </ButtonGroup>
 
-            <ButtonGroup>
+            <ButtonGroup class="store-toolbar__actions">
                 <app-search-bar
                     ref="searchInput"
                     v-model="searchTerm"
@@ -54,7 +54,7 @@
                         :key="col.name"
                         :props="props"
                     >
-                        <div class="row items-center full-width">
+                        <div class="row items-center full-width template-row">
                             <q-avatar
                                 :color="
                                     props.row.archived ? 'grey-4' : 'grey-2'
@@ -66,8 +66,10 @@
                                 class="q-mr-md"
                             />
 
-                            <div class="column">
-                                <div class="text-weight-bold">
+                            <div class="column template-row__info">
+                                <div
+                                    class="text-weight-bold template-row__name"
+                                >
                                     {{ props.row.name }}
                                     <q-badge
                                         v-if="props.row.archived"
@@ -108,13 +110,16 @@
                                 </span>
                             </div>
 
-                            <div class="row q-gutter-x-sm">
+                            <div
+                                class="row q-gutter-x-sm template-row__actions"
+                            >
                                 <q-btn
                                     flat
                                     round
-                                    dense
+                                    :dense="!$q.screen.xs"
                                     icon="sym_o_history"
                                     color="grey-7"
+                                    aria-label="Version history"
                                     @click.stop="
                                         () => handleRevisions(props.row)
                                     "
@@ -124,9 +129,10 @@
                                 <q-btn
                                     flat
                                     round
-                                    dense
+                                    :dense="!$q.screen.xs"
                                     icon="sym_o_edit"
                                     color="grey-7"
+                                    aria-label="Edit action template"
                                     @click.stop="() => handleEdit(props.row)"
                                 >
                                     <q-tooltip>Edit</q-tooltip>
@@ -135,9 +141,10 @@
                                     v-if="!props.row.archived"
                                     flat
                                     round
-                                    dense
+                                    :dense="!$q.screen.xs"
                                     icon="sym_o_play_arrow"
                                     color="primary"
+                                    aria-label="Launch action"
                                     @click.stop="() => handleSelect(props.row)"
                                 >
                                     <q-tooltip>Launch</q-tooltip>
@@ -146,9 +153,10 @@
                                     v-if="!props.row.archived"
                                     flat
                                     round
-                                    dense
+                                    :dense="!$q.screen.xs"
                                     icon="sym_o_delete"
                                     color="negative"
+                                    aria-label="Delete action template"
                                     @click.stop="() => confirmDelete(props.row)"
                                 >
                                     <q-tooltip>Delete</q-tooltip>
@@ -384,3 +392,42 @@ const confirmDelete = (template: ActionTemplateDto): void => {
     });
 };
 </script>
+
+<style scoped>
+.template-row__info {
+    min-width: 0;
+}
+
+/*
+ * On phones the row turns into two lines: the template on the first one and
+ * the row actions, with comfortable touch targets, below it.
+ */
+@media (max-width: 599px) {
+    .template-row {
+        flex-wrap: wrap;
+    }
+
+    .template-row__name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .template-row__actions {
+        width: 100%;
+        justify-content: flex-end;
+        margin-top: 4px;
+    }
+
+    .store-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+
+    .store-toolbar__actions .app-search-bar {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+}
+</style>

--- a/frontend/src/components/actions/action-triggers.vue
+++ b/frontend/src/components/actions/action-triggers.vue
@@ -1,12 +1,21 @@
 <template>
     <div class="column q-gutter-y-md">
-        <div class="flex justify-between items-center">
+        <div
+            :class="
+                $q.screen.xs
+                    ? 'column q-gutter-y-sm'
+                    : 'flex justify-between items-center'
+            "
+        >
             <AppSearchBar
                 v-model="searchTerm"
                 placeholder="Search Action Triggers..."
-                style="min-width: 300px"
+                :style="$q.screen.xs ? undefined : 'min-width: 300px'"
             />
-            <div class="row q-gutter-x-sm">
+            <div
+                class="row q-gutter-x-sm"
+                :class="$q.screen.xs ? 'justify-end' : ''"
+            >
                 <AppRefreshButton @click="loadTriggers" />
                 <AppCreateButton
                     label="New Trigger"
@@ -23,6 +32,8 @@
             v-else-if="filteredTriggers.length > 0"
             :rows="filteredTriggers"
             :columns="columns"
+            :visible-columns="visibleColumns"
+            :grid="$q.screen.xs"
             row-key="uuid"
             flat
             bordered
@@ -30,6 +41,96 @@
             class="bg-white"
             :pagination="{ rowsPerPage: 20 }"
         >
+            <!-- Phones get a tappable card per trigger instead of a table -->
+            <template #item="itemProps">
+                <div class="col-12 q-pa-xs">
+                    <q-card flat bordered>
+                        <q-card-section class="row items-start no-wrap q-pb-xs">
+                            <q-icon
+                                :name="getTypeIcon(itemProps.row.type)"
+                                size="sm"
+                                class="q-mr-md q-mt-xs text-grey-7"
+                            />
+                            <div class="col" style="min-width: 0">
+                                <div class="text-weight-bold ellipsis">
+                                    {{ itemProps.row.name }}
+                                </div>
+                                <div class="text-caption text-grey-7">
+                                    {{ itemProps.row.description }}
+                                </div>
+                                <div
+                                    class="row items-center q-gutter-x-sm q-mt-xs"
+                                >
+                                    <q-badge
+                                        color="grey-3"
+                                        text-color="grey-9"
+                                        :label="itemProps.row.type"
+                                    />
+                                    <span
+                                        class="text-caption text-grey-7 ellipsis"
+                                    >
+                                        {{
+                                            itemProps.row.templateName ||
+                                            itemProps.row.templateUuid
+                                        }}
+                                    </span>
+                                </div>
+                            </div>
+                        </q-card-section>
+
+                        <q-card-actions align="right">
+                            <q-btn
+                                flat
+                                round
+                                icon="sym_o_edit"
+                                color="grey-7"
+                                aria-label="Edit trigger"
+                                :disable="
+                                    itemProps.row.creatorUuid !==
+                                    currentUser?.uuid
+                                "
+                                @click="() => editTrigger(itemProps.row)"
+                            >
+                                <q-tooltip
+                                    v-if="
+                                        itemProps.row.creatorUuid ===
+                                        currentUser?.uuid
+                                    "
+                                    >Edit</q-tooltip
+                                >
+                                <q-tooltip v-else
+                                    >Only the creator can edit this
+                                    trigger</q-tooltip
+                                >
+                            </q-btn>
+                            <q-btn
+                                flat
+                                round
+                                icon="sym_o_delete"
+                                color="negative"
+                                aria-label="Delete trigger"
+                                :disable="
+                                    itemProps.row.creatorUuid !==
+                                    currentUser?.uuid
+                                "
+                                @click="() => confirmDelete(itemProps.row)"
+                            >
+                                <q-tooltip
+                                    v-if="
+                                        itemProps.row.creatorUuid ===
+                                        currentUser?.uuid
+                                    "
+                                    >Delete</q-tooltip
+                                >
+                                <q-tooltip v-else
+                                    >Only the creator can delete this
+                                    trigger</q-tooltip
+                                >
+                            </q-btn>
+                        </q-card-actions>
+                    </q-card>
+                </div>
+            </template>
             <template #body="props">
                 <q-tr :props="props">
                     <q-td key="name" :props="props">
@@ -49,7 +150,7 @@
                             </div>
                         </div>
                     </q-td>
-                    <q-td key="type" :props="props">
+                    <q-td v-if="!$q.screen.lt.md" key="type" :props="props">
                         <q-badge
                             color="grey-3"
                             text-color="grey-9"
@@ -61,7 +162,7 @@
                             props.row.templateName || props.row.templateUuid
                         }}</span>
                     </q-td>
-                    <q-td key="creator" :props="props">
+                    <q-td v-if="!$q.screen.lt.md" key="creator" :props="props">
                         <span class="text-grey-8">{{
                             props.row.creatorName || props.row.creatorUuid
                         }}</span>
@@ -186,6 +287,16 @@ const columns: QTableColumn[] = [
     { name: 'creator', label: 'Creator', field: 'creatorName', align: 'left' },
     { name: 'actions', label: '', field: 'actions', align: 'right' },
 ];
+
+/**
+ * Type and creator are dropped below `md`; the type is shown as a badge in
+ * the phone card layout instead.
+ */
+const visibleColumns = computed(() =>
+    $q.screen.lt.md
+        ? ['name', 'template', 'actions']
+        : columns.map((column) => column.name),
+);
 
 // Computed
 const filteredTriggers = computed(() => {

--- a/frontend/src/components/actions/actions-table.vue
+++ b/frontend/src/components/actions/actions-table.vue
@@ -4,6 +4,8 @@
         v-model:pagination="pagination"
         :rows="data"
         :columns="columns as any"
+        :visible-columns="visibleColumns"
+        :grid="$q.screen.xs"
         :rows-per-page-options="[10, 20, 50, 100]"
         row-key="uuid"
         :loading="isLoading"
@@ -13,6 +15,172 @@
         @row-click="handleRowClick"
         @request="setPagination"
     >
+        <!--
+            In card (grid) mode the column headers are gone, so sorting gets
+            its own control on top of the list.
+        -->
+        <template v-if="$q.screen.xs" #top>
+            <div class="row full-width items-center no-wrap q-gutter-x-sm">
+                <q-select
+                    v-model="mobileSortBy"
+                    :options="sortOptions"
+                    dense
+                    outlined
+                    emit-value
+                    map-options
+                    label="Sort by"
+                    class="col"
+                />
+                <q-btn
+                    flat
+                    round
+                    color="primary"
+                    :icon="
+                        pagination.descending
+                            ? 'sym_o_arrow_downward'
+                            : 'sym_o_arrow_upward'
+                    "
+                    :aria-label="
+                        pagination.descending
+                            ? 'Sorted descending, switch to ascending'
+                            : 'Sorted ascending, switch to descending'
+                    "
+                    @click="toggleSortDirection"
+                >
+                    <q-tooltip>
+                        {{ pagination.descending ? 'Descending' : 'Ascending' }}
+                    </q-tooltip>
+                </q-btn>
+            </div>
+        </template>
+
+        <template #item="itemProps">
+            <div class="col-12 q-pa-xs">
+                <q-card
+                    flat
+                    bordered
+                    class="cursor-pointer"
+                    @click="() => openAction(itemProps.row.uuid)"
+                >
+                    <q-card-section class="row items-start no-wrap q-pb-xs">
+                        <div class="col" style="min-width: 0">
+                            <div class="text-weight-medium ellipsis">
+                                {{ itemProps.row.template.name || 'N/A' }}
+                            </div>
+                            <div class="text-caption text-grey-7 ellipsis">
+                                {{ itemProps.row.mission.name || 'N/A' }}
+                            </div>
+                        </div>
+
+                        <div class="col-auto row items-center no-wrap">
+                            <template
+                                v-if="
+                                    itemProps.row.state ===
+                                        ActionState.PROCESSING ||
+                                    itemProps.row.state === ActionState.PENDING
+                                "
+                            >
+                                <q-skeleton
+                                    class="q-pa-none q-ma-none"
+                                    style="background: none"
+                                >
+                                    <q-badge
+                                        :color="
+                                            getActionColor(itemProps.row.state)
+                                        "
+                                        class="q-pa-sm"
+                                    >
+                                        {{ itemProps.row.state }}
+                                    </q-badge>
+                                </q-skeleton>
+                            </template>
+                            <template v-else>
+                                <ActionBadge :action="itemProps.row" />
+                            </template>
+
+                            <q-btn
+                                flat
+                                round
+                                icon="sym_o_more_vert"
+                                unelevated
+                                color="primary"
+                                aria-label="Action options"
+                                class="cursor-pointer q-ml-xs"
+                                @click.stop
+                            >
+                                <q-menu auto-close>
+                                    <q-list>
+                                        <q-item
+                                            v-ripple
+                                            clickable
+                                            @click="
+                                                () =>
+                                                    openAction(
+                                                        itemProps.row.uuid,
+                                                    )
+                                            "
+                                        >
+                                            <q-item-section>
+                                                View Details
+                                            </q-item-section>
+                                        </q-item>
+
+                                        <q-item
+                                            v-ripple
+                                            clickable
+                                            :disabled="
+                                                !canCancel(itemProps.row.state)
+                                            "
+                                            @click="
+                                                () =>
+                                                    handleCancel(
+                                                        itemProps.row.uuid,
+                                                    )
+                                            "
+                                        >
+                                            <q-item-section>
+                                                Cancel Action
+                                            </q-item-section>
+                                        </q-item>
+                                        <DeleteActionDialogOpener
+                                            :action="itemProps.row"
+                                        >
+                                            <q-item v-ripple clickable>
+                                                <q-item-section>
+                                                    Delete Action
+                                                </q-item-section>
+                                            </q-item>
+                                        </DeleteActionDialogOpener>
+                                    </q-list>
+                                </q-menu>
+                            </q-btn>
+                        </div>
+                    </q-card-section>
+
+                    <q-card-section class="q-pt-none text-caption text-grey-7">
+                        <div class="row items-center q-gutter-x-sm">
+                            <span>
+                                {{
+                                    itemProps.row.createdAt
+                                        ? formatDate(
+                                              itemProps.row.createdAt,
+                                              true,
+                                          )
+                                        : 'N/A'
+                                }}
+                            </span>
+                            <span v-if="itemProps.row.runtime">
+                                · {{ formatDuration(itemProps.row.runtime) }}
+                            </span>
+                        </div>
+                        <div v-if="itemProps.row.stateCause" class="ellipsis">
+                            {{ itemProps.row.stateCause }}
+                        </div>
+                    </q-card-section>
+                </q-card>
+            </div>
+        </template>
+
         <template #body-cell-state="props">
             <q-td :props="props" class="truncate-cell">
                 <template
@@ -305,13 +473,58 @@ const columns = [
     },
 ];
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const handleRowClick = async (_: Event, row: any): Promise<void> => {
+/**
+ * Columns shown below `md`. The remaining ones (docker image, state reason,
+ * creation date, submitted by) do not fit on a small screen and are dropped;
+ * the essentials stay visible.
+ */
+const COMPACT_COLUMNS = [
+    'state',
+    'template.name',
+    'mission.name',
+    'updatedAt',
+    'Details',
+];
+
+const visibleColumns = computed(() =>
+    $q.screen.lt.md ? COMPACT_COLUMNS : columns.map((column) => column.name),
+);
+
+/**
+ * In card mode (phones) the sortable column headers are not rendered, so the
+ * sort field and direction are offered as a select plus a toggle button.
+ */
+const sortOptions = [
+    { label: 'Creation Date', value: 'createdAt' },
+    { label: 'Last Update', value: 'updatedAt' },
+    { label: 'Status', value: 'state' },
+    { label: 'Action Name', value: 'template.name' },
+    { label: 'Mission', value: 'mission.name' },
+    { label: 'Duration', value: 'runtime' },
+];
+
+const mobileSortBy = computed({
+    get: () => properties.handler.sortBy,
+    set: (value: string) => {
+        properties.handler.setSort(value);
+    },
+});
+
+const toggleSortDirection = (): void => {
+    properties.handler.setDescending(!properties.handler.descending);
+};
+
+const openAction = async (uuid: string): Promise<void> => {
     await router.push({
         name: ROUTES.ANALYSIS_DETAILS.routeName,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        params: { id: row.uuid },
+        params: { id: uuid },
     });
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handleRowClick = async (_: Event, row: any): Promise<void> => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+    await openAction(row.uuid);
 };
 </script>
 

--- a/frontend/src/components/actions/artifact-file-tree.vue
+++ b/frontend/src/components/actions/artifact-file-tree.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         class="bg-grey-2 rounded-borders q-pa-sm"
-        style="max-height: 200px; overflow-y: auto"
+        style="max-height: 200px; overflow: auto"
     >
         <q-tree
             :nodes="artifactFileTree"

--- a/frontend/src/components/actions/compute-resources-fieldset.vue
+++ b/frontend/src/components/actions/compute-resources-fieldset.vue
@@ -2,7 +2,7 @@
     <div>
         <span class="text-h5">Compute Resources</span>
         <div class="row q-col-gutter-md q-mt-xs">
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     v-model.number="model.cpuMemory"
                     label="Memory (GB)"
@@ -17,7 +17,7 @@
                 </AppInput>
             </div>
 
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     v-model.number="model.cpuCores"
                     label="CPU Cores"
@@ -31,7 +31,7 @@
                 </AppInput>
             </div>
 
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <AppInput
                     v-model.number="model.maxRuntime"
                     label="Max Runtime (h)"
@@ -48,7 +48,7 @@
                 />
             </div>
 
-            <div v-if="readonly" class="col-6">
+            <div v-if="readonly" class="col-12 col-sm-6">
                 <AppInput
                     :model-value="hasGpu ? 'Enabled' : 'Disabled'"
                     label="GPU Acceleration"
@@ -56,7 +56,10 @@
                 />
             </div>
 
-            <div v-if="hasGpu || (!readonly && gpuEnabled)" class="col-6">
+            <div
+                v-if="hasGpu || (!readonly && gpuEnabled)"
+                class="col-12 col-sm-6"
+            >
                 <AppInput
                     v-model.number="model.gpuMemory"
                     label="GPU Memory (GB)"

--- a/frontend/src/components/actions/compute-resources-selector.vue
+++ b/frontend/src/components/actions/compute-resources-selector.vue
@@ -8,7 +8,7 @@
                 v-ripple
                 flat
                 bordered
-                class="col cursor-pointer transition-all"
+                class="col cursor-pointer transition-all preset-card"
                 :class="{
                     'bg-button-primary text-white':
                         selectedPreset === preset.name,
@@ -51,7 +51,7 @@
                 v-ripple
                 flat
                 bordered
-                class="col cursor-pointer transition-all"
+                class="col cursor-pointer transition-all preset-card"
                 :class="{
                     'bg-button-primary text-white': selectedPreset === 'Custom',
                     'bg-white text-grey-9': selectedPreset !== 'Custom',
@@ -89,7 +89,7 @@
             v-if="selectedPreset === 'Custom'"
             class="row q-col-gutter-md q-mt-xs"
         >
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <label>
                     Memory (GB) <span class="text-negative">*</span>
                 </label>
@@ -107,7 +107,7 @@
                     @update:model-value="updateCpuMemory"
                 />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <label> CPU Cores <span class="text-negative">*</span> </label>
                 <q-input
                     :model-value="cpuCores"
@@ -123,7 +123,7 @@
                     @update:model-value="updateCpuCores"
                 />
             </div>
-            <div class="col-6">
+            <div class="col-12 col-sm-6">
                 <label>
                     Max Runtime (h) <span class="text-negative">*</span>
                 </label>
@@ -150,7 +150,7 @@
                 />
             </div>
 
-            <div v-if="isGpuEnabled" class="col-6">
+            <div v-if="isGpuEnabled" class="col-12 col-sm-6">
                 <label>
                     GPU Memory (GB) <span class="text-negative">*</span>
                 </label>
@@ -322,6 +322,16 @@ function updateGpuMemory(value: number | string | null) {
 </script>
 
 <style scoped>
+/*
+ * Four presets side by side do not fit on a phone; they wrap into a
+ * two-column grid instead (unchanged from `sm` upwards).
+ */
+@media (max-width: 599px) {
+    .preset-card {
+        flex: 0 1 calc(50% - 16px);
+    }
+}
+
 .transition-all {
     transition: all 0.2s ease-in-out;
 }

--- a/frontend/src/components/actions/running-actions.vue
+++ b/frontend/src/components/actions/running-actions.vue
@@ -22,11 +22,75 @@
             <q-table
                 :rows="actions?.data"
                 :columns="columns as any"
+                :visible-columns="visibleColumns"
+                :grid="$q.screen.xs"
                 hide-pagination
                 flat
-                class="q-pa-md cursor-pointer"
+                class="cursor-pointer"
+                :class="$q.screen.xs ? 'q-pa-sm' : 'q-pa-md'"
                 @row-click="handleRowClick"
             >
+                <!--
+                    On phones the table becomes a compact list of cards, so the
+                    panel never scrolls sideways.
+                -->
+                <template #item="itemProps">
+                    <div class="col-12 q-pa-xs">
+                        <q-card
+                            flat
+                            bordered
+                            class="cursor-pointer"
+                            @click="() => openAction(itemProps.row.uuid)"
+                        >
+                            <q-card-section
+                                class="row items-center no-wrap q-py-sm"
+                            >
+                                <div class="col" style="min-width: 0">
+                                    <div class="text-weight-medium ellipsis">
+                                        {{ actionName(itemProps.row) }}
+                                    </div>
+                                    <div
+                                        class="text-caption text-grey-7 ellipsis"
+                                    >
+                                        {{ itemProps.row.mission.name }}
+                                    </div>
+                                </div>
+
+                                <div class="col-auto q-ml-sm">
+                                    <template
+                                        v-if="
+                                            itemProps.row.state ===
+                                                ActionState.PROCESSING ||
+                                            itemProps.row.state ===
+                                                ActionState.PENDING
+                                        "
+                                    >
+                                        <q-skeleton
+                                            class="q-pa-none q-ma-none"
+                                            style="background: none"
+                                        >
+                                            <q-badge
+                                                :color="
+                                                    getActionColor(
+                                                        itemProps.row.state,
+                                                    )
+                                                "
+                                                class="q-pa-sm"
+                                            >
+                                                {{ itemProps.row.state }}
+                                            </q-badge>
+                                        </q-skeleton>
+                                    </template>
+
+                                    <template v-else>
+                                        <ActionBadge :action="itemProps.row" />
+                                    </template>
+                                </div>
+                            </q-card-section>
+                        </q-card>
+                    </div>
+                </template>
+
                 <template #body-cell-state="props">
                     <q-td :props="props">
                         <template
@@ -74,12 +138,15 @@
 import type { ActionDto } from '@kleinkram/api-dto/types/actions/action.dto';
 import { ActionState } from '@kleinkram/shared';
 import ActionBadge from 'components/action-badge.vue';
+import { useQuasar } from 'quasar';
 import { useRunningActions } from 'src/composables/use-actions-queries';
 import ROUTES from 'src/router/routes';
 import { getActionColor } from 'src/services/generic';
+import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 
 const router = useRouter();
+const $q = useQuasar();
 
 const { data: actions, isFetched } = useRunningActions();
 
@@ -125,17 +192,36 @@ const columns = [
     },
 ];
 
+/**
+ * The docker image and the submitter do not fit on a small screen; the state,
+ * the mission and the action name are the ones worth keeping.
+ */
+const visibleColumns = computed(() =>
+    $q.screen.lt.md
+        ? ['state', 'mission', 'name']
+        : columns.map((column) => column.name),
+);
+
+const actionName = (action: ActionDto): string =>
+    action.template.name === ''
+        ? 'N/A'
+        : `${action.template.name} v${action.template.version}`;
+
 const toActions = async (): Promise<void> => {
     await router.push('/actions/runs');
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const handleRowClick = async (_: Event, row: any): Promise<void> => {
+const openAction = async (uuid: string): Promise<void> => {
     await router.push({
         name: ROUTES.ANALYSIS_DETAILS.routeName,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        params: { id: row.uuid },
+        params: { id: uuid },
     });
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handleRowClick = async (_: Event, row: any): Promise<void> => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+    await openAction(row.uuid);
 };
 </script>
 
@@ -189,5 +275,12 @@ const handleRowClick = async (_: Event, row: any): Promise<void> => {
     align-items: center;
     justify-content: center;
     text-align: center;
+}
+
+/* The card list already fits the panel width on a phone */
+@media (max-width: 599px) {
+    .card-wrapper {
+        overflow-x: hidden;
+    }
 }
 </style>

--- a/frontend/src/components/actions/trigger-definition-drawer.vue
+++ b/frontend/src/components/actions/trigger-definition-drawer.vue
@@ -2,10 +2,10 @@
     <q-drawer
         v-model="internalOpen"
         side="right"
-        :width="600"
+        :width="$q.screen.lt.md ? $q.screen.width : 600"
         bordered
         overlay
-        behavior="desktop"
+        :behavior="$q.screen.lt.md ? 'mobile' : 'desktop'"
     >
         <div class="column full-height">
             <!-- Header -->
@@ -18,6 +18,7 @@
                     round
                     dense
                     icon="sym_o_close"
+                    aria-label="Close"
                     @click="closeDrawer"
                 />
             </div>

--- a/frontend/src/components/banner/dev-instance-warning-banner.vue
+++ b/frontend/src/components/banner/dev-instance-warning-banner.vue
@@ -2,15 +2,10 @@
     <q-banner
         v-if="isDevInstance"
         inline-actions
-        class="text-white bg-red"
-        style="margin: 10px 0"
+        class="text-white bg-red dev-instance-banner"
     >
         <template #avatar>
-            <q-icon
-                name="sym_o_warning"
-                color="white"
-                style="font-weight: bold; font-size: 36px; padding: 2px"
-            />
+            <q-icon name="sym_o_warning" color="white" />
         </template>
         <span>
             This app is the development version of Kleinkram. Data may be lost
@@ -25,3 +20,38 @@ import ENV from 'src/environment';
 // TODO: currently, all hosted versions should show this warning
 const isDevInstance = ENV.BACKEND_URL.includes('.dev.leggedrobotics.com');
 </script>
+
+<style scoped>
+.dev-instance-banner {
+    margin: 10px 0;
+}
+
+/* The text must always wrap; never clip it to a fixed height */
+.dev-instance-banner :deep(.q-banner__content) {
+    min-height: 0;
+    overflow-wrap: anywhere;
+    white-space: normal;
+}
+
+.dev-instance-banner :deep(.q-banner__avatar > .q-icon) {
+    font-size: 36px;
+    font-weight: bold;
+    padding: 2px;
+}
+
+@media (max-width: 599px) {
+    .dev-instance-banner {
+        padding: 8px 12px;
+    }
+
+    .dev-instance-banner :deep(.q-banner__avatar > .q-icon) {
+        font-size: 26px;
+    }
+
+    /* Tighter gap between the icon and the wrapped message on phones */
+    .dev-instance-banner
+        :deep(.q-banner__avatar:not(:empty) + .q-banner__content) {
+        padding-left: 12px;
+    }
+}
+</style>

--- a/frontend/src/components/buttons/button-group-overlay.vue
+++ b/frontend/src/components/buttons/button-group-overlay.vue
@@ -1,11 +1,43 @@
 <!-- applies the appropriate spacing between buttons -->
 <template>
-    <div class="flex justify-between" style="gap: 10px; color: #0f62fe">
-        <div class="flex q-ml-lg" style="gap: 10px; align-items: center">
+    <div class="button-group-overlay flex justify-between">
+        <div class="button-group-overlay__start flex items-center">
             <slot name="start" />
         </div>
-        <div class="flex q-pr-lg" style="gap: 20px">
+        <div class="button-group-overlay__end flex">
             <slot name="end" />
         </div>
     </div>
 </template>
+
+<style scoped>
+.button-group-overlay {
+    gap: 10px;
+    color: #0f62fe;
+}
+
+.button-group-overlay__start {
+    gap: 10px;
+    margin-left: 24px;
+}
+
+.button-group-overlay__end {
+    gap: 20px;
+    padding-right: 24px;
+}
+
+@media (max-width: 1023px) {
+    .button-group-overlay {
+        flex-wrap: wrap;
+    }
+
+    .button-group-overlay__start,
+    .button-group-overlay__end {
+        width: 100%;
+        flex-wrap: wrap;
+        margin-left: 0;
+        padding: 0 16px;
+        gap: 8px;
+    }
+}
+</style>

--- a/frontend/src/components/buttons/edit-file-button.vue
+++ b/frontend/src/components/buttons/edit-file-button.vue
@@ -4,7 +4,8 @@
         flat
         color="primary"
         icon="sym_o_edit"
-        label="Edit File"
+        :label="$q.screen.xs ? undefined : 'Edit File'"
+        aria-label="Edit file"
         :disable="!isEnabled"
         @click="editFile"
     >

--- a/frontend/src/components/cli-links/klein-download-file.vue
+++ b/frontend/src/components/cli-links/klein-download-file.vue
@@ -11,27 +11,22 @@
         >
             Kleinkram CLI:
         </p>
-        <div class="button-border">
+        <div class="button-border klein-command__box">
             <div class="q-ml-sm row items-center no-wrap">
-                <div
-                    class="text-truncate"
-                    style="
-                        flex: 1 1 auto;
-                        white-space: nowrap;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                        font-size: smaller;
-                    "
-                >
+                <div class="klein-command">
                     klein download
                     <span style="opacity: 0.8"> --dest=. {{ file.uuid }} </span>
                 </div>
                 <q-btn
                     icon="sym_o_content_copy"
                     flat
+                    aria-label="Copy CLI command"
+                    class="klein-command__copy"
                     style="padding: 3px; color: #0f62fe; rotate: 180deg"
                     @click.stop="copyCommandAction"
-                />
+                >
+                    <q-tooltip>Copy CLI command</q-tooltip>
+                </q-btn>
             </div>
         </div>
     </div>
@@ -49,3 +44,34 @@ const copyCommandAction = async (): Promise<void> => {
     await navigator.clipboard.writeText(text);
 };
 </script>
+
+<style scoped>
+.klein-command__box {
+    max-width: 100%;
+}
+
+/* One truncated line, as before, but it can no longer push the box wider */
+.klein-command {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: smaller;
+}
+
+.klein-command__copy {
+    flex: 0 0 auto;
+}
+
+/* On phones the command wraps instead of overflowing the page */
+@media (max-width: 599px) {
+    .klein-command {
+        overflow: visible;
+        white-space: normal;
+        word-break: break-all;
+        text-overflow: clip;
+        padding: 4px 0;
+    }
+}
+</style>

--- a/frontend/src/components/common/app-create-button.vue
+++ b/frontend/src/components/common/app-create-button.vue
@@ -1,8 +1,7 @@
 <template>
     <q-btn
         flat
-        style="height: 100%"
-        class="bg-button-secondary text-on-color"
+        class="bg-button-secondary text-on-color app-create-button"
         :icon="icon"
         :label="label"
         :disable="disable"
@@ -31,3 +30,16 @@ const onClick = (event: Event): void => {
     emit('click', event);
 };
 </script>
+
+<style scoped>
+.app-create-button {
+    height: 100%;
+}
+
+/* Touch target on small screens */
+@media (max-width: 1023px) {
+    .app-create-button {
+        min-height: 40px;
+    }
+}
+</style>

--- a/frontend/src/components/common/app-refresh-button.vue
+++ b/frontend/src/components/common/app-refresh-button.vue
@@ -1,10 +1,10 @@
 <template>
     <q-btn
         flat
-        style="height: 36px; width: 36px"
         color="icon-secondary"
-        class="button-border"
+        class="button-border app-refresh-button"
         icon="sym_o_loop"
+        aria-label="Refetch the data"
         @click="handleClick"
     >
         <q-tooltip>Refetch the Data</q-tooltip>
@@ -23,5 +23,18 @@ const handleClick = (): void => {
 .button-border {
     border: 1px solid #e0e0e0;
     border-radius: 4px;
+}
+
+.app-refresh-button {
+    height: 36px;
+    width: 36px;
+}
+
+/* Touch target on small screens */
+@media (max-width: 1023px) {
+    .app-refresh-button {
+        height: 40px;
+        width: 40px;
+    }
 }
 </style>

--- a/frontend/src/components/common/app-search-bar.vue
+++ b/frontend/src/components/common/app-search-bar.vue
@@ -61,4 +61,13 @@ defineExpose({
     height: 36px;
     min-height: 36px;
 }
+
+/* Touch target on small screens */
+@media (max-width: 1023px) {
+    :deep(.q-field__control),
+    :deep(.q-field__marginal) {
+        height: 40px;
+        min-height: 40px;
+    }
+}
 </style>

--- a/frontend/src/components/common/drawer-header.vue
+++ b/frontend/src/components/common/drawer-header.vue
@@ -1,10 +1,9 @@
 <template>
     <div
-        class="q-pa-lg flex row justify-between items-center"
-        style="height: 84px"
+        class="q-pa-lg flex row no-wrap justify-between items-center drawer-header"
     >
-        <div class="flex column justify-center">
-            <h3 class="text-h4 q-ma-none">{{ title }}</h3>
+        <div class="flex column justify-center drawer-header__text">
+            <h3 class="q-ma-none drawer-header__title">{{ title }}</h3>
             <span v-if="subtitle" class="text-caption text-grey-7">
                 {{ subtitle }}
             </span>
@@ -34,3 +33,36 @@ const emitClose = (): void => {
     emit('close');
 };
 </script>
+
+<style scoped>
+.drawer-header {
+    min-height: 84px;
+    gap: 12px;
+}
+
+.drawer-header__text {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.drawer-header__title {
+    /* text-h4 */
+    font-size: 2.125rem;
+    font-weight: 400;
+    line-height: 2.5rem;
+    letter-spacing: 0.00735em;
+}
+
+@media (max-width: 599px) {
+    .drawer-header {
+        padding: 16px;
+    }
+
+    .drawer-header__title {
+        /* text-h5 */
+        font-size: 1.5rem;
+        line-height: 2rem;
+        letter-spacing: normal;
+    }
+}
+</style>

--- a/frontend/src/components/configure-access-rights/access-rights-table.vue
+++ b/frontend/src/components/configure-access-rights/access-rights-table.vue
@@ -1,6 +1,6 @@
 <template>
     <q-table
-        class="table-white q-mt-xs"
+        class="table-white q-mt-xs access-rights-table"
         :columns="columns"
         :rows="accessRights"
         hide-pagination
@@ -177,3 +177,16 @@ const isDeleteDisabled = (group: DefaultRightDto): boolean => {
     return false;
 };
 </script>
+
+<style scoped>
+@media (max-width: 599px) {
+    /* Scroll inside the dialog rather than widening it */
+    .access-rights-table {
+        max-width: 100%;
+    }
+
+    .access-rights-table :deep(.q-table__middle) {
+        overflow-x: auto;
+    }
+}
+</style>

--- a/frontend/src/components/configure-metadata.vue
+++ b/frontend/src/components/configure-metadata.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div class="col-9">
+        <div class="col-12 col-md-9">
             <label>Metadata</label>
             <q-select
                 ref="selectReference"

--- a/frontend/src/components/create-file.vue
+++ b/frontend/src/components/create-file.vue
@@ -189,7 +189,6 @@
             dense
             clearable
             placeholder="Google Drive Link"
-            style="min-width: 300px"
             :rules="driveUrlRules"
             :disable="entries.length > 0"
             :hint="

--- a/frontend/src/components/dashboard/dashboard-component.vue
+++ b/frontend/src/components/dashboard/dashboard-component.vue
@@ -36,15 +36,34 @@ const greeting = computed(() => {
 </script>
 
 <style scoped>
+/*
+ * Phones (< 600px) stack every panel in a single column. The container turns
+ * into a flex column so that the `grid-column: span 2` / `grid-row: span 2`
+ * rules the panels declare for the desktop grid are ignored instead of
+ * creating implicit columns that would overflow the viewport. The panels then
+ * size themselves to their content rather than to a fixed 350px row.
+ */
 .dashboard-grid {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     width: 100%;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-template-rows: repeat(4, 350px);
-    gap: 24px;
+    gap: 16px;
 }
 
-@media (min-width: 800px) {
+.dashboard-grid > * {
+    min-width: 0;
+}
+
+@media (min-width: 600px) {
+    .dashboard-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-rows: repeat(4, 350px);
+        gap: 24px;
+    }
+}
+
+@media (min-width: 1024px) {
     .dashboard-grid {
         grid-template-columns: repeat(3, minmax(0, 1fr));
         grid-template-rows: repeat(3, 350px);

--- a/frontend/src/components/dashboard/dashboard-recent-projects.vue
+++ b/frontend/src/components/dashboard/dashboard-recent-projects.vue
@@ -4,12 +4,13 @@
         <q-card class="full-width q-pa-md header-row" flat>
             <span style="font-size: larger">Recently used projects</span>
             <div class="arrow-buttons">
-                <template v-if="projects.length > 0">
+                <template v-if="projects.length > 0 && !isMobile">
                     <q-btn
                         :disable="!canScrollLeft"
                         flat
                         icon="sym_o_arrow_back"
                         class="scroll-button"
+                        aria-label="Scroll projects left"
                         @click="scrollLeft"
                     />
                     <q-btn
@@ -17,6 +18,7 @@
                         flat
                         icon="sym_o_arrow_forward"
                         class="scroll-button"
+                        aria-label="Scroll projects right"
                         @click="scrollRight"
                     />
                 </template>
@@ -24,16 +26,48 @@
                     flat
                     icon="sym_o_arrow_outward"
                     class="scroll-button"
+                    aria-label="Show all projects"
                     @click="toProjects"
-                />
+                >
+                    <q-tooltip>Show all projects</q-tooltip>
+                </q-btn>
             </div>
         </q-card>
 
         <q-separator />
 
+        <!-- Compact list on phones and tablets -->
+        <q-list
+            v-if="projects.length > 0 && isMobile"
+            separator
+            class="project-list"
+        >
+            <q-item
+                v-for="project in projects"
+                :key="project.uuid"
+                v-ripple
+                clickable
+                class="project-list-item"
+                @click="() => goToProject(project.uuid)"
+            >
+                <q-item-section>
+                    <q-item-label lines="1">{{ project.name }}</q-item-label>
+                    <q-item-label caption lines="2">
+                        {{ project.description }}
+                    </q-item-label>
+                    <q-item-label caption class="text-grey-6">
+                        Updated {{ timeAgo(project) }}
+                    </q-item-label>
+                </q-item-section>
+                <q-item-section side>
+                    <q-icon name="sym_o_chevron_right" size="20px" />
+                </q-item-section>
+            </q-item>
+        </q-list>
+
         <!-- Scrollable Card Section -->
         <div
-            v-if="projects.length > 0"
+            v-else-if="projects.length > 0"
             ref="cardWrapper"
             class="card-wrapper"
             @scroll="checkScroll"
@@ -100,11 +134,20 @@ import {
 } from '@kleinkram/api-dto/types/project/recent-projects.dto';
 import { useQuery } from '@tanstack/vue-query';
 import { formatDistanceToNow } from 'date-fns';
+import { useQuasar } from 'quasar';
 import { recentProjects } from 'src/services/queries/project';
 import { computed, ComputedRef, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 const router = useRouter();
+const $q = useQuasar();
+
+/**
+ * Below 1024px the horizontal card carousel is replaced by a compact,
+ * tappable list: the cards are 300px wide and swiping them sideways inside a
+ * vertically scrolling page is awkward on touch devices.
+ */
+const isMobile = computed(() => $q.screen.lt.md);
 
 const { data } = useQuery<ResentProjectsDto | undefined>({
     queryKey: ['projects', 5],
@@ -199,6 +242,19 @@ onMounted(() => {
 .card {
     min-width: 300px; /* Prevent card from shrinking */
     cursor: pointer;
+}
+
+/*
+ * Tablets keep the fixed 350px dashboard row, so the list has to scroll
+ * inside the panel; on phones the panel grows with its content instead.
+ */
+.project-list {
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.project-list-item {
+    min-height: 48px;
 }
 
 .card .q-card:hover {

--- a/frontend/src/components/dashboard/dashboard-storage-indicator.vue
+++ b/frontend/src/components/dashboard/dashboard-storage-indicator.vue
@@ -146,4 +146,15 @@ const option = computed(() => {
     };
 });
 </script>
-<style scoped></style>
+<style scoped>
+/*
+ * On phones the dashboard stacks its panels in a flex column, so the card no
+ * longer inherits a height from the grid row. Give the chart an explicit box
+ * to render into, otherwise its `height: 100%` collapses to zero.
+ */
+@media (max-width: 599px) {
+    .dashboard-card {
+        height: 280px;
+    }
+}
+</style>

--- a/frontend/src/components/dashboard/dashboard-worker-list.vue
+++ b/frontend/src/components/dashboard/dashboard-worker-list.vue
@@ -37,6 +37,8 @@
                         <q-btn
                             flat
                             dense
+                            class="worker-toggle"
+                            :aria-label="`Toggle details of ${singleWorker.hostname}`"
                             @click="() => extendWorker(singleWorker.uuid)"
                         >
                             <q-icon
@@ -53,7 +55,8 @@
                         <q-icon
                             name="sym_o_dns"
                             size="20px"
-                            @click="extendWorker"
+                            class="cursor-pointer"
+                            @click="() => extendWorker(singleWorker.uuid)"
                         />
                         <span class="worker-name">{{
                             singleWorker.hostname
@@ -96,19 +99,19 @@
                         "
                     >
                         <div class="row">
-                            <div class="q-mt-md col-6">
+                            <div class="q-mt-md col-12 col-md-6">
                                 <q-icon name="sym_o_psychology" size="20px" />
                                 <span class="worker-name">{{
                                     singleWorker.cpuModel
                                 }}</span>
                             </div>
-                            <div class="q-mt-md col-3">
+                            <div class="q-mt-md col-12 col-md-3">
                                 <q-icon name="sym_o_hub" size="20px" />
                                 <span class="worker-name"
                                     >{{ singleWorker.cpuCores }} Cores</span
                                 >
                             </div>
-                            <div class="q-mt-md col-3">
+                            <div class="q-mt-md col-12 col-md-3">
                                 <q-icon name="sym_o_memory" size="20px" />
                                 <span class="worker-name"
                                     >{{ singleWorker.cpuMemory }}GB</span
@@ -210,6 +213,30 @@ const extendWorker = (uuid: string): void => {
 
 .crossed-out {
     position: relative;
+}
+
+/*
+ * On narrow screens the worker row has to fit a button, three icons, the
+ * hostname and the status side by side: let the hostname shrink and truncate
+ * instead of pushing the status out of the panel, and give the expand button
+ * a comfortable touch target.
+ */
+@media (max-width: 1023px) {
+    .worker-name {
+        min-width: 0;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    .worker-toggle {
+        min-width: 40px;
+        min-height: 40px;
+    }
+
+    .worker-status {
+        white-space: nowrap;
+    }
 }
 
 .crossed-out::before {

--- a/frontend/src/components/explorer-page/explorer-page-files-table.vue
+++ b/frontend/src/components/explorer-page/explorer-page-files-table.vue
@@ -1,4 +1,54 @@
 <template>
+    <div v-if="isPhone" class="row items-center justify-between q-mb-sm">
+        <q-btn-dropdown
+            flat
+            dense
+            no-caps
+            class="text-grey-8"
+            icon="sym_o_swap_vert"
+            :label="`Sort: ${activeSortLabel}`"
+            aria-label="Change sorting"
+        >
+            <q-list>
+                <q-item
+                    v-for="option in sortOptions"
+                    :key="option.value"
+                    v-close-popup
+                    clickable
+                    @click="() => toggleSort(option.value)"
+                >
+                    <q-item-section>{{ option.label }}</q-item-section>
+                    <q-item-section side>
+                        <q-icon
+                            v-if="pagination.sortBy === option.value"
+                            :name="
+                                pagination.descending
+                                    ? 'sym_o_arrow_downward'
+                                    : 'sym_o_arrow_upward'
+                            "
+                            size="18px"
+                        />
+                    </q-item-section>
+                </q-item>
+            </q-list>
+        </q-btn-dropdown>
+
+        <q-btn
+            flat
+            dense
+            no-caps
+            class="text-grey-8"
+            :icon="allOnPageSelected ? 'sym_o_deselect' : 'sym_o_select_all'"
+            :label="allOnPageSelected ? 'Clear' : 'Select all'"
+            :aria-label="
+                allOnPageSelected
+                    ? 'Clear selection'
+                    : 'Select all files on this page'
+            "
+            @click="toggleSelectAll"
+        />
+    </div>
+
     <q-table
         ref="tableRef"
         v-model:pagination="pagination"
@@ -7,14 +57,16 @@
         bordered
         :rows-per-page-options="[5, 10, 20, 50, 100]"
         :rows="data"
-        :columns="fileColumns as any"
+        :columns="visibleFileColumns as any"
         row-key="uuid"
         :loading="isLoading"
         binary-state-sort
         wrap-cells
-        virtual-scroll
+        :grid="isPhone"
+        :virtual-scroll="!isPhone"
         separator="none"
         selection="multiple"
+        :class="{ 'files-table--grid': isPhone }"
         @row-click="onRowClick"
         @request="setPagination"
     >
@@ -169,6 +221,139 @@
                 </q-btn>
             </q-td>
         </template>
+
+        <template #item="props">
+            <div class="col-12 file-card-wrapper">
+                <q-card
+                    flat
+                    bordered
+                    class="file-card"
+                    :class="{ 'file-card--selected': props.selected }"
+                    @click="() => openFile(props.row)"
+                >
+                    <div class="q-pa-sm">
+                        <div class="row items-center no-wrap">
+                            <q-checkbox
+                                v-model="props.selected"
+                                dense
+                                color="grey-8"
+                                class="q-mr-sm"
+                                :aria-label="`Select ${props.row.filename}`"
+                                @click.stop
+                            />
+                            <q-icon
+                                :name="getIcon(props.row.state)"
+                                :color="getColorFileState(props.row.state)"
+                                size="20px"
+                                class="q-mr-sm"
+                            >
+                                <q-tooltip>
+                                    {{ getTooltip(props.row.state) }}
+                                </q-tooltip>
+                            </q-icon>
+                            <div class="col file-card__name">
+                                {{ props.row.filename }}
+                            </div>
+                            <q-btn
+                                flat
+                                round
+                                dense
+                                icon="sym_o_more_vert"
+                                unelevated
+                                color="primary"
+                                class="cursor-pointer"
+                                aria-label="File actions"
+                                @click.stop
+                            >
+                                <q-menu auto-close>
+                                    <q-list>
+                                        <q-item
+                                            v-ripple
+                                            clickable
+                                            @click="() => openFile(props.row)"
+                                        >
+                                            <q-item-section>
+                                                View
+                                            </q-item-section>
+                                        </q-item>
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                <edit-file-dialog-opener
+                                                    :file="props.row"
+                                                >
+                                                    Edit
+                                                </edit-file-dialog-opener>
+                                            </q-item-section>
+                                        </q-item>
+                                        <q-item
+                                            v-ripple
+                                            clickable
+                                            @click="
+                                                () =>
+                                                    _downloadFile(
+                                                        props.row.uuid,
+                                                        props.row.filename,
+                                                    )
+                                            "
+                                        >
+                                            <q-item-section>
+                                                Download
+                                            </q-item-section>
+                                        </q-item>
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                <MoveFileDialogOpener
+                                                    :files="[props.row]"
+                                                    :mission="props.row.mission"
+                                                >
+                                                    Move
+                                                </MoveFileDialogOpener>
+                                            </q-item-section>
+                                        </q-item>
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                <DeleteFileDialogOpener
+                                                    :file="props.row"
+                                                >
+                                                    Delete File
+                                                </DeleteFileDialogOpener>
+                                            </q-item-section>
+                                        </q-item>
+                                    </q-list>
+                                </q-menu>
+                            </q-btn>
+                        </div>
+
+                        <div
+                            class="row items-center text-caption text-grey-7 file-card__meta"
+                        >
+                            <span>{{ formatSize(props.row.size) }}</span>
+                            <span aria-hidden="true">&middot;</span>
+                            <span>
+                                {{ formatDate(new Date(props.row.date)) }}
+                            </span>
+                        </div>
+
+                        <div
+                            v-if="sortedCats(props.row).length > 0"
+                            class="q-mt-xs"
+                        >
+                            <q-chip
+                                v-for="cat in sortedCats(props.row)"
+                                :key="cat.uuid"
+                                :label="cat.name"
+                                :color="hashUUIDtoColor(cat.uuid)"
+                                style="color: white"
+                                dense
+                                clickable
+                                class="q-mr-xs q-ml-none"
+                                @click.stop="() => chipClicked(cat)"
+                            />
+                        </div>
+                    </div>
+                </q-card>
+            </div>
+        </template>
     </q-table>
 
     <div class="flex row justify-center q-mt-sm">
@@ -225,7 +410,7 @@ import CreateFileDialogOpener from 'components/button-wrapper/dialog-opener-crea
 import EditFileDialogOpener from 'components/button-wrapper/edit-file-dialog-opener.vue';
 import MoveFileDialogOpener from 'components/button-wrapper/move-file-dialog-opener.vue';
 import { fileColumns } from 'components/explorer-page/explorer-page-table-columns';
-import { QTable } from 'quasar';
+import { QTable, useQuasar } from 'quasar';
 import {
     useHandler,
     useMission,
@@ -233,7 +418,8 @@ import {
 } from 'src/hooks/query-hooks';
 import { useMissionUUID, useProjectUUID } from 'src/hooks/router-hooks';
 import ROUTES from 'src/router/routes';
-import { parseDate } from 'src/services/date-formating';
+import { formatDate, parseDate } from 'src/services/date-formating';
+import { formatSize } from 'src/services/general-formatting';
 import {
     _downloadFile,
     getColorFileState,
@@ -250,6 +436,33 @@ const selected = defineModel('selected', { required: true, type: Array });
 
 const $emit = defineEmits(['update:selected', 'reset-filter']);
 const $router = useRouter();
+const $q = useQuasar();
+
+/**
+ * Phones render the files as tappable cards, tablets keep the table but drop
+ * the secondary columns so that it fits without horizontal scrolling.
+ */
+const isPhone = computed(() => $q.screen.xs);
+
+const COMPACT_COLUMN_NAMES = new Set([
+    'state',
+    'filename',
+    'size',
+    'fileaction',
+]);
+
+const visibleFileColumns = computed(() =>
+    $q.screen.lt.md
+        ? fileColumns.filter((column) => COMPACT_COLUMN_NAMES.has(column.name))
+        : fileColumns,
+);
+
+const sortOptions = [
+    { label: 'File name', value: 'filename' },
+    { label: 'Health', value: 'state' },
+    { label: 'Created', value: 'createdAt' },
+    { label: 'Size', value: 'size' },
+];
 
 const projectUuid = useProjectUUID();
 const missionUuid = useMissionUUID();
@@ -326,6 +539,12 @@ async function setPagination(update: TableRequest): Promise<void> {
     await refetch();
 }
 
+const activeSortLabel = computed(
+    () =>
+        sortOptions.find((option) => option.value === queryHandler.value.sortBy)
+            ?.label ?? 'File name',
+);
+
 const pagination = computed({
     get: () => ({
         page: queryHandler.value.page,
@@ -390,6 +609,30 @@ const {
 const data = computed(() => (rawData.value ? rawData.value.data : []));
 const total = computed(() => (rawData.value ? rawData.value.count : 0));
 
+/**
+ * The card layout has no header row, so selecting every file of the current
+ * page gets its own button.
+ */
+const allOnPageSelected = computed(() => {
+    const selectedKeys = new Set(
+        selected.value.map((row) => (row as FileWithTopicDto).uuid),
+    );
+    return (
+        data.value.length > 0 &&
+        data.value.every((row) => selectedKeys.has(row.uuid))
+    );
+});
+
+function toggleSelectAll(): void {
+    const pageKeys = new Set(data.value.map((row) => row.uuid));
+    const otherPages = selected.value.filter(
+        (row) => !pageKeys.has((row as FileWithTopicDto).uuid),
+    );
+    selected.value = allOnPageSelected.value
+        ? otherPages
+        : [...otherPages, ...data.value];
+}
+
 watch(
     () => total.value,
     () => {
@@ -402,7 +645,7 @@ watch(
 );
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const onRowClick = async (_: Event, row: any): Promise<void> => {
+const openFile = async (row: any): Promise<void> => {
     await $router.push({
         path: '',
         // @ts-ignore
@@ -416,6 +659,25 @@ const onRowClick = async (_: Event, row: any): Promise<void> => {
         },
     });
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const onRowClick = async (_: Event, row: any): Promise<void> => {
+    await openFile(row);
+};
+
+/**
+ * Sorting control used by the card layout on phones, where the sortable
+ * table header is not rendered.
+ */
+async function toggleSort(name: string): Promise<void> {
+    const handler = queryHandler.value;
+    handler.setDescending(
+        handler.sortBy === name ? !handler.descending : false,
+    );
+    handler.setSort(name);
+    handler.setPage(1);
+    await refetch();
+}
 
 function chipClicked(cat: CategoryDto): void {
     queryHandler.value.addCategory(cat.uuid);
@@ -432,3 +694,59 @@ function sortedCats(file: FileWithTopicDto): CategoryDto[] {
     return file.categories.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 </script>
+
+<style scoped>
+.file-card-wrapper {
+    padding: 4px 0;
+}
+
+.file-card {
+    border-radius: 4px;
+}
+
+.file-card--selected {
+    background-color: #e7efff;
+}
+
+.file-card__name {
+    min-width: 0;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 20px;
+    overflow: hidden;
+    word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.file-card__meta {
+    gap: 6px;
+    margin-top: 2px;
+}
+
+/* The card list is a plain column; the cards carry their own borders, so the
+   table container does not need one. */
+.files-table--grid {
+    border: 0;
+    background: transparent;
+}
+
+.files-table--grid :deep(.q-table__grid-content) {
+    margin: 0;
+}
+
+@media (max-width: 599px) {
+    /* .q-table__bottom already wraps globally; keep it compact and give the
+       pagination arrows a comfortable touch target. */
+    :deep(.q-table__bottom) {
+        font-size: 12px;
+        column-gap: 8px;
+    }
+
+    :deep(.q-table__bottom .q-btn) {
+        min-height: 36px;
+        min-width: 36px;
+    }
+}
+</style>

--- a/frontend/src/components/explorer-page/explorer-page-mission-table.vue
+++ b/frontend/src/components/explorer-page/explorer-page-mission-table.vue
@@ -4,15 +4,17 @@
         v-model:pagination="pagination"
         v-model:selected="selected"
         flat
-        bordered
+        :bordered="!isPhone"
+        :grid="isPhone"
         :rows-per-page-options="[10, 20, 50, 100]"
         :rows="data"
-        :columns="missionColumns as any"
+        :columns="tableColumns as any"
+        :visible-columns="visibleColumns"
         row-key="uuid"
         :loading="isLoading"
         binary-state-sort
         wrap-cells
-        virtual-scroll
+        :virtual-scroll="!isPhone"
         separator="none"
         selection="multiple"
         @row-click="onRowClick"
@@ -94,6 +96,141 @@
             </div>
         </template>
 
+        <!-- Phone layout: one tappable card per mission -->
+        <template #item="props">
+            <div class="col-12 q-pb-sm">
+                <q-card
+                    flat
+                    bordered
+                    class="mission-card"
+                    :class="{ 'mission-card--selected': props.selected }"
+                >
+                    <div class="row no-wrap items-start q-pa-sm">
+                        <q-checkbox
+                            v-model="props.selected"
+                            dense
+                            color="grey-8"
+                            class="q-mr-sm"
+                            aria-label="Select mission"
+                        />
+
+                        <div
+                            class="col cursor-pointer"
+                            style="min-width: 0"
+                            @click="(event) => onRowClick(event, props.row)"
+                        >
+                            <div
+                                class="text-subtitle2 mission-card__text ellipsis-2-lines"
+                            >
+                                {{ props.row.name }}
+                            </div>
+                            <div class="text-caption text-grey-7 q-mt-xs">
+                                {{ props.row.filesCount }}
+                                {{
+                                    props.row.filesCount === 1
+                                        ? 'file'
+                                        : 'files'
+                                }}
+                                &middot; {{ formatSize(props.row.size) }}
+                            </div>
+                            <div class="text-caption text-grey-7">
+                                {{ props.row.creator.name }} &middot;
+                                {{ formatDate(new Date(props.row.createdAt)) }}
+                            </div>
+                            <div
+                                v-if="missingTags(props.row).length === 0"
+                                class="text-caption q-mt-xs"
+                            >
+                                <q-icon
+                                    name="sym_o_check"
+                                    color="black"
+                                    size="14px"
+                                    class="q-mr-xs"
+                                />
+                                Metadata complete
+                            </div>
+                            <div
+                                v-else
+                                class="text-caption q-mt-xs"
+                                style="color: red"
+                            >
+                                <q-icon
+                                    name="sym_o_error"
+                                    color="red"
+                                    size="16px"
+                                    class="q-mr-xs"
+                                />
+                                {{ missingTagsText(props.row) }}
+                            </div>
+                        </div>
+
+                        <q-btn
+                            flat
+                            round
+                            dense
+                            icon="sym_o_more_vert"
+                            unelevated
+                            color="primary"
+                            class="cursor-pointer"
+                            aria-label="Mission actions"
+                            @click.stop
+                        >
+                            <q-menu auto-close>
+                                <q-list>
+                                    <q-item
+                                        v-ripple
+                                        clickable
+                                        @click="
+                                            (event) =>
+                                                onRowClick(event, props.row)
+                                        "
+                                    >
+                                        <q-item-section>
+                                            View Files
+                                        </q-item-section>
+                                    </q-item>
+                                    <EditMissionDialogOpener
+                                        :mission="props.row"
+                                    >
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                Edit Mission
+                                            </q-item-section>
+                                        </q-item>
+                                    </EditMissionDialogOpener>
+                                    <MissionMetadataOpener :mission="props.row">
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                Edit Metadata
+                                            </q-item-section>
+                                        </q-item>
+                                    </MissionMetadataOpener>
+                                    <MoveMissionDialogOpener
+                                        :mission="props.row"
+                                    >
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                Move
+                                            </q-item-section>
+                                        </q-item>
+                                    </MoveMissionDialogOpener>
+                                    <DeleteMissionDialogOpener
+                                        :mission="props.row"
+                                    >
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                Delete
+                                            </q-item-section>
+                                        </q-item>
+                                    </DeleteMissionDialogOpener>
+                                </q-list>
+                            </q-menu>
+                        </q-btn>
+                    </div>
+                </q-card>
+            </div>
+        </template>
+
         <template #body-cell-missionaction="props">
             <q-td :props="props">
                 <q-btn
@@ -104,6 +241,7 @@
                     unelevated
                     color="primary"
                     class="cursor-pointer"
+                    aria-label="Mission actions"
                     @click.stop
                 >
                     <q-menu auto-close>
@@ -111,7 +249,7 @@
                             <q-item
                                 v-ripple
                                 clickable
-                                @click="(e) => onRowClick(e, props.row)"
+                                @click="(event) => onRowClick(event, props.row)"
                             >
                                 <q-item-section>View Files</q-item-section>
                             </q-item>
@@ -152,9 +290,11 @@ import type { MissionWithFilesDto } from '@kleinkram/api-dto/types/mission/missi
 import type { TagDto } from '@kleinkram/api-dto/types/tags/tags.dto';
 import { keepPreviousData, useQuery } from '@tanstack/vue-query';
 import { missionColumns } from 'components/explorer-page/explorer-page-table-columns';
-import { QTable } from 'quasar';
+import { QTable, useQuasar } from 'quasar';
 import { useHandler, useProjectQuery } from 'src/hooks/query-hooks';
 import ROUTES from 'src/router/routes';
+import { formatDate } from 'src/services/date-formating';
+import { formatSize } from 'src/services/general-formatting';
 import { missionsOfProject } from 'src/services/queries/mission';
 import { TableRequest } from 'src/services/query-handler';
 import { computed, ref, watch } from 'vue';
@@ -170,6 +310,27 @@ import { useProjectUUID } from 'src/hooks/router-hooks';
 const $emit = defineEmits(['update:selected']);
 
 const queryHandler = useHandler();
+const $q = useQuasar();
+
+/**
+ * Phones get a card list instead of a table, tablets keep the table but only
+ * show the columns that fit without horizontal scrolling.
+ */
+const isPhone = computed(() => $q.screen.xs);
+const isCompact = computed(() => $q.screen.lt.md);
+
+const tableColumns = computed(() =>
+    isCompact.value
+        ? // `required` columns cannot be hidden by `visible-columns`
+          missionColumns.map((column) => ({ ...column, required: false }))
+        : missionColumns,
+);
+
+const visibleColumns = computed(() =>
+    isCompact.value
+        ? ['name', 'NrOfFiles', 'tagverification', 'missionaction']
+        : undefined,
+);
 
 async function setPagination(update: TableRequest): Promise<void> {
     queryHandler.value.setPage(update.pagination.page);
@@ -277,4 +438,16 @@ watch(
     },
 );
 </script>
-<style scoped></style>
+<style scoped>
+.mission-card {
+    border-radius: 4px;
+}
+
+.mission-card--selected {
+    background-color: #e7efff;
+}
+
+.mission-card__text {
+    overflow-wrap: anywhere;
+}
+</style>

--- a/frontend/src/components/explorer-page/explorer-page-project-table.vue
+++ b/frontend/src/components/explorer-page/explorer-page-project-table.vue
@@ -4,14 +4,16 @@
         v-model:pagination="pagination"
         v-model:selected="selected"
         flat
-        bordered
+        :bordered="!isPhone"
+        :grid="isPhone"
         :rows-per-page-options="[10, 20, 50, 100]"
         :rows="data"
-        :columns="explorerPageTableColumns as any"
+        :columns="tableColumns as any"
+        :visible-columns="visibleColumns"
         row-key="uuid"
         :loading="isLoading"
         wrap-cells
-        virtual-scroll
+        :virtual-scroll="!isPhone"
         separator="none"
         selection="multiple"
         binary-state-sort
@@ -27,6 +29,55 @@
         </template>
         <template #loading>
             <q-inner-loading showing color="primary" />
+        </template>
+
+        <!-- Sorting is done through the column headers on wider screens; the
+             card layout has no headers, so it gets an explicit sort menu. -->
+        <template v-if="isPhone" #top>
+            <div class="row items-center full-width" style="gap: 8px">
+                <q-btn-dropdown
+                    flat
+                    dense
+                    no-caps
+                    class="button-border q-px-sm"
+                    :label="`Sort: ${currentSortLabel}`"
+                    aria-label="Sort projects"
+                >
+                    <q-list>
+                        <q-item
+                            v-for="option in sortOptions"
+                            :key="option.value"
+                            v-close-popup
+                            clickable
+                            @click="() => applySort(option.value)"
+                        >
+                            <q-item-section>{{ option.label }}</q-item-section>
+                        </q-item>
+                    </q-list>
+                </q-btn-dropdown>
+
+                <q-btn
+                    flat
+                    dense
+                    class="button-border"
+                    style="min-width: 40px; min-height: 40px"
+                    :icon="
+                        descending
+                            ? 'sym_o_arrow_downward'
+                            : 'sym_o_arrow_upward'
+                    "
+                    :aria-label="
+                        descending
+                            ? 'Sort ascending instead'
+                            : 'Sort descending instead'
+                    "
+                    @click="toggleSortDirection"
+                >
+                    <q-tooltip>
+                        {{ descending ? 'Descending' : 'Ascending' }}
+                    </q-tooltip>
+                </q-btn>
+            </div>
         </template>
 
         <template #no-data>
@@ -54,6 +105,130 @@
             </div>
         </template>
 
+        <!-- Phone layout: one tappable card per project -->
+        <template #item="props">
+            <div class="col-12 q-pb-sm">
+                <q-card
+                    flat
+                    bordered
+                    class="project-card"
+                    :class="{ 'project-card--selected': props.selected }"
+                >
+                    <div class="row no-wrap items-start q-pa-sm">
+                        <q-checkbox
+                            v-model="props.selected"
+                            dense
+                            color="grey-8"
+                            class="q-mr-sm"
+                            aria-label="Select project"
+                        />
+
+                        <div
+                            class="col cursor-pointer"
+                            style="min-width: 0"
+                            @click="(event) => onRowClick(event, props.row)"
+                        >
+                            <div
+                                class="text-subtitle2 project-card__text ellipsis-2-lines"
+                            >
+                                {{ props.row.name }}
+                            </div>
+                            <div
+                                v-if="props.row.description"
+                                class="text-caption text-grey-8 project-card__text ellipsis-2-lines"
+                            >
+                                {{ props.row.description }}
+                            </div>
+                            <div class="text-caption text-grey-7 q-mt-xs">
+                                {{ props.row.missionCount }}
+                                {{
+                                    props.row.missionCount === 1
+                                        ? 'mission'
+                                        : 'missions'
+                                }}
+                                &middot; {{ formatSize(props.row.size) }}
+                            </div>
+                            <div class="text-caption text-grey-7">
+                                {{ props.row.creator.name }} &middot;
+                                {{ formatDate(new Date(props.row.createdAt)) }}
+                            </div>
+                        </div>
+
+                        <q-btn
+                            flat
+                            round
+                            dense
+                            icon="sym_o_more_vert"
+                            unelevated
+                            color="primary"
+                            class="cursor-pointer"
+                            aria-label="Project actions"
+                            @click.stop
+                        >
+                            <q-menu auto-close>
+                                <q-list>
+                                    <q-item
+                                        v-ripple
+                                        clickable
+                                        @click="
+                                            (event) =>
+                                                onRowClick(event, props.row)
+                                        "
+                                    >
+                                        <q-item-section>
+                                            View Missions
+                                        </q-item-section>
+                                    </q-item>
+                                    <EditProjectDialogOpener
+                                        :project-uuid="props.row.uuid"
+                                    >
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                Edit Project
+                                            </q-item-section>
+                                        </q-item>
+                                    </EditProjectDialogOpener>
+                                    <ConfigureTagsDialogOpener
+                                        :project-uuid="props.row.uuid"
+                                    >
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                Enforce Metadata
+                                            </q-item-section>
+                                        </q-item>
+                                    </ConfigureTagsDialogOpener>
+                                    <change-project-rights-dialog-opener
+                                        :project-uuid="props.row.uuid"
+                                        :project-access-uuid="
+                                            props.row.project_access_uuid ?? ''
+                                        "
+                                    >
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                Manage Access
+                                            </q-item-section>
+                                        </q-item>
+                                    </change-project-rights-dialog-opener>
+                                    <DeleteProjectDialogOpener
+                                        :project-uuid="props.row.uuid"
+                                        :has-missions="
+                                            props.row.missionCount > 0
+                                        "
+                                    >
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                Delete
+                                            </q-item-section>
+                                        </q-item>
+                                    </DeleteProjectDialogOpener>
+                                </q-list>
+                            </q-menu>
+                        </q-btn>
+                    </div>
+                </q-card>
+            </div>
+        </template>
+
         <template #body-cell-project-action="props">
             <Suspense>
                 <q-td :props="props">
@@ -65,6 +240,7 @@
                         unelevated
                         color="primary"
                         class="cursor-pointer"
+                        aria-label="Project actions"
                         @click.stop
                     >
                         <q-menu auto-close>
@@ -72,7 +248,9 @@
                                 <q-item
                                     v-ripple
                                     clickable
-                                    @click="(e) => onRowClick(e, props.row)"
+                                    @click="
+                                        (event) => onRowClick(event, props.row)
+                                    "
                                 >
                                     <q-item-section>
                                         View Missions
@@ -132,7 +310,7 @@ import ChangeProjectRightsDialogOpener from 'components/button-wrapper/dialog-op
 import ConfigureTagsDialogOpener from 'components/button-wrapper/dialog-opener-configure-tags.vue';
 import DialogOpenerCreateProject from 'components/button-wrapper/dialog-opener-create-project.vue';
 import EditProjectDialogOpener from 'components/button-wrapper/edit-project-dialog-opener.vue';
-import { QTable } from 'quasar';
+import { QTable, useQuasar } from 'quasar';
 import { explorerPageTableColumns } from 'src/components/explorer-page/explorer-page-table-columns';
 import {
     useFilteredProjects,
@@ -140,20 +318,68 @@ import {
     useUser,
 } from 'src/hooks/query-hooks';
 import ROUTES from 'src/router/routes';
+import { formatDate } from 'src/services/date-formating';
+import { formatSize } from 'src/services/general-formatting';
 import { TableRequest } from 'src/services/query-handler';
 import { computed, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
 const urlHandler = useHandler();
+const $q = useQuasar();
 
 const { myProjects } = defineProps<{ myProjects: boolean }>();
 const { data: user } = useUser();
+
+/**
+ * Phones get a card list instead of a table, tablets keep the table but only
+ * show the columns that fit without horizontal scrolling.
+ */
+const isPhone = computed(() => $q.screen.xs);
+const isCompact = computed(() => $q.screen.lt.md);
+
+const tableColumns = computed(() =>
+    isCompact.value
+        ? // `required` columns cannot be hidden by `visible-columns`
+          explorerPageTableColumns.map((column) => ({
+              ...column,
+              required: false,
+          }))
+        : explorerPageTableColumns,
+);
+
+const visibleColumns = computed(() =>
+    isCompact.value
+        ? ['name', 'description', 'nrOfMissions', 'project-action']
+        : undefined,
+);
+
+const sortOptions = explorerPageTableColumns
+    .filter((column) => column.sortable === true)
+    .map((column) => ({ label: column.label, value: column.name }));
+
+const descending = computed(() => urlHandler.value.descending);
+
+const currentSortLabel = computed(
+    () =>
+        sortOptions.find((option) => option.value === urlHandler.value.sortBy)
+            ?.label ?? 'Name',
+);
 
 async function setPagination(update: TableRequest): Promise<void> {
     urlHandler.value.setPage(update.pagination.page);
     urlHandler.value.setTake(update.pagination.rowsPerPage);
     urlHandler.value.setSort(update.pagination.sortBy);
     urlHandler.value.setDescending(update.pagination.descending);
+    await refetch();
+}
+
+async function applySort(sortBy: string): Promise<void> {
+    urlHandler.value.setSort(sortBy);
+    await refetch();
+}
+
+async function toggleSortDirection(): Promise<void> {
+    urlHandler.value.setDescending(!urlHandler.value.descending);
     await refetch();
 }
 
@@ -220,3 +446,17 @@ const onRowClick = async (_: Event, row: any): Promise<void> => {
     });
 };
 </script>
+
+<style scoped>
+.project-card {
+    border-radius: 4px;
+}
+
+.project-card--selected {
+    background-color: #e7efff;
+}
+
+.project-card__text {
+    overflow-wrap: anywhere;
+}
+</style>

--- a/frontend/src/components/explorer-page/explorer-page-table-header.vue
+++ b/frontend/src/components/explorer-page/explorer-page-table-header.vue
@@ -1,7 +1,9 @@
 <template>
     <div>
         <template v-if="urlHandler.isListingMissions">
-            <h2 class="text-h6 q-mb-xs">Explore all Missions of Project</h2>
+            <h2 class="text-h6 q-mb-xs explorer-table-header__title">
+                Explore all Missions of Project
+            </h2>
             <HelpMessage
                 text="You can only see missions on which you have at least view access on project level or mission level."
                 link="https://docs.datasets.leggedrobotics.com/usage/getting-started.html"
@@ -9,7 +11,9 @@
         </template>
 
         <template v-if="urlHandler.isListingFiles">
-            <h2 class="text-h6 q-mb-xs">Explore all Files of Mission</h2>
+            <h2 class="text-h6 q-mb-xs explorer-table-header__title">
+                Explore all Files of Mission
+            </h2>
             <HelpMessage
                 text="You can only see files of missions you have access to."
                 link="https://docs.datasets.leggedrobotics.com/usage/getting-started.html"
@@ -28,3 +32,19 @@ defineProps({
     },
 });
 </script>
+
+<style scoped>
+/* Keep the heading readable, and wrapping, on narrow screens */
+.explorer-table-header__title {
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 599px) {
+    .explorer-table-header__title {
+        font-size: 1rem;
+        font-weight: 500;
+        line-height: 1.5rem;
+        letter-spacing: 0.00937em;
+    }
+}
+</style>

--- a/frontend/src/components/explorer-page/mission-actions.vue
+++ b/frontend/src/components/explorer-page/mission-actions.vue
@@ -1,18 +1,30 @@
 <template>
     <div class="column q-gutter-y-md">
-        <div class="flex justify-between items-center">
-            <div class="row q-gutter-x-md items-center q-ml-xs">
+        <div
+            class="flex items-center actions-toolbar"
+            :class="isMobile ? 'no-wrap' : 'justify-between'"
+        >
+            <div class="actions-toolbar__search q-ml-xs">
                 <AppSearchBar
                     v-model="searchName"
                     placeholder="Filter by Action Name"
-                    style="min-width: 300px"
                 />
             </div>
 
-            <app-refresh-button @click="refetchData" />
+            <app-refresh-button
+                aria-label="Refresh action executions"
+                @click="refetchData"
+            />
         </div>
 
-        <ActionsTable :handler="handler" />
+        <!--
+            actions-table.vue drops its secondary columns below md and switches
+            to cards on phones; the wrapper only makes sure a leftover overflow
+            scrolls inside the tab instead of the page.
+        -->
+        <div class="actions-table-scroll">
+            <ActionsTable :handler="handler" />
+        </div>
     </div>
 </template>
 
@@ -21,12 +33,20 @@ import { useQueryClient } from '@tanstack/vue-query';
 import ActionsTable from 'components/actions/actions-table.vue';
 import AppRefreshButton from 'components/common/app-refresh-button.vue';
 import AppSearchBar from 'components/common/app-search-bar.vue';
+import { useQuasar } from 'quasar';
 import { actionKeys } from 'src/api/keys/action-keys';
 import { useHandler } from 'src/hooks/query-hooks';
 import { computed } from 'vue';
 
 const handler = useHandler();
 const queryClient = useQueryClient();
+const $q = useQuasar();
+
+/**
+ * Below 1024px the search field grows to the full width and only the refresh
+ * button stays next to it.
+ */
+const isMobile = computed(() => $q.screen.lt.md);
 
 const searchName = computed({
     get: () => handler.value.searchParams.name ?? '',
@@ -39,3 +59,36 @@ const refetchData = async (): Promise<void> => {
     await queryClient.invalidateQueries({ queryKey: actionKeys.all });
 };
 </script>
+
+<style scoped>
+.actions-toolbar {
+    gap: 8px;
+}
+
+.actions-toolbar__search {
+    min-width: 300px;
+}
+
+.actions-table-scroll {
+    max-width: 100%;
+}
+
+@media (max-width: 1023px) {
+    .actions-toolbar__search {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+
+    .actions-table-scroll {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-width: 599px) {
+    .actions-table-scroll :deep(.q-table__bottom) {
+        font-size: 12px;
+        column-gap: 8px;
+    }
+}
+</style>

--- a/frontend/src/components/explorer-page/mission-files.vue
+++ b/frontend/src/components/explorer-page/mission-files.vue
@@ -12,7 +12,12 @@
 
         <div
             v-if="selectedFiles.length === 0"
-            class="q-my-lg flex justify-between items-center"
+            class="q-my-lg flex files-header"
+            :class="
+                isMobile
+                    ? 'column items-stretch'
+                    : 'justify-between items-center'
+            "
         >
             <Suspense>
                 <ExplorerPageTableHeader
@@ -21,24 +26,27 @@
                 />
 
                 <template #fallback>
-                    <div style="width: 550px; height: 67px">
+                    <div class="files-header__skeleton">
                         <q-skeleton
                             class="q-mr-md q-mb-sm q-mt-sm"
-                            style="width: 300px; height: 20px"
+                            style="width: 300px; max-width: 100%; height: 20px"
                         />
                         <q-skeleton
                             class="q-mr-md"
-                            style="width: 200px; height: 18px"
+                            style="width: 200px; max-width: 100%; height: 18px"
                         />
                     </div>
                 </template>
             </Suspense>
             <div
-                class="q-pa-md bg-grey-1 rounded-borders border-grey-3"
-                style="border: 1px solid #e0e0e0; flex-grow: 1"
+                class="q-pa-md bg-grey-1 rounded-borders border-grey-3 files-header__search"
+                style="border: 1px solid #e0e0e0"
             >
-                <div class="row items-start no-wrap q-gutter-x-sm">
-                    <div class="col">
+                <div
+                    class="search-row"
+                    :class="{ 'search-row--stacked': isMobile }"
+                >
+                    <div class="search-row__input">
                         <SmartSearchInput
                             :model-value="filterText"
                             :provider="provider"
@@ -51,22 +59,25 @@
                             @toggle-advanced="toggleAdvanced"
                         />
                     </div>
-                    <div class="col-auto">
+                    <div class="search-row__actions">
                         <q-btn
                             flat
-                            class="bg-button-secondary text-on-color"
+                            class="bg-button-secondary text-on-color search-row__search"
                             icon="sym_o_search"
-                            label="Search"
+                            :label="$q.screen.xs ? undefined : 'Search'"
+                            aria-label="Search files"
                             @click="refresh"
-                        />
-                    </div>
-                    <div class="col-auto">
+                        >
+                            <q-tooltip v-if="$q.screen.xs">Search</q-tooltip>
+                        </q-btn>
                         <create-file-dialog-opener
                             :mission="missionData as MissionWithFilesDto"
+                            class="search-row__upload"
                         >
                             <app-create-button
                                 label="Upload File"
                                 icon="sym_o_upload"
+                                class="full-width"
                             />
                         </create-file-dialog-opener>
                     </div>
@@ -86,7 +97,12 @@
                 </q-slide-transition>
             </div>
         </div>
-        <div v-else class="q-py-lg" style="background: #0f62fe">
+        <div
+            v-else
+            class="selection-bar"
+            :class="$q.screen.xs ? 'q-py-sm' : 'q-py-lg'"
+            style="background: #0f62fe"
+        >
             <ButtonGroupOverlay>
                 <template #start>
                     <div style="margin: 0; font-size: 14pt; color: white">
@@ -97,6 +113,7 @@
                 </template>
                 <template v-if="missionData" #end>
                     <klein-download-files
+                        v-if="$q.screen.gt.xs"
                         :files="selectedFiles"
                         style="max-width: 300px"
                     />
@@ -212,6 +229,12 @@ const $q = useQuasar();
 
 const projectUuid = useProjectUUID();
 const missionUuid = useMissionUUID();
+
+/**
+ * Below 1024px the search panel is stacked under the section title and the
+ * search/upload buttons move onto their own row.
+ */
+const isMobile = computed(() => $q.screen.lt.md);
 
 const {
     data: missionData,
@@ -550,6 +573,75 @@ const openUploadDialogWithFiles = (files: File[]) => {
     position: relative;
     height: 100%;
     min-height: 400px;
+}
+
+.files-header__search {
+    flex-grow: 1;
+}
+
+.files-header__skeleton {
+    width: 550px;
+    max-width: 100%;
+    height: 67px;
+}
+
+.search-row {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.search-row__input {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.search-row__actions {
+    display: flex;
+    flex: 0 0 auto;
+    gap: 8px;
+}
+
+/* Mobile: search input on its own row, the buttons on a second one */
+.search-row--stacked {
+    flex-direction: column;
+}
+
+.search-row--stacked .search-row__actions {
+    width: 100%;
+}
+
+.search-row--stacked .search-row__upload {
+    flex: 1 1 auto;
+}
+
+.search-row--stacked .q-btn {
+    min-height: 40px;
+}
+
+@media (max-width: 1023px) {
+    .files-header__search {
+        width: 100%;
+        margin-top: 12px;
+    }
+
+    .files-header__skeleton {
+        width: 100%;
+        height: auto;
+    }
+}
+
+@media (max-width: 599px) {
+    /* The shared overlay uses generous side gutters; tighten them on phones
+       so the wrapped bulk-action buttons keep their room. */
+    .selection-bar :deep(.q-ml-lg) {
+        margin-left: 8px;
+    }
+
+    .selection-bar :deep(.q-pr-lg) {
+        padding-right: 8px;
+    }
 }
 
 .drop-overlay {

--- a/frontend/src/components/explorer-page/mission-files.vue
+++ b/frontend/src/components/explorer-page/mission-files.vue
@@ -98,11 +98,55 @@
             </div>
         </div>
         <div
-            v-else
-            class="selection-bar"
-            :class="$q.screen.xs ? 'q-py-sm' : 'q-py-lg'"
+            v-else-if="$q.screen.xs"
+            class="selection-bar selection-bar--phone"
             style="background: #0f62fe"
         >
+            <div class="row items-center justify-between no-wrap">
+                <div class="text-white text-subtitle1 text-weight-medium">
+                    {{ selectedFiles.length }}
+                    {{ selectedFiles.length === 1 ? 'file' : 'files' }}
+                    selected
+                </div>
+                <q-btn
+                    flat
+                    round
+                    icon="sym_o_close"
+                    color="white"
+                    aria-label="Clear selection"
+                    @click="deselect"
+                >
+                    <q-tooltip>Clear selection</q-tooltip>
+                </q-btn>
+            </div>
+            <div v-if="missionData" class="selection-bar__actions">
+                <OpenMultCategoryAdd
+                    :mission="missionData"
+                    :files="selectedFiles"
+                />
+                <OpenMultiFileMoveDialog
+                    :mission="missionData"
+                    :files="selectedFiles"
+                />
+                <q-btn
+                    flat
+                    no-caps
+                    icon="sym_o_download"
+                    label="Download"
+                    color="white"
+                    @click="downloadCallback"
+                />
+                <q-btn
+                    flat
+                    no-caps
+                    icon="sym_o_delete"
+                    label="Delete"
+                    color="white"
+                    @click="deleteFilesCallback"
+                />
+            </div>
+        </div>
+        <div v-else class="selection-bar q-py-lg" style="background: #0f62fe">
             <ButtonGroupOverlay>
                 <template #start>
                     <div style="margin: 0; font-size: 14pt; color: white">
@@ -632,16 +676,29 @@ const openUploadDialogWithFiles = (files: File[]) => {
     }
 }
 
-@media (max-width: 599px) {
-    /* The shared overlay uses generous side gutters; tighten them on phones
-       so the wrapped bulk-action buttons keep their room. */
-    .selection-bar :deep(.q-ml-lg) {
-        margin-left: 8px;
-    }
+/* Phone layout of the bulk-action bar: a header row with the count and the
+   close button, then the actions as a two-column grid of equal buttons */
+.selection-bar--phone {
+    padding: 8px 8px 8px 16px;
+}
 
-    .selection-bar :deep(.q-pr-lg) {
-        padding-right: 8px;
-    }
+.selection-bar__actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px 8px;
+    margin: 4px 8px 0 0;
+}
+
+.selection-bar__actions :deep(.q-btn) {
+    width: 100%;
+    min-height: 44px;
+    justify-content: flex-start;
+    text-transform: none;
+}
+
+.selection-bar__actions :deep(.q-btn .q-btn__content) {
+    justify-content: flex-start;
+    flex-wrap: nowrap;
 }
 
 .drop-overlay {

--- a/frontend/src/components/explorer-page/mission-metadata-drawer.vue
+++ b/frontend/src/components/explorer-page/mission-metadata-drawer.vue
@@ -3,12 +3,11 @@
         v-model="isOpen"
         side="right"
         bordered
-        behavior="desktop"
-        :width="600"
+        :behavior="$q.screen.xs ? 'mobile' : 'desktop'"
+        :width="drawerWidth"
     >
         <div
-            class="q-pa-lg flex row justify-between items-start"
-            style="height: 114px"
+            class="q-pa-lg flex row justify-between items-start q-gutter-y-sm metadata-drawer__header"
         >
             <div class="flex column justify-center">
                 <h3 class="text-h5 q-ma-none text-weight-medium">Metadata</h3>
@@ -142,6 +141,10 @@ const closeDrawer = () => {
 };
 
 const $q = useQuasar();
+
+/** The drawer covers the full viewport on phones. */
+const drawerWidth = computed(() => ($q.screen.xs ? $q.screen.width : 600));
+
 const { data: permissions } = usePermissionsQuery();
 
 const canModify = computed(() =>
@@ -225,6 +228,29 @@ const getIconForDataType = (datatype: DataType): string => {
 </script>
 
 <style scoped>
+.metadata-drawer__header {
+    height: 114px;
+}
+
+@media (max-width: 599px) {
+    /* Title and buttons wrap on phones, so the header grows with them */
+    .metadata-drawer__header {
+        height: auto;
+        padding: 16px;
+    }
+
+    .tag-item-container {
+        padding: 16px;
+    }
+
+    /* Touch devices have no hover, so the copy button is always visible */
+    .actions-container {
+        opacity: 1 !important;
+        position: static !important;
+        padding-right: 0 !important;
+    }
+}
+
 .button-border {
     border: 1px solid #e0e0e0;
 }

--- a/frontend/src/components/explorer-page/my-projects-selector.vue
+++ b/frontend/src/components/explorer-page/my-projects-selector.vue
@@ -1,5 +1,10 @@
 <template>
-    <q-btn-dropdown dense flat class="button-border q-px-sm">
+    <q-btn-dropdown
+        dense
+        flat
+        class="button-border q-px-sm my-projects-selector"
+        aria-label="Filter the project list by owner"
+    >
         <template #label>
             {{ myProjects ? 'My Projects' : 'All Projects' }}
         </template>
@@ -21,3 +26,12 @@
 <script setup lang="ts">
 const myProjects = defineModel<boolean>();
 </script>
+
+<style scoped>
+/* Comfortable touch target on phones and tablets */
+@media (max-width: 1023px) {
+    .my-projects-selector {
+        min-height: 40px;
+    }
+}
+</style>

--- a/frontend/src/components/explorer-page/project-list-filter-options.vue
+++ b/frontend/src/components/explorer-page/project-list-filter-options.vue
@@ -1,32 +1,36 @@
 <template>
-    <div class="flex justify-between items-center">
-        <button-group>
+    <div class="project-filter-options">
+        <div class="project-filter-options__scope">
             <my-projects-selector
                 v-if="myProjects !== undefined"
                 v-model="myProjects"
                 class="self-stretch"
             />
-        </button-group>
+        </div>
 
-        <button-group>
+        <div class="project-filter-options__search">
             <app-search-bar
                 v-model="search"
                 placeholder="Search by Project Name"
             />
+        </div>
 
+        <div class="project-filter-options__actions">
             <app-refresh-button @click="resetCache" />
 
             <dialog-opener-create-project>
-                <app-create-button label="Create Project" />
+                <app-create-button
+                    :label="$q.screen.xs ? 'Create' : 'Create Project'"
+                    aria-label="Create Project"
+                />
             </dialog-opener-create-project>
-        </button-group>
+        </div>
     </div>
 </template>
 
 <script setup lang="ts">
 import { useQueryClient } from '@tanstack/vue-query';
 import DialogOpenerCreateProject from 'components/button-wrapper/dialog-opener-create-project.vue';
-import ButtonGroup from 'components/buttons/button-group.vue';
 import AppCreateButton from 'components/common/app-create-button.vue';
 import AppRefreshButton from 'components/common/app-refresh-button.vue';
 import AppSearchBar from 'components/common/app-search-bar.vue';
@@ -52,3 +56,63 @@ watch([myProjects, search], () => {
     });
 });
 </script>
+
+<style scoped>
+/*
+ * Desktop keeps the original layout: the scope selector on the left, the
+ * search field and the action buttons pushed to the right.
+ */
+.project-filter-options {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.project-filter-options__scope {
+    margin-right: auto;
+}
+
+.project-filter-options__actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+/*
+ * Below 1024px the search field claims a full row of its own and the
+ * remaining controls wrap onto a second row with comfortable touch targets.
+ */
+@media (max-width: 1023px) {
+    .project-filter-options {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .project-filter-options__search {
+        order: -1;
+        flex: 1 0 100%;
+        min-width: 0;
+    }
+
+    .project-filter-options__scope {
+        margin-right: 0;
+    }
+
+    .project-filter-options__actions {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .project-filter-options__scope :deep(.q-btn),
+    .project-filter-options__actions :deep(.q-btn) {
+        min-height: 40px;
+        min-width: 40px;
+    }
+
+    .project-filter-options__search :deep(.q-field .q-field__control),
+    .project-filter-options__search :deep(.q-field .q-field__marginal) {
+        height: 40px;
+        min-height: 40px;
+    }
+}
+</style>

--- a/frontend/src/components/files/files-filter.vue
+++ b/frontend/src/components/files/files-filter.vue
@@ -3,8 +3,11 @@
         class="q-pa-md q-mt-md bg-grey-1 rounded-borders q-mb-md border-grey-3"
         style="border: 1px solid #e0e0e0"
     >
-        <div class="row items-start no-wrap q-gutter-x-sm">
-            <div class="col">
+        <div
+            class="row items-start"
+            :class="isPhone ? 'q-col-gutter-sm' : 'no-wrap q-gutter-x-sm'"
+        >
+            <div :class="isPhone ? 'col-12' : 'col'">
                 <SmartSearchInput
                     :model-value="filterText"
                     :provider="provider"
@@ -17,10 +20,11 @@
                     @toggle-advanced="toggleAdvanced"
                 />
             </div>
-            <div class="col-auto">
+            <div :class="isPhone ? 'col-12' : 'col-auto'">
                 <q-btn
                     flat
                     class="bg-button-secondary text-on-color"
+                    :class="{ 'full-width': isPhone }"
                     icon="sym_o_search"
                     label="Search"
                     @click="refresh"
@@ -45,6 +49,7 @@
 </template>
 
 <script setup lang="ts">
+import { useQuasar } from 'quasar';
 import SmartSearchInput from 'src/components/common/smart-search-input.vue';
 import ComposableFilterPopup from 'src/components/files/filter/composable-filter-popup.vue';
 import { DEFAULT_STATE, useFileFilter } from 'src/composables/use-file-filter';
@@ -63,6 +68,14 @@ const props = defineProps({
 defineEmits(['update:model-value']);
 
 const { state } = props.useFilter;
+
+const $q = useQuasar();
+
+/**
+ * On phones the search field and its button do not fit next to each other,
+ * so they are stacked and both span the full width.
+ */
+const isPhone = computed(() => $q.screen.xs);
 
 const handler = useHandler();
 const showAdvanced = ref(false);

--- a/frontend/src/components/files/filter/components/date-filter.vue
+++ b/frontend/src/components/files/filter/components/date-filter.vue
@@ -10,7 +10,7 @@
             />
         </div>
         <q-slide-transition>
-            <div v-if="showDateInputs" class="row q-gutter-x-sm">
+            <div v-if="showDateInputs" class="row q-gutter-x-sm date-inputs">
                 <div class="col">
                     <q-input
                         :model-value="startDateProxy"
@@ -252,3 +252,25 @@ function updateEndDateProxy(v: unknown) {
     endDateProxy.value = (v as string) || '';
 }
 </script>
+
+<style scoped>
+/*
+ * Two 150px-wide date fields next to each other are unusable on a phone,
+ * so they are stacked. The gutter's negative margin is reset as well.
+ */
+@media (max-width: 599px) {
+    .date-inputs {
+        flex-direction: column;
+        margin-left: 0;
+    }
+
+    .date-inputs > .col {
+        width: 100%;
+        margin-left: 0;
+    }
+
+    .date-inputs > .col + .col {
+        margin-top: 8px;
+    }
+}
+</style>

--- a/frontend/src/components/files/filter/composable-filter-popup.vue
+++ b/frontend/src/components/files/filter/composable-filter-popup.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="column q-gutter-y-md" style="min-width: 300px; padding: 16px">
+    <div class="column q-gutter-y-md filter-popup">
         <div class="text-h6">Advanced Filters</div>
 
         <!-- Render each filter's advanced component -->
@@ -59,3 +59,21 @@ function onReset() {
     emit('reset');
 }
 </script>
+
+<style scoped>
+.filter-popup {
+    min-width: 300px;
+    padding: 16px;
+}
+
+/*
+ * The 300px floor is wider than the content area of a small phone, which
+ * would push the whole page sideways.
+ */
+@media (max-width: 599px) {
+    .filter-popup {
+        min-width: 0;
+        padding: 8px 0;
+    }
+}
+</style>

--- a/frontend/src/components/files/filter/metadata-filter-builder.vue
+++ b/frontend/src/components/files/filter/metadata-filter-builder.vue
@@ -58,6 +58,8 @@
                         dense
                         icon="sym_o_close"
                         color="negative"
+                        aria-label="Remove metadata filter"
+                        class="remove-metadata-filter"
                         @click="() => removeTag(tagTypeUUID)"
                     />
                 </div>
@@ -186,3 +188,13 @@ const metadataPlaceholder = computed(() => {
     return "e.g. description='some description'";
 });
 </script>
+
+<style scoped>
+/* Finger-sized delete target on touch devices */
+@media (max-width: 1023px) {
+    .remove-metadata-filter {
+        min-width: 40px;
+        min-height: 40px;
+    }
+}
+</style>

--- a/frontend/src/components/info-banner.vue
+++ b/frontend/src/components/info-banner.vue
@@ -3,7 +3,7 @@
         class="q-pa-md rounded-borders q-mb-lg flex justify-between items-center relative-position info-banner"
         :class="[`bg-${color}`, `text-${textColor}`]"
     >
-        <div class="flex items-center">
+        <div class="flex items-center info-banner__text">
             <q-icon name="sym_o_info" class="q-mr-sm" size="sm" />
             <span>{{ text }}</span>
         </div>
@@ -41,6 +41,27 @@ const emitClick = (): void => {
 </script>
 
 <style scoped>
+/*
+ * On phones the text and the button do not fit next to each other, so the
+ * banner turns into a stack with the action below the message.
+ */
+@media (max-width: 599px) {
+    .info-banner {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+
+    .info-banner__text {
+        align-items: flex-start;
+        flex-wrap: nowrap;
+    }
+
+    .info-banner__text .q-icon {
+        margin-top: 2px;
+    }
+}
+
 .info-banner::before {
     content: '';
     position: absolute;

--- a/frontend/src/components/inspect-file/file-detail.vue
+++ b/frontend/src/components/inspect-file/file-detail.vue
@@ -12,10 +12,10 @@
     <div v-if="file" class="q-my-lg">
         <!-- YAML/Text Preview -->
         <div v-if="isYaml" class="q-mb-lg">
-            <h2 class="text-h4 q-mb-md">Content Preview</h2>
+            <h2 class="text-h5 text-md-h4 q-mb-md">Content Preview</h2>
             <div
                 v-if="yamlContent"
-                class="bg-grey-1 q-pa-md rounded-borders border-solid"
+                class="bg-grey-1 q-pa-md rounded-borders border-solid code-block"
             >
                 <pre class="q-ma-none text-code" style="overflow-x: auto">{{
                     yamlContent
@@ -28,7 +28,7 @@
 
         <!-- TUM Preview -->
         <div v-else-if="isTum" class="q-mb-lg">
-            <h2 class="text-h4 q-mb-md flex items-center">
+            <h2 class="text-h5 text-md-h4 q-mb-md flex items-center">
                 Trajectory Preview
                 <q-badge
                     color="orange-7"
@@ -79,7 +79,7 @@
                 "
                 class="q-mt-lg"
             >
-                <h3 class="text-h5 q-mb-md">SQL Schema</h3>
+                <h3 class="text-h6 text-md-h5 q-mb-md">SQL Schema</h3>
                 <div
                     v-if="isLoading"
                     class="row justify-center q-pa-md bg-grey-1 rounded-borders"
@@ -89,7 +89,7 @@
                 </div>
                 <div
                     v-else-if="preview.dbSchema?.value"
-                    class="bg-grey-1 q-pa-md rounded-borders border-solid"
+                    class="bg-grey-1 q-pa-md rounded-borders border-solid code-block"
                 >
                     <pre class="q-ma-none text-code" style="overflow-x: auto">{{
                         preview.dbSchema.value
@@ -103,7 +103,7 @@
         <!-- Uploading Placeholder -->
         <div
             v-else-if="file.state === FileState.UPLOADING"
-            class="text-center q-pa-xl bg-grey-1 rounded-borders border-dashed text-grey-7"
+            class="text-center q-pa-xl q-px-md bg-grey-1 rounded-borders border-dashed text-grey-7"
         >
             <q-icon name="sym_o_cloud_upload" size="4em" class="q-mb-md" />
             <div class="text-h6">No preview available while uploading</div>
@@ -285,6 +285,12 @@ function handleResumePreview(t: string, limit: number) {
 .text-code {
     font-family: monospace;
     font-size: 13px;
+}
+/* Code previews scroll inside their own box, the page never scrolls */
+.code-block {
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: auto;
 }
 .border-solid {
     border: 1px solid #e0e0e0;

--- a/frontend/src/components/inspect-file/file-error-state.vue
+++ b/frontend/src/components/inspect-file/file-error-state.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="text-center q-pa-xl bg-grey-1 rounded-borders border-dashed text-grey-7"
+        class="text-center q-pa-xl bg-grey-1 rounded-borders border-dashed text-grey-7 file-error-state"
     >
         <div v-if="file.state === FileState.CORRUPTED">
             <q-icon name="sym_o_broken_image" size="4em" class="q-mb-md" />
@@ -56,5 +56,11 @@ const fileExtension = computed(
 <style scoped>
 .border-dashed {
     border: 2px dashed #e0e0e0;
+}
+
+@media (max-width: 599px) {
+    .file-error-state {
+        padding: 32px 16px;
+    }
 }
 </style>

--- a/frontend/src/components/inspect-file/file-header.vue
+++ b/frontend/src/components/inspect-file/file-header.vue
@@ -1,7 +1,19 @@
 <template>
     <title-section :title="`File: ${file?.filename ?? 'Loading...'}`">
+        <template #title>
+            <h1 class="text-h5 text-md-h3 q-ma-none file-header__title">
+                <span v-if="!$q.screen.xs">File: </span>
+                {{ file?.filename ?? 'Loading...' }}
+                <q-tooltip v-if="file?.filename">
+                    {{ file.filename }}
+                </q-tooltip>
+            </h1>
+        </template>
+
         <template #buttons>
-            <div class="column row-md items-end q-gutter-sm">
+            <div
+                class="column row-md items-end q-gutter-sm file-header__actions"
+            >
                 <button-group class="col-auto">
                     <edit-file-button v-if="file" :file="file" />
 
@@ -18,6 +30,7 @@
                         flat
                         icon="sym_o_more_vert"
                         color="primary"
+                        aria-label="More file actions"
                         class="cursor-pointer button-border"
                         @click.stop
                     >
@@ -99,26 +112,30 @@
         </template>
 
         <template #subtitle>
-            <div class="q-gutter-md q-mt-xs">
-                <div class="row items-start q-gutter-y-sm">
+            <div class="q-gutter-md q-mt-xs file-header__body">
+                <div class="row items-start q-gutter-y-sm file-header__meta">
                     <div class="col-12 col-md-2">
-                        <div class="text-placeholder">Project</div>
-                        <div class="text-subtitle1 text-primary ellipsis">
-                            {{ file?.mission.project.name }}
-                            <q-tooltip>
+                        <div class="file-header__meta-item">
+                            <div class="text-placeholder">Project</div>
+                            <div class="text-subtitle1 text-primary ellipsis">
                                 {{ file?.mission.project.name }}
-                            </q-tooltip>
+                                <q-tooltip>
+                                    {{ file?.mission.project.name }}
+                                </q-tooltip>
+                            </div>
                         </div>
                     </div>
                     <div class="col-12 col-md-2">
-                        <div class="text-placeholder">Mission</div>
-                        <div class="text-subtitle1 text-primary ellipsis">
-                            {{ file?.mission.name }}
-                            <q-tooltip>{{ file?.mission.name }}</q-tooltip>
+                        <div class="file-header__meta-item">
+                            <div class="text-placeholder">Mission</div>
+                            <div class="text-subtitle1 text-primary ellipsis">
+                                {{ file?.mission.name }}
+                                <q-tooltip>{{ file?.mission.name }}</q-tooltip>
+                            </div>
                         </div>
                     </div>
                     <div class="col-12 col-md-3">
-                        <div v-if="file?.date">
+                        <div v-if="file?.date" class="file-header__meta-item">
                             <div class="text-placeholder">Start Date</div>
                             <div class="text-subtitle1 text-primary">
                                 {{ formatDate(file?.date, true) }}
@@ -126,7 +143,10 @@
                         </div>
                     </div>
                     <div class="col-12 col-md-2">
-                        <div v-if="file?.creator">
+                        <div
+                            v-if="file?.creator"
+                            class="file-header__meta-item"
+                        >
                             <div class="text-placeholder">Creator</div>
                             <div class="text-subtitle1 text-primary ellipsis">
                                 {{ file?.creator.name }}
@@ -135,21 +155,31 @@
                         </div>
                     </div>
                     <div class="col-12 col-md-1">
-                        <div class="text-placeholder">File State</div>
-                        <q-icon
-                            :name="getIcon(file?.state ?? FileState.OK)"
-                            :color="
-                                getColorFileState(file?.state ?? FileState.OK)
-                            "
-                            size="sm"
-                        >
-                            <q-tooltip>{{ getTooltip(file?.state) }}</q-tooltip>
-                        </q-icon>
+                        <div class="file-header__meta-item">
+                            <div class="text-placeholder">File State</div>
+                            <q-icon
+                                :name="getIcon(file?.state ?? FileState.OK)"
+                                :color="
+                                    getColorFileState(
+                                        file?.state ?? FileState.OK,
+                                    )
+                                "
+                                size="sm"
+                            >
+                                <q-tooltip>
+                                    {{ getTooltip(file?.state) }}
+                                </q-tooltip>
+                            </q-icon>
+                        </div>
                     </div>
                     <div class="col-12 col-md-1">
-                        <div class="text-placeholder">Size</div>
-                        <div class="text-subtitle1 text-primary">
-                            {{ file?.size ? formatSize(file?.size) : '...' }}
+                        <div class="file-header__meta-item">
+                            <div class="text-placeholder">Size</div>
+                            <div class="text-subtitle1 text-primary">
+                                {{
+                                    file?.size ? formatSize(file?.size) : '...'
+                                }}
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -176,6 +206,7 @@ import ButtonGroup from 'components/buttons/button-group.vue';
 import EditFileButton from 'components/buttons/edit-file-button.vue';
 import KleinDownloadFile from 'components/cli-links/klein-download-file.vue';
 import TitleSection from 'components/title-section.vue';
+import { useQuasar } from 'quasar';
 import { formatDate } from 'src/services/date-formating';
 import { formatSize } from 'src/services/general-formatting';
 import {
@@ -185,6 +216,8 @@ import {
     hashUUIDtoColor,
 } from 'src/services/generic';
 import { computed } from 'vue';
+
+const $q = useQuasar();
 
 const properties = defineProps<{ file: FileWithTopicDto }>();
 const emit = defineEmits([
@@ -237,5 +270,63 @@ const handleCopyFoxglove = (): void => {
 }
 .button-border {
     border: 1px solid #ddd;
+}
+
+/* Matches the default title of title-section (ellipsis on one line) */
+.file-header__title {
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+/* Below the desktop breakpoint the file name wraps instead of being cut */
+@media (max-width: 1023px) {
+    .file-header__title {
+        overflow: visible;
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
+}
+
+@media (max-width: 599px) {
+    /* q-gutter-md widens the block by its negative margin, which pushed
+       the right edge past the card on phones; use plain vertical spacing */
+    .file-header__body {
+        margin-left: 0 !important;
+    }
+
+    .file-header__body > * {
+        margin-left: 0 !important;
+        margin-top: 12px !important;
+    }
+
+    .file-header__meta {
+        margin-top: 0 !important;
+    }
+
+    .file-header__meta > * {
+        padding-top: 0;
+        margin-top: 10px;
+    }
+
+    /* Actions stretch to the full width so nothing sticks out to the right */
+    .file-header__actions {
+        align-items: stretch;
+        width: 100%;
+        min-width: 0;
+    }
+
+    /* Stacked label/value pairs: small label above a wrapping value */
+    .file-header__meta .file-header__meta-item {
+        min-width: 0;
+    }
+
+    .file-header__meta .file-header__meta-item > :last-child {
+        min-width: 0;
+        overflow: visible;
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
 }
 </style>

--- a/frontend/src/components/inspect-file/file-history/file-event-file-info.vue
+++ b/frontend/src/components/inspect-file/file-history/file-event-file-info.vue
@@ -1,5 +1,9 @@
 <template>
-    <span v-if="file" class="text-grey-6 text-caption q-ml-md">
+    <span
+        v-if="file"
+        class="text-grey-6 text-caption file-event-file-info"
+        :class="$q.screen.xs ? 'q-ml-none' : 'q-ml-md'"
+    >
         File:
         <span v-if="file.projectName"> {{ file.projectName }} / </span>
         <span v-if="file.missionName"> {{ file.missionName }} / </span>
@@ -24,8 +28,17 @@
 
 <script setup lang="ts">
 import type { FileEventDto } from '@kleinkram/api-dto/types/file/file-event.dto';
+import { useQuasar } from 'quasar';
 
 defineProps<{
     file?: FileEventDto['file'];
 }>();
+
+const $q = useQuasar();
 </script>
+
+<style scoped>
+.file-event-file-info {
+    overflow-wrap: anywhere;
+}
+</style>

--- a/frontend/src/components/inspect-file/file-history/file-event-group-item.vue
+++ b/frontend/src/components/inspect-file/file-history/file-event-group-item.vue
@@ -39,9 +39,12 @@
                     </span>
                     <FileEventFileInfo :file="event.file" />
                 </q-item-label>
+                <q-item-label v-if="$q.screen.xs" caption class="text-grey-6">
+                    {{ formatDate(event.createdAt) }}
+                </q-item-label>
             </q-item-section>
 
-            <q-item-section side>
+            <q-item-section v-if="!$q.screen.xs" side>
                 <div class="text-caption text-grey-6">
                     {{ formatDate(event.createdAt) }}
                 </div>
@@ -54,7 +57,7 @@
                     <q-item
                         v-for="subEvent in event.events"
                         :key="subEvent.uuid"
-                        class="q-pl-xl"
+                        :class="$q.screen.xs ? 'q-pl-md' : 'q-pl-xl'"
                     >
                         <q-item-section>
                             <q-item-label class="text-caption text-grey-7">
@@ -98,8 +101,15 @@
                                 &rarr;
                                 {{ subEvent.details.newFilename }}
                             </q-item-label>
+                            <q-item-label
+                                v-if="$q.screen.xs"
+                                caption
+                                class="text-grey-6"
+                            >
+                                {{ formatDate(subEvent.createdAt) }}
+                            </q-item-label>
                         </q-item-section>
-                        <q-item-section side>
+                        <q-item-section v-if="!$q.screen.xs" side>
                             <div class="text-caption text-grey-6">
                                 {{ formatDate(subEvent.createdAt) }}
                             </div>
@@ -113,6 +123,7 @@
 
 <script setup lang="ts">
 import { FileEventType } from '@kleinkram/shared';
+import { useQuasar } from 'quasar';
 import { formatDate } from 'src/services/date-formating';
 import FileEventAttribution from './file-event-attribution.vue';
 import FileEventFileInfo from './file-event-file-info.vue';
@@ -124,4 +135,6 @@ defineProps<{
     event: GroupedFileEvent;
     hideActionAttribution?: boolean;
 }>();
+
+const $q = useQuasar();
 </script>

--- a/frontend/src/components/inspect-file/file-history/file-event-single-item.vue
+++ b/frontend/src/components/inspect-file/file-history/file-event-single-item.vue
@@ -16,8 +16,11 @@
             <q-item-label v-if="event.details?.sourceFilename" caption>
                 &larr; {{ event.details.sourceFilename }}
             </q-item-label>
+            <q-item-label v-if="$q.screen.xs" caption class="text-grey-6">
+                {{ formatDate(event.createdAt) }}
+            </q-item-label>
         </q-item-section>
-        <q-item-section side style="padding-right: 40px">
+        <q-item-section v-if="!$q.screen.xs" side style="padding-right: 40px">
             <div class="text-caption text-grey-6">
                 {{ formatDate(event.createdAt) }}
             </div>
@@ -27,6 +30,7 @@
 
 <script setup lang="ts">
 import type { FileEventDto } from '@kleinkram/api-dto/types/file/file-event.dto';
+import { useQuasar } from 'quasar';
 import { formatDate } from 'src/services/date-formating';
 import FileEventAttribution from './file-event-attribution.vue';
 import FileEventFileInfo from './file-event-file-info.vue';
@@ -37,4 +41,6 @@ defineProps<{
     event: FileEventDto;
     hideActionAttribution?: boolean;
 }>();
+
+const $q = useQuasar();
 </script>

--- a/frontend/src/components/inspect-file/file-topic-table.vue
+++ b/frontend/src/components/inspect-file/file-topic-table.vue
@@ -1,7 +1,9 @@
 <template>
     <div class="file-topic-table">
-        <div class="flex justify-between items-center q-mb-md">
-            <h2 class="text-h4 q-my-none flex items-center">
+        <div
+            class="flex justify-between items-center q-mb-md file-topic-table__head"
+        >
+            <h2 class="text-h5 text-md-h4 q-my-none flex items-center">
                 Messages
                 <q-badge
                     color="orange-7"
@@ -19,7 +21,11 @@
                     </q-tooltip>
                 </q-badge>
             </h2>
-            <app-search-bar v-model="search" placeholder="Search topics..." />
+            <app-search-bar
+                v-model="search"
+                placeholder="Search topics..."
+                class="file-topic-table__search"
+            />
         </div>
 
         <q-table
@@ -48,6 +54,11 @@
                                 round
                                 flat
                                 dense
+                                :aria-label="
+                                    props.expand
+                                        ? 'Collapse topic preview'
+                                        : 'Expand topic preview'
+                                "
                                 :icon="
                                     props.expand
                                         ? 'sym_o_expand_less'
@@ -55,6 +66,16 @@
                                 "
                                 @click.stop="() => toggleExpand(props)"
                             />
+                        </template>
+
+                        <template v-else-if="col.name === 'name'">
+                            <div class="topic-name">{{ col.value }}</div>
+                            <div
+                                v-if="$q.screen.xs"
+                                class="text-caption text-grey-7 topic-name"
+                            >
+                                {{ props.row.type }}
+                            </div>
                         </template>
 
                         <template v-else>
@@ -65,7 +86,7 @@
 
                 <q-tr v-if="props.expand" :props="props">
                     <q-td colspan="100%" class="q-pa-none">
-                        <div class="q-pa-md">
+                        <div class="q-pa-md topic-expanded">
                             <MessageViewer
                                 :topic-name="props.row.name"
                                 :message-type="props.row.type"
@@ -102,6 +123,7 @@
 <script setup lang="ts">
 import AppSearchBar from 'components/common/app-search-bar.vue';
 import type { QTableColumn } from 'quasar';
+import { useQuasar } from 'quasar';
 import { computed, ref } from 'vue';
 import { detectPreviewType, PreviewType } from '../../services/message-factory';
 import MessageViewer from './message-viewer.vue';
@@ -125,6 +147,7 @@ const properties = defineProps<{
 }>();
 
 const emit = defineEmits(['load-preview', 'pause-preview', 'resume-preview']);
+const $q = useQuasar();
 const search = ref('');
 
 const filteredTopics = computed(() => {
@@ -137,7 +160,7 @@ const filteredTopics = computed(() => {
     );
 });
 
-const columns: QTableColumn[] = [
+const allColumns: QTableColumn[] = [
     {
         name: 'expand',
         label: '',
@@ -174,6 +197,20 @@ const columns: QTableColumn[] = [
         align: 'right',
     },
 ];
+
+/**
+ * Phones only have room for the topic and the message count; the datatype
+ * is shown as a caption below the topic name instead of in its own column.
+ */
+const HIDDEN_COLUMNS_ON_PHONES = new Set(['type', 'freq']);
+
+const columns = computed<QTableColumn[]>(() =>
+    $q.screen.xs
+        ? allColumns.filter(
+              (column) => !HIDDEN_COLUMNS_ON_PHONES.has(column.name),
+          )
+        : allColumns,
+);
 
 interface LoadPlan {
     /** Number of messages to keep in memory */
@@ -405,3 +442,59 @@ const loadMore = (topicName: string): void => {
     loadData(topicName, 20, true);
 };
 </script>
+
+<style scoped>
+.file-topic-table {
+    max-width: 100%;
+}
+
+/* Long topic names wrap instead of widening the table */
+.topic-name {
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 599px) {
+    /* Title and search bar stack, the search bar takes the full width */
+    .file-topic-table__head {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+    }
+
+    .file-topic-table__search {
+        width: 100%;
+    }
+
+    /* The expanded preview gets the full width of the table */
+    .topic-expanded {
+        min-width: 0;
+        padding: 8px 4px;
+    }
+
+    /* Fixed layout so the topic column shrinks and the count stays visible */
+    :deep(.q-table) {
+        table-layout: fixed;
+        width: 100%;
+    }
+
+    :deep(.q-table th:first-child),
+    :deep(.q-table td:first-child) {
+        width: 44px;
+        padding-left: 4px;
+        padding-right: 4px;
+    }
+
+    :deep(.q-table th:last-child),
+    :deep(.q-table td:last-child) {
+        width: 84px;
+    }
+
+    :deep(.q-table td[colspan]) {
+        width: auto;
+    }
+
+    .topic-name {
+        overflow-wrap: anywhere;
+    }
+}
+</style>

--- a/frontend/src/components/inspect-file/file-topic-table.vue
+++ b/frontend/src/components/inspect-file/file-topic-table.vue
@@ -471,26 +471,31 @@ const loadMore = (topicName: string): void => {
         padding: 8px 4px;
     }
 
-    /* Fixed layout so the topic column shrinks and the count stays visible */
+    /* The topic column takes the remaining width; breaking anywhere keeps
+       its minimum width tiny so the table can shrink to the phone width */
     :deep(.q-table) {
-        table-layout: fixed;
         width: 100%;
     }
 
     :deep(.q-table th:first-child),
-    :deep(.q-table td:first-child) {
+    :deep(.q-table td:first-child:not([colspan])) {
         width: 44px;
         padding-left: 4px;
         padding-right: 4px;
     }
 
-    :deep(.q-table th:last-child),
-    :deep(.q-table td:last-child) {
-        width: 84px;
+    :deep(.q-table th:nth-child(2)),
+    :deep(.q-table td:nth-child(2)) {
+        width: 100%;
+        min-width: 0;
+        white-space: normal;
+        overflow-wrap: anywhere;
     }
 
-    :deep(.q-table td[colspan]) {
-        width: auto;
+    :deep(.q-table th:last-child),
+    :deep(.q-table td:last-child:not([colspan])) {
+        white-space: nowrap;
+        text-align: right;
     }
 
     .topic-name {

--- a/frontend/src/components/inspect-file/file-topic-table.vue
+++ b/frontend/src/components/inspect-file/file-topic-table.vue
@@ -465,10 +465,13 @@ const loadMore = (topicName: string): void => {
         width: 100%;
     }
 
-    /* The expanded preview gets the full width of the table */
+    /* The expanded preview gets exactly the width of the table: a table
+       cell otherwise grows to its content and pushes the row off screen */
     .topic-expanded {
-        min-width: 0;
+        width: 0;
+        min-width: 100%;
         padding: 8px 4px;
+        overflow-x: hidden;
     }
 
     /* The topic column takes the remaining width; breaking anywhere keeps

--- a/frontend/src/components/inspect-file/message-viewer.vue
+++ b/frontend/src/components/inspect-file/message-viewer.vue
@@ -1,14 +1,18 @@
 <template>
     <div class="message-viewer q-pa-sm rounded-borders">
-        <div class="row justify-between items-center q-mb-sm">
-            <div class="text-subtitle2 text-grey-8 flex items-center">
+        <div
+            class="row justify-between items-center q-mb-sm message-viewer__header"
+        >
+            <div
+                class="text-subtitle2 text-grey-8 flex items-center message-viewer__title"
+            >
                 {{ topicName }}
                 <q-badge color="grey-4" text-color="black" class="q-ml-sm">
                     {{ messageType }}
                 </q-badge>
             </div>
 
-            <div class="row items-center q-gutter-x-sm">
+            <div class="row items-center q-gutter-x-sm message-viewer__badges">
                 <q-badge
                     v-if="(sampleStride ?? 1) > 1"
                     color="grey-3"
@@ -196,3 +200,33 @@ const emitPausePreview = (): void => {
     emit('pause-preview');
 };
 </script>
+
+<style scoped>
+.message-viewer {
+    min-width: 0;
+}
+
+@media (max-width: 599px) {
+    /* Topic name, type badge, sampling badge and BETA wrap onto their own
+       lines instead of pushing each other out of the viewport */
+    .message-viewer__header {
+        flex-wrap: wrap;
+        row-gap: 4px;
+    }
+
+    .message-viewer__title {
+        flex-wrap: wrap;
+        min-width: 0;
+        overflow-wrap: anywhere;
+    }
+
+    .message-viewer__badges {
+        flex-wrap: wrap;
+        row-gap: 4px;
+    }
+
+    .message-viewer {
+        padding: 4px;
+    }
+}
+</style>

--- a/frontend/src/components/inspect-file/viewers/json-log-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/json-log-viewer.vue
@@ -6,7 +6,10 @@
                 :key="idx"
                 class="q-py-md items-start"
             >
-                <q-item-section side style="min-width: 150px">
+                <q-item-section
+                    side
+                    :style="{ minWidth: $q.screen.xs ? '0' : '150px' }"
+                >
                     <div class="text-caption text-weight-bold text-primary">
                         {{ formatTime(msg.logTime) }}
                     </div>
@@ -79,8 +82,10 @@
 </template>
 
 <script setup lang="ts">
-import { Notify, copyToClipboard as quasarCopy } from 'quasar';
+import { Notify, copyToClipboard as quasarCopy, useQuasar } from 'quasar';
 import { onMounted } from 'vue';
+
+const $q = useQuasar();
 
 const properties = defineProps<{
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/src/components/inspect-file/viewers/ros-log-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/ros-log-viewer.vue
@@ -34,7 +34,10 @@
                     style="font-family: monospace; font-size: 0.8em"
                 >
                     <!-- Time -->
-                    <span class="text-grey-7 q-mr-sm" style="min-width: 140px">
+                    <span
+                        class="text-grey-7 q-mr-sm"
+                        :style="{ minWidth: $q.screen.xs ? '0' : '140px' }"
+                    >
                         [{{ formatTime(msg.logTime) }}]
                     </span>
 
@@ -82,9 +85,11 @@
 </template>
 
 <script setup lang="ts">
-import { Notify, copyToClipboard as quasarCopy } from 'quasar';
+import { Notify, copyToClipboard as quasarCopy, useQuasar } from 'quasar';
 import { onMounted } from 'vue';
 import SmoothLoading from '../../common/smooth-loading.vue';
+
+const $q = useQuasar();
 
 const properties = defineProps<{
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/src/components/inspect-file/viewers/ros-log-viewer.vue
+++ b/frontend/src/components/inspect-file/viewers/ros-log-viewer.vue
@@ -27,39 +27,70 @@
                 class="q-pa-sm bg-grey-1 rounded-borders"
                 style="max-height: 500px; overflow-y: auto"
             >
-                <div
-                    v-for="(msg, idx) in messages"
-                    :key="idx"
-                    class="row no-wrap items-baseline q-py-xs"
-                    style="font-family: monospace; font-size: 0.8em"
-                >
-                    <!-- Time -->
-                    <span
-                        class="text-grey-7 q-mr-sm"
-                        :style="{ minWidth: $q.screen.xs ? '0' : '140px' }"
+                <template v-if="$q.screen.xs">
+                    <!-- Phones: two-line entries (meta line, then message) -->
+                    <div
+                        v-for="(msg, idx) in messages"
+                        :key="idx"
+                        class="log-entry q-py-xs"
                     >
-                        [{{ formatTime(msg.logTime) }}]
-                    </span>
-
-                    <!-- Level -->
-                    <span
-                        class="text-weight-bold q-mr-sm"
-                        :class="getLevelClass(msg.data.level)"
-                        style="min-width: 50px"
+                        <div class="row items-center no-wrap q-gutter-x-sm">
+                            <span
+                                class="log-level"
+                                :class="getLevelClass(msg.data.level)"
+                            >
+                                {{ getLevelLabel(msg.data.level) }}
+                            </span>
+                            <span class="text-grey-7 log-meta">
+                                {{ formatTime(msg.logTime) }}
+                            </span>
+                            <span
+                                class="text-grey-8 log-meta ellipsis col"
+                                :title="msg.data.name"
+                            >
+                                {{ msg.data.name }}
+                            </span>
+                        </div>
+                        <div class="text-grey-10 log-message">
+                            {{ msg.data.msg }}
+                        </div>
+                    </div>
+                </template>
+                <template v-else>
+                    <div
+                        v-for="(msg, idx) in messages"
+                        :key="idx"
+                        class="row no-wrap items-baseline q-py-xs"
+                        style="font-family: monospace; font-size: 0.8em"
                     >
-                        [{{ getLevelLabel(msg.data.level) }}]
-                    </span>
+                        <!-- Time -->
+                        <span
+                            class="text-grey-7 q-mr-sm"
+                            style="min-width: 140px"
+                        >
+                            [{{ formatTime(msg.logTime) }}]
+                        </span>
 
-                    <!-- Node -->
-                    <span class="text-grey-9 q-mr-sm text-weight-medium">
-                        [{{ msg.data.name }}]
-                    </span>
+                        <!-- Level -->
+                        <span
+                            class="text-weight-bold q-mr-sm"
+                            :class="getLevelClass(msg.data.level)"
+                            style="min-width: 50px"
+                        >
+                            [{{ getLevelLabel(msg.data.level) }}]
+                        </span>
 
-                    <!-- Message -->
-                    <span class="text-grey-10 break-word col">
-                        {{ msg.data.msg }}
-                    </span>
-                </div>
+                        <!-- Node -->
+                        <span class="text-grey-9 q-mr-sm text-weight-medium">
+                            [{{ msg.data.name }}]
+                        </span>
+
+                        <!-- Message -->
+                        <span class="text-grey-10 break-word col">
+                            {{ msg.data.msg }}
+                        </span>
+                    </div>
+                </template>
             </div>
 
             <div
@@ -192,5 +223,37 @@ const loadMore = (): void => {
 }
 .hover-bg:hover {
     background-color: #fafafa;
+}
+
+.log-entry {
+    border-bottom: 1px solid #eeeeee;
+}
+
+.log-entry:last-child {
+    border-bottom: none;
+}
+
+.log-level {
+    font-family: monospace;
+    font-size: 0.75em;
+    font-weight: 700;
+    padding: 1px 6px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.05);
+    flex: 0 0 auto;
+}
+
+.log-meta {
+    font-family: monospace;
+    font-size: 0.75em;
+    min-width: 0;
+}
+
+.log-message {
+    font-family: monospace;
+    font-size: 0.8em;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    margin-top: 2px;
 }
 </style>

--- a/frontend/src/components/queue-items.vue
+++ b/frontend/src/components/queue-items.vue
@@ -1,6 +1,9 @@
 <template>
-    <div class="row items-center">
-        <div class="col-5 q-py-md q-pr-md">
+    <div class="row items-center queue-filters">
+        <div
+            class="col-12 col-md-5 q-py-md"
+            :class="$q.screen.gt.sm ? 'q-pr-md' : ''"
+        >
             <q-input v-model="startDate" filled hint="File Processing since: ">
                 <template #prepend>
                     <q-icon name="sym_o_event" class="cursor-pointer">
@@ -49,7 +52,10 @@
                 </template>
             </q-input>
         </div>
-        <div class="col-5 q-py-md q-pr-md">
+        <div
+            class="col-12 col-md-5 q-py-md"
+            :class="$q.screen.gt.sm ? 'q-pr-md' : ''"
+        >
             <q-select
                 v-model="fileStateFilter"
                 multiple
@@ -87,7 +93,10 @@
                 </template>
             </q-select>
         </div>
-        <div class="col-2 q-py-md">
+        <div
+            class="col-12 col-md-2 q-py-md"
+            :class="$q.screen.gt.sm ? '' : 'q-pt-none'"
+        >
             <app-refresh-button @click="refresh" />
         </div>
     </div>
@@ -98,14 +107,99 @@
         v-model:selected="selected"
         :rows="queueEntries?.data || []"
         :columns="columns as any"
+        :visible-columns="visibleColumns"
         row-key="uuid"
         flat
-        bordered
+        :bordered="!$q.screen.xs"
+        :grid="$q.screen.xs"
         :loading="isLoading"
         binary-state-sort
-        selection="multiple"
+        :selection="$q.screen.lt.md ? 'none' : 'multiple'"
+        class="queue-table"
         @row-click="rowClick"
     >
+        <template #item="props">
+            <div class="col-12 q-pb-sm">
+                <q-card
+                    flat
+                    bordered
+                    class="queue-card"
+                    @click="() => openRow(props.row)"
+                >
+                    <q-card-section>
+                        <div class="row no-wrap items-start">
+                            <div class="col" style="min-width: 0">
+                                <div
+                                    class="queue-card__name text-weight-medium"
+                                >
+                                    {{ displayNameOf(props.row) }}
+                                </div>
+                                <div
+                                    class="queue-card__meta text-caption q-mt-xs"
+                                >
+                                    {{ props.row.mission.project.name }} /
+                                    {{ props.row.mission.name }}
+                                </div>
+                            </div>
+                            <q-btn
+                                flat
+                                round
+                                icon="sym_o_more_vert"
+                                unelevated
+                                color="primary"
+                                aria-label="File actions"
+                                class="queue-card__action cursor-pointer"
+                                @click.stop
+                            >
+                                <q-menu
+                                    auto-close
+                                    style="
+                                        max-width: 200px;
+                                        min-width: 160px;
+                                        width: 180px;
+                                    "
+                                >
+                                    <q-list>
+                                        <q-item
+                                            v-for="action in rowActions(
+                                                props.row,
+                                            )"
+                                            :key="action.label"
+                                            v-ripple
+                                            clickable
+                                            :disable="action.disabled"
+                                            @click="action.handler"
+                                        >
+                                            <q-item-section>
+                                                {{ action.label }}
+                                            </q-item-section>
+                                        </q-item>
+                                    </q-list>
+                                </q-menu>
+                            </q-btn>
+                        </div>
+
+                        <div
+                            class="row items-center justify-between q-mt-sm"
+                            style="gap: 8px"
+                        >
+                            <q-badge :color="getColor(props.row.state)">
+                                {{ getSimpleFileStateName(props.row.state) }}
+                            </q-badge>
+                            <span class="queue-card__meta text-caption">
+                                {{ lastUpdateOf(props.row) }}
+                            </span>
+                        </div>
+
+                        <div class="queue-card__meta text-caption q-mt-xs">
+                            {{ props.row.location }} ·
+                            {{ props.row.creator.name }}
+                        </div>
+                    </q-card-section>
+                </q-card>
+            </div>
+        </template>
+
         <template #body-selection="props">
             <q-checkbox
                 v-model="props.selected"
@@ -141,40 +235,15 @@
                     >
                         <q-list>
                             <q-item
+                                v-for="action in rowActions(props.row)"
+                                :key="action.label"
                                 v-ripple
                                 clickable
-                                :disable="
-                                    props.row.state !== QueueState.COMPLETED
-                                "
-                                @click="() => downloadFile(props.row)"
-                            >
-                                <q-item-section>Download File</q-item-section>
-                            </q-item>
-                            <q-item
-                                v-ripple
-                                clickable
-                                :disable="!canDelete(props.row)"
-                                @click="() => openDeleteFileDialog(props.row)"
-                            >
-                                <q-item-section>Delete File</q-item-section>
-                            </q-item>
-                            <q-item
-                                v-ripple
-                                clickable
-                                :disable="
-                                    props.row.state !==
-                                    QueueState.AWAITING_PROCESSING
-                                "
-                                @click="
-                                    () =>
-                                        _cancelProcessing({
-                                            missionUUID: props.row.mission.uuid,
-                                            queueUUID: props.row.uuid,
-                                        })
-                                "
+                                :disable="action.disabled"
+                                @click="action.handler"
                             >
                                 <q-item-section>
-                                    Cancel Processing
+                                    {{ action.label }}
                                 </q-item-section>
                             </q-item>
                         </q-list>
@@ -316,6 +385,10 @@ async function refresh(): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function rowClick(event: any, row: FileQueueEntryDto): Promise<void> {
+    await openRow(row);
+}
+
+async function openRow(row: FileQueueEntryDto): Promise<void> {
     const isFile =
         row.displayName.endsWith('.bag') || row.displayName.endsWith('.mcap');
     const isCompleted = row.state === QueueState.COMPLETED;
@@ -366,10 +439,69 @@ async function downloadFile(row: FileQueueEntryDto): Promise<void> {
     );
 }
 
+/**
+ * On phones the table is rendered as a card list (see the `#item` slot), on
+ * small screens we only keep the columns that carry the essential
+ * information so that the table does not need horizontal scrolling.
+ */
+const visibleColumns = computed<string[] | undefined>(() =>
+    $q.screen.lt.md
+        ? ['Filename', 'Mission', 'Status', 'change', 'action']
+        : undefined,
+);
+
+function displayNameOf(row: FileQueueEntryDto): string {
+    if (
+        row.displayName === row.identifier &&
+        row.location === FileLocation.DRIVE
+    )
+        return 'Not available';
+    return row.displayName;
+}
+
+function lastUpdateOf(row: FileQueueEntryDto): string {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    return row.updatedAt ? formatDate(row.updatedAt, true) : 'error';
+}
+
+interface QueueRowAction {
+    label: string;
+    disabled: boolean;
+    handler: () => void;
+}
+
+function rowActions(row: FileQueueEntryDto): QueueRowAction[] {
+    return [
+        {
+            label: 'Download File',
+            disabled: row.state !== QueueState.COMPLETED,
+            handler: (): void => {
+                void downloadFile(row);
+            },
+        },
+        {
+            label: 'Delete File',
+            disabled: !canDelete(row),
+            handler: (): void => {
+                openDeleteFileDialog(row);
+            },
+        },
+        {
+            label: 'Cancel Processing',
+            disabled: row.state !== QueueState.AWAITING_PROCESSING,
+            handler: (): void => {
+                _cancelProcessing({
+                    missionUUID: row.mission.uuid,
+                    queueUUID: row.uuid,
+                });
+            },
+        },
+    ];
+}
+
 const columns = [
     {
         name: 'Project',
-        required: true,
         label: 'Project',
         align: 'left',
         field: (row: FileQueueEntryDto): string => row.mission.project.name,
@@ -384,7 +516,6 @@ const columns = [
     { name: 'Status', label: 'Status', align: 'left', field: 'state' },
     {
         name: 'Location',
-        required: true,
         label: 'File Origin',
         align: 'left',
         field: 'location',
@@ -394,27 +525,17 @@ const columns = [
         required: true,
         label: 'Filename',
         align: 'left',
-        field: (row: FileQueueEntryDto): string => {
-            if (
-                row.displayName === row.identifier &&
-                row.location === FileLocation.DRIVE
-            )
-                return 'Not available';
-            return row.displayName;
-        },
+        field: (row: FileQueueEntryDto): string => displayNameOf(row),
     },
     {
         name: 'change',
         required: true,
         label: 'Last status update',
         align: 'left',
-        field: (row: FileQueueEntryDto): string =>
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            row.updatedAt ? formatDate(row.updatedAt, true) : 'error',
+        field: (row: FileQueueEntryDto): string => lastUpdateOf(row),
     },
     {
         name: 'Creator',
-        required: true,
         label: 'Creator',
         align: 'left',
         field: (row: FileQueueEntryDto): string => row.creator.name,
@@ -431,4 +552,56 @@ const columns = [
 ];
 </script>
 
-<style scoped></style>
+<style scoped>
+/* Stacked filter controls need to span the full width on small screens */
+@media (max-width: 1023px) {
+    .queue-filters :deep(.q-field) {
+        width: 100%;
+    }
+
+    /* Enlarge the icon-only refresh button to a comfortable touch target */
+    .queue-filters :deep(.q-btn) {
+        height: 40px !important;
+        width: 40px !important;
+    }
+}
+
+.queue-card {
+    cursor: pointer;
+}
+
+/* The dense row-action button is below the comfortable touch target size */
+@media (max-width: 1023px) {
+    .queue-table :deep(.q-td .q-btn) {
+        min-height: 40px;
+        min-width: 40px;
+    }
+}
+
+.queue-card__name {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.queue-card__meta {
+    color: #58585c;
+    overflow-wrap: anywhere;
+}
+
+.queue-card__action {
+    min-height: 40px;
+    min-width: 40px;
+}
+
+@media (max-width: 599px) {
+    /* The pagination controls must wrap instead of overflowing the page */
+    .queue-table :deep(.q-table__bottom) {
+        flex-wrap: wrap;
+        row-gap: 4px;
+    }
+
+    .queue-table :deep(.q-table__grid-content) {
+        margin: 0;
+    }
+}
+</style>

--- a/frontend/src/components/rename-files-dialog.vue
+++ b/frontend/src/components/rename-files-dialog.vue
@@ -1,6 +1,6 @@
 <template>
     <q-dialog ref="dialogRef" @hide="onDialogHide">
-        <q-card class="q-dialog-plugin" style="min-width: 500px">
+        <q-card class="q-dialog-plugin rename-files-card">
             <q-card-section>
                 <div class="text-h6">Invalid Filenames</div>
                 <div class="text-caption text-grey">
@@ -136,3 +136,15 @@ export default defineComponent({
     },
 });
 </script>
+
+<style scoped>
+.rename-files-card {
+    min-width: 500px;
+}
+
+@media (max-width: 599px) {
+    .rename-files-card {
+        min-width: 0;
+    }
+}
+</style>

--- a/frontend/src/components/select-mission-tags.vue
+++ b/frontend/src/components/select-mission-tags.vue
@@ -48,15 +48,8 @@
         ] as TagTypeDto[]"
         :key="tagtype.uuid"
     >
-        <div
-            style="
-                display: flex;
-                flex-direction: row;
-                justify-content: left;
-                margin-bottom: 20px;
-            "
-        >
-            <div style="display: flex; width: 200px">
+        <div class="tag-row">
+            <div class="tag-row__label">
                 <label style="align-self: center">
                     {{ tagtype.name }}
 
@@ -71,7 +64,7 @@
                 </q-chip>
             </div>
 
-            <div style="display: flex; flex-direction: row; flex-grow: 2">
+            <div class="tag-row__input">
                 <q-input
                     v-if="tagtype.datatype !== DataType.BOOLEAN"
                     v-model="localTagValues[tagtype.uuid]"
@@ -282,5 +275,37 @@ const removeTagType = (metadataTypeUUID: string): void => {
     display: flex;
     justify-content: space-between;
     align-items: center;
+}
+
+.tag-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: left;
+    margin-bottom: 20px;
+}
+
+.tag-row__label {
+    display: flex;
+    width: 200px;
+    flex: 0 0 auto;
+}
+
+.tag-row__input {
+    display: flex;
+    flex-direction: row;
+    flex-grow: 2;
+    min-width: 0;
+}
+
+@media (max-width: 599px) {
+    .tag-row {
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: 16px;
+    }
+
+    .tag-row__label {
+        width: 100%;
+    }
 }
 </style>

--- a/frontend/src/components/title-section.vue
+++ b/frontend/src/components/title-section.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="bg-white flex column" style="margin: 0 -24px; padding: 0 24px">
-        <div style="padding: 24px 0; gap: 24px; padding-bottom: 10px">
+    <div class="bg-white flex column title-section">
+        <div class="title-section__inner">
             <div class="row justify-between items-start q-gutter-y-md">
-                <div class="col-12 col-md column">
+                <div class="col-12 col-md column" style="min-width: 0">
                     <slot name="title">
                         <div class="row no-wrap items-center" style="gap: 16px">
                             <h1 class="text-h5 text-md-h3 q-ma-none ellipsis">
@@ -19,12 +19,15 @@
                     </div>
                 </div>
 
-                <div class="col-12 col-md-auto flex justify-end">
+                <div
+                    class="col-12 col-md-auto flex title-section__buttons"
+                    :class="$q.screen.gt.sm ? 'justify-end' : 'justify-start'"
+                >
                     <slot name="buttons" />
                 </div>
             </div>
         </div>
-        <div v-if="slots.tabs" class="justify-start flex">
+        <div v-if="slots.tabs" class="justify-start flex scroll-x-nowrap">
             <div class="q-mt-sm q-pa-none">
                 <slot name="tabs" />
             </div>
@@ -32,11 +35,14 @@
         <div v-else style="height: 14px" />
     </div>
 
-    <q-separator style="margin: 0 -24px; padding: 0 24px" />
+    <q-separator class="title-section__separator" />
 </template>
 
 <script setup lang="ts">
+import { useQuasar } from 'quasar';
 import { useSlots } from 'vue';
+
+const $q = useQuasar();
 
 const { title } = defineProps<{
     title: string | undefined;
@@ -52,3 +58,28 @@ defineSlots<{
     tabs: string;
 }>();
 </script>
+
+<style scoped>
+.title-section,
+.title-section__separator {
+    margin: 0 calc(-1 * var(--page-gutter));
+    padding: 0 var(--page-gutter);
+}
+
+.title-section__inner {
+    padding: 24px 0 10px;
+    gap: 24px;
+}
+
+@media (max-width: 1023px) {
+    .title-section__inner {
+        padding: 16px 0 8px;
+    }
+
+    /* Wrapped action buttons need room between rows on small screens */
+    .title-section__buttons {
+        gap: 8px;
+        max-width: 100%;
+    }
+}
+</style>

--- a/frontend/src/components/user-profile/admin-settings.vue
+++ b/frontend/src/components/user-profile/admin-settings.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="row">
-        <div style="width: 300px">
+        <div class="admin-action">
             <q-btn
                 label="Reset S3 Tagging"
-                class="button-border bg-button-primary full-width"
+                class="button-border bg-button-primary full-width admin-action__btn"
                 icon="sym_o_sell"
                 flat
                 @click="resetS3Tagging"
@@ -14,10 +14,10 @@
                 cannot be undone. There is no confirmation!
             </div>
         </div>
-        <div style="width: 300px; margin-left: 20px">
+        <div class="admin-action">
             <q-btn
                 label="Recompute File Sizes"
-                class="button-border bg-button-primary full-width"
+                class="button-border bg-button-primary full-width admin-action__btn"
                 icon="sym_o_expand"
                 flat
                 @click="resetFileSizes"
@@ -29,10 +29,10 @@
             </div>
         </div>
 
-        <div style="width: 300px; margin-left: 20px">
+        <div class="admin-action">
             <q-btn
                 label="Recalculate Hashes"
-                class="button-border bg-button-primary full-width"
+                class="button-border bg-button-primary full-width admin-action__btn"
                 icon="sym_o_fingerprint"
                 flat
                 @click="recalculateHashes"
@@ -44,10 +44,10 @@
             </div>
         </div>
 
-        <div style="width: 300px; margin-left: 20px">
+        <div class="admin-action">
             <q-btn
                 label="Fix Missing Topics"
-                class="button-border bg-button-primary full-width"
+                class="button-border bg-button-primary full-width admin-action__btn"
                 icon="sym_o_topic"
                 flat
                 @click="reextractTopics"
@@ -114,3 +114,32 @@ async function reextractTopics(): Promise<void> {
     });
 }
 </script>
+
+<style scoped>
+.admin-action {
+    width: 300px;
+}
+
+.admin-action + .admin-action {
+    margin-left: 20px;
+}
+
+/*
+ * Below the desktop breakpoint the four fixed-width maintenance blocks are
+ * stacked and span the full width instead of overflowing the row.
+ */
+@media (max-width: 1023px) {
+    .admin-action {
+        width: 100%;
+    }
+
+    .admin-action + .admin-action {
+        margin-left: 0;
+        margin-top: 24px;
+    }
+
+    .admin-action__btn {
+        min-height: 44px;
+    }
+}
+</style>

--- a/frontend/src/components/user-profile/user-profile-api-keys.vue
+++ b/frontend/src/components/user-profile/user-profile-api-keys.vue
@@ -2,16 +2,89 @@
     <q-table
         v-model:pagination="pagination"
         flat
-        bordered
+        :bordered="!$q.screen.xs"
         :rows="apiKeys"
         :columns="columns"
+        :visible-columns="visibleColumns"
         row-key="uuid"
         wrap-cells
         separator="none"
+        :grid="$q.screen.xs"
         :rows-per-page-options="[10, 20, 50]"
         :loading="isLoading"
+        class="api-key-table"
         @request="onRequest"
     >
+        <template #item="props">
+            <div class="col-12 q-pb-sm">
+                <q-card flat bordered>
+                    <q-card-section>
+                        <div class="row no-wrap items-center justify-between">
+                            <span class="text-weight-medium api-key-card__type">
+                                {{ props.row.keyType }}
+                            </span>
+                            <q-badge
+                                :color="
+                                    props.row.expired ? 'negative' : 'positive'
+                                "
+                                :label="
+                                    props.row.expired ? 'Expired' : 'Active'
+                                "
+                            />
+                        </div>
+
+                        <div class="api-key-card__row">
+                            <span class="api-key-card__label">Rights</span>
+                            <span>{{ rightsLabel(props.row.rights) }}</span>
+                        </div>
+
+                        <div class="api-key-card__row">
+                            <span class="api-key-card__label">Mission</span>
+                            <router-link
+                                v-if="
+                                    props.row.missionUuid &&
+                                    props.row.projectUuid
+                                "
+                                :to="{
+                                    name: ROUTES.FILES.routeName,
+                                    params: {
+                                        projectUuid: props.row.projectUuid,
+                                        missionUuid: props.row.missionUuid,
+                                    },
+                                }"
+                                class="text-primary"
+                            >
+                                {{ props.row.missionName }}
+                            </router-link>
+                            <span v-else>{{
+                                props.row.missionName ?? '—'
+                            }}</span>
+                        </div>
+
+                        <div class="api-key-card__row">
+                            <span class="api-key-card__label">Action</span>
+                            <router-link
+                                v-if="props.row.actionUuid"
+                                :to="{
+                                    name: ROUTES.ANALYSIS_DETAILS.routeName,
+                                    params: { id: props.row.actionUuid },
+                                }"
+                                class="text-primary"
+                            >
+                                {{ actionLabel(props.row) }}
+                            </router-link>
+                            <span v-else>—</span>
+                        </div>
+
+                        <div class="api-key-card__row">
+                            <span class="api-key-card__label">Created</span>
+                            <span>{{ createdLabel(props.row) }}</span>
+                        </div>
+                    </q-card-section>
+                </q-card>
+            </div>
+        </template>
+
         <template #no-data>
             <div
                 class="flex flex-center"
@@ -55,11 +128,7 @@
                     }"
                     class="text-primary"
                 >
-                    {{
-                        props.row.actionTemplateVersion
-                            ? `${props.row.actionTemplateName} v${props.row.actionTemplateVersion}`
-                            : props.row.actionTemplateName || '—'
-                    }}
+                    {{ actionLabel(props.row) }}
                 </router-link>
                 <span v-else>—</span>
             </q-td>
@@ -83,6 +152,7 @@
 import type { ApiKeyMetadataDto } from '@kleinkram/api-dto/types/user/api-key-metadata.dto';
 import { AccessGroupRights } from '@kleinkram/shared';
 import type { QTableColumn } from 'quasar';
+import { useQuasar } from 'quasar';
 import { useMyApiKeys } from 'src/hooks/query-hooks';
 import ROUTES from 'src/router/routes';
 import { formatDate } from 'src/services/date-formating';
@@ -90,7 +160,30 @@ import { QueryURLHandler } from 'src/services/query-handler';
 import { computed, reactive } from 'vue';
 import { useRouter } from 'vue-router';
 
+const $q = useQuasar();
 const router = useRouter();
+
+/**
+ * On phones the table is rendered as a card list (see the `#item` slot); on
+ * small screens the least important columns are dropped so that the table
+ * fits without horizontal scrolling.
+ */
+const visibleColumns = computed<string[] | undefined>(() =>
+    $q.screen.lt.md
+        ? ['key_type', 'rights', 'missionName', 'deletedAt']
+        : undefined,
+);
+
+const actionLabel = (row: ApiKeyMetadataDto): string => {
+    const name = row.actionTemplateName ?? '';
+    if (name === '') return '—';
+    return row.actionTemplateVersion === undefined
+        ? name
+        : `${name} v${String(row.actionTemplateVersion)}`;
+};
+
+const createdLabel = (row: ApiKeyMetadataDto): string =>
+    formatDate(new Date(row.createdAt));
 const queryHandler = reactive(
     new QueryURLHandler(router, undefined, undefined, 'createdAt', true),
 );
@@ -191,7 +284,6 @@ const columns: QTableColumn<ApiKeyMetadataDto>[] = [
     },
     {
         name: 'actionTemplateName',
-        required: true,
         label: 'Action',
         align: 'left',
         field: (row) => row.actionTemplateName,
@@ -208,7 +300,6 @@ const columns: QTableColumn<ApiKeyMetadataDto>[] = [
     },
     {
         name: 'createdAt',
-        required: true,
         label: 'Created',
         align: 'left',
         field: (row) => row.createdAt,
@@ -217,3 +308,35 @@ const columns: QTableColumn<ApiKeyMetadataDto>[] = [
     },
 ];
 </script>
+
+<style scoped>
+.api-key-card__type {
+    overflow-wrap: anywhere;
+}
+
+.api-key-card__row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 6px;
+    font-size: 13px;
+    overflow-wrap: anywhere;
+}
+
+.api-key-card__label {
+    color: #58585c;
+    flex: 0 0 auto;
+}
+
+@media (max-width: 599px) {
+    /* The pagination controls must wrap instead of overflowing the page */
+    .api-key-table :deep(.q-table__bottom) {
+        flex-wrap: wrap;
+        row-gap: 4px;
+    }
+
+    .api-key-table :deep(.q-table__grid-content) {
+        margin: 0;
+    }
+}
+</style>

--- a/frontend/src/components/user-profile/user-profile-banner.vue
+++ b/frontend/src/components/user-profile/user-profile-banner.vue
@@ -1,15 +1,22 @@
 <template>
-    <div v-if="user" class="row">
+    <div
+        v-if="user"
+        class="profile-banner"
+        :class="$q.screen.xs ? 'column items-center text-center' : 'row'"
+    >
         <q-img
             v-if="user.avatarUrl"
             :src="user.avatarUrl"
-            style="width: 100px; height: 100px; border-radius: 50%"
+            class="profile-banner__avatar"
         />
-        <div class="q-ml-md">
-            <h2 class="text-h3" style="margin-bottom: 5px; margin-top: 10px">
+        <div :class="$q.screen.xs ? 'q-mt-sm' : 'q-ml-md'">
+            <h2
+                class="profile-banner__name"
+                :class="$q.screen.xs ? 'text-h5' : 'text-h3'"
+            >
                 {{ user.name }}
             </h2>
-            <p class="text-subtitle2" style="color: #58585c">
+            <p class="text-subtitle2 profile-banner__email">
                 {{ user.email }}
             </p>
         </div>
@@ -20,8 +27,45 @@
 </template>
 
 <script setup lang="ts">
+import { useQuasar } from 'quasar';
 import { useUser } from 'src/hooks/query-hooks';
 import 'vue-json-pretty/lib/styles.css';
 
+const $q = useQuasar();
 const { data: user } = useUser();
 </script>
+
+<style scoped>
+.profile-banner {
+    max-width: 100%;
+}
+
+.profile-banner__avatar {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    flex: 0 0 auto;
+}
+
+.profile-banner__name {
+    margin-bottom: 5px;
+    margin-top: 10px;
+    overflow-wrap: anywhere;
+}
+
+.profile-banner__email {
+    color: #58585c;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 599px) {
+    .profile-banner__avatar {
+        width: 72px;
+        height: 72px;
+    }
+
+    .profile-banner__name {
+        margin-top: 0;
+    }
+}
+</style>

--- a/frontend/src/components/user-profile/user-profile-details.vue
+++ b/frontend/src/components/user-profile/user-profile-details.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="user" class="q-table-container">
+    <div v-if="user" class="q-table-container profile-details">
         <table class="q-table__table">
             <tbody>
                 <tr>
@@ -129,5 +129,49 @@ const primaryGroup = computed(
 
 .first-column {
     width: 130px;
+}
+</style>
+
+<style scoped>
+/*
+ * On phones the two-column key/value table does not fit: the labels and the
+ * (potentially very long) values are stacked instead, and chip content is
+ * allowed to wrap so that UUIDs never push the page wider than the viewport.
+ */
+@media (max-width: 599px) {
+    .profile-details tr {
+        display: block;
+        border-bottom: 1px solid #e0e0e0;
+    }
+
+    .profile-details .q-table__cell {
+        display: block;
+        width: auto;
+        border-right: none;
+        border-bottom: none;
+        padding: 2px 8px;
+    }
+
+    .profile-details .first-column {
+        padding-top: 8px;
+        color: #58585c;
+        font-size: 12px;
+    }
+
+    .profile-details tr td:last-child {
+        padding-bottom: 8px;
+    }
+
+    .profile-details :deep(.q-chip) {
+        max-width: 100%;
+        height: auto;
+        min-height: 2em;
+    }
+
+    .profile-details :deep(.q-chip__content) {
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: break-all;
+    }
 }
 </style>

--- a/frontend/src/components/user-profile/user-profile.vue
+++ b/frontend/src/components/user-profile/user-profile.vue
@@ -32,10 +32,12 @@
                 </q-tabs>
             </template>
         </title-section>
-        <h4>{{ tab }}</h4>
+        <h4 :class="$q.screen.xs ? 'text-h5 q-mt-md q-mb-sm' : ''">
+            {{ tab }}
+        </h4>
         <q-tab-panels
             v-model="tab"
-            class="q-mt-lg"
+            :class="$q.screen.xs ? 'q-mt-md' : 'q-mt-lg'"
             style="background: transparent"
         >
             <q-tab-panel name="Details">
@@ -70,10 +72,12 @@ import AdminSettings from 'components/user-profile/admin-settings.vue';
 import UserProfileApiKeys from 'components/user-profile/user-profile-api-keys.vue';
 import UserProfileBanner from 'components/user-profile/user-profile-banner.vue';
 import UserProfileDetails from 'components/user-profile/user-profile-details.vue';
+import { useQuasar } from 'quasar';
 import { useHandler, useUser } from 'src/hooks/query-hooks';
 import { ref } from 'vue';
 import 'vue-json-pretty/lib/styles.css';
 
+const $q = useQuasar();
 const { data: user } = useUser();
 const tab = ref('Details');
 

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -18,26 +18,60 @@ q-page {
     min-height: 0 !important;
 }
 
-@media (max-width: 600px) {
+/////////////////////////////////////////////////////////////////
+// Page gutter
+//
+// Horizontal spacing between the viewport edge and the page content. The
+// header, the breadcrumbs and full-bleed sections (title-section) use the
+// same variable, so they stay aligned with the content on every screen
+// size. Components that need to span the full width use
+// `margin: 0 calc(-1 * var(--page-gutter))`.
+/////////////////////////////////////////////////////////////////
+
+:root {
+    --page-gutter: 25px;
+}
+
+@media (max-width: 999px) {
+    :root {
+        --page-gutter: 16px;
+    }
+}
+
+.q-page-container {
+    margin-left: var(--page-gutter);
+    margin-right: var(--page-gutter);
+}
+
+@media (max-width: 599px) {
     .q-page-container {
-        margin-left: 0;
-        margin-right: 0;
         overflow-x: hidden;
     }
-}
 
-@media (min-width: 600px) {
-    .q-page-container {
-        margin-left: 10px;
-        margin-right: 10px;
+    // Quasar's default table cell padding is generous; tighten on phones
+    .q-table th,
+    .q-table td {
+        padding: 8px 10px;
+    }
+
+    // Dialogs take the full width on phones
+    .q-dialog__inner--minimized > div {
+        max-width: 100vw !important;
+        min-width: 0 !important;
+        width: 100%;
     }
 }
 
-@media (min-width: 1000px) {
-    .q-page-container {
-        margin-left: 25px;
-        margin-right: 25px;
-    }
+// A horizontally scrollable row (e.g. tabs, chips) that must not wrap
+.scroll-x-nowrap {
+    overflow-x: auto;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+
+.scroll-x-nowrap::-webkit-scrollbar {
+    display: none;
 }
 
 /////////////////////////////////////////////////////////////////

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -60,6 +60,24 @@ q-page {
         min-width: 0 !important;
         width: 100%;
     }
+
+    // Pagination controls wrap instead of overflowing
+    .q-table__bottom {
+        flex-wrap: wrap;
+        row-gap: 4px;
+    }
+
+    // Long chip values (UUIDs, tokens, group names) wrap instead of
+    // forcing horizontal scroll
+    .q-chip {
+        max-width: 100%;
+        height: auto;
+    }
+
+    .q-chip__content {
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
 }
 
 // A horizontally scrollable row (e.g. tabs, chips) that must not wrap

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -54,11 +54,15 @@ q-page {
         padding: 8px 10px;
     }
 
-    // Dialogs take the full width on phones
+    // Dialogs take the full width on phones, whatever inline size they set
+    .q-dialog__inner--minimized {
+        padding: 8px;
+    }
+
     .q-dialog__inner--minimized > div {
-        max-width: 100vw !important;
+        max-width: 100% !important;
         min-width: 0 !important;
-        width: 100%;
+        width: 100% !important;
     }
 
     // Pagination controls wrap instead of overflowing

--- a/frontend/src/dialogs/base-dialog.vue
+++ b/frontend/src/dialogs/base-dialog.vue
@@ -25,8 +25,8 @@
                     />
                 </div>
 
-                <div v-if="$slots.tabs" class="q-mx-lg justify-start flex">
-                    <div class="q-mt-md q-pa-none">
+                <div v-if="$slots.tabs" class="q-mx-lg base-dialog__tabs">
+                    <div class="q-mt-md q-pa-none base-dialog__tabs-inner">
                         <slot name="tabs" />
                     </div>
                 </div>
@@ -76,6 +76,25 @@ export default {
 </script>
 
 <style scoped>
+/* The tabs must not widen the dialog: they scroll inside their row */
+.base-dialog__tabs {
+    display: flex;
+    justify-content: flex-start;
+    min-width: 0;
+    max-width: 100%;
+}
+
+.base-dialog__tabs-inner {
+    min-width: 0;
+    max-width: 100%;
+}
+
+.base-dialog__card,
+.base-dialog__card > div {
+    min-width: 0;
+    max-width: 100%;
+}
+
 .base-dialog__content {
     margin: 40px 24px;
     max-height: calc(min(650px, 100vh - 350px));
@@ -95,6 +114,14 @@ export default {
     .base-dialog__header,
     .base-dialog__actions {
         padding: 16px;
+    }
+
+    .base-dialog__tabs {
+        margin: 0 16px;
+    }
+
+    .base-dialog__tabs-inner {
+        width: 100%;
     }
 
     .base-dialog__title {

--- a/frontend/src/dialogs/base-dialog.vue
+++ b/frontend/src/dialogs/base-dialog.vue
@@ -1,12 +1,17 @@
 <template>
     <q-dialog ref="dialogRef">
         <q-card
-            class="flex column justify-between"
+            class="flex column justify-between base-dialog__card"
             style="min-height: 400px; min-width: 600px"
         >
             <div :style="contentStyle">
-                <div class="q-pa-lg flex row justify-between">
-                    <h3 class="text-h3 q-ma-none" style="max-width: 80%">
+                <div
+                    class="q-pa-lg flex row justify-between base-dialog__header"
+                >
+                    <h3
+                        class="text-h3 q-ma-none base-dialog__title"
+                        style="max-width: 80%"
+                    >
                         <slot name="title" />
                     </h3>
                     <q-btn
@@ -27,20 +32,14 @@
                 </div>
 
                 <q-separator />
-                <div
-                    style="
-                        margin: 40px 24px;
-                        max-height: calc(min(650px, 100vh - 350px));
-                        overflow-y: auto;
-                    "
-                >
+                <div class="base-dialog__content">
                     <slot name="content" />
                 </div>
             </div>
 
             <div>
                 <q-separator />
-                <div class="q-pa-lg flex row justify-end">
+                <div class="q-pa-lg flex row justify-end base-dialog__actions">
                     <slot name="actions" />
                 </div>
             </div>
@@ -75,3 +74,36 @@ export default {
     },
 };
 </script>
+
+<style scoped>
+.base-dialog__content {
+    margin: 40px 24px;
+    max-height: calc(min(650px, 100vh - 350px));
+    overflow-y: auto;
+}
+
+@media (max-width: 599px) {
+    .base-dialog__card {
+        min-height: 0 !important;
+    }
+
+    .base-dialog__content {
+        margin: 16px;
+        max-height: calc(100vh - 200px);
+    }
+
+    .base-dialog__header,
+    .base-dialog__actions {
+        padding: 16px;
+    }
+
+    .base-dialog__title {
+        font-size: 1.5rem;
+        line-height: 2rem;
+    }
+
+    .base-dialog__actions {
+        gap: 8px;
+    }
+}
+</style>

--- a/frontend/src/dialogs/create-mission-dialog.vue
+++ b/frontend/src/dialogs/create-mission-dialog.vue
@@ -100,7 +100,7 @@
                         @update:tag-values="updateTagValue"
                     />
                 </q-tab-panel>
-                <q-tab-panel name="upload" style="min-width: 280px">
+                <q-tab-panel name="upload">
                     <CreateFile
                         v-if="newMission"
                         ref="createFileReference"

--- a/frontend/src/dialogs/create-mission-from-folder-dialog.vue
+++ b/frontend/src/dialogs/create-mission-from-folder-dialog.vue
@@ -64,7 +64,7 @@
                     <q-file
                         v-model="files"
                         outlined
-                        style="min-width: 300px"
+                        style="width: 100%"
                         @click="transferClick"
                     >
                         <template #prepend>

--- a/frontend/src/dialogs/tag-filter.vue
+++ b/frontend/src/dialogs/tag-filter.vue
@@ -4,11 +4,11 @@
             class="q-pa-sm text-center"
             style="width: 80%; min-height: 250px; max-width: 1500px"
         >
-            <div class="q-mt-md row">
-                <div class="col-4">
+            <div class="q-mt-md row q-col-gutter-sm items-end">
+                <div class="col-12 col-sm-4">
                     <q-input v-model="tagtype" label="Search Metadata" />
                 </div>
-                <div class="col-2">
+                <div class="col-12 col-sm-2">
                     <q-btn label="Search" color="primary" />
                 </div>
             </div>
@@ -34,14 +34,9 @@
                     @update:tag-values="updateTagValues"
                 />
             </div>
-            <div class="q-mt-md row">
-                <div class="col-10" />
-                <div class="col-1">
-                    <q-btn label="Close" color="orange" @click="onDialogHide" />
-                </div>
-                <div class="col-1">
-                    <q-btn label="Apply" color="primary" @click="applyAction" />
-                </div>
+            <div class="q-mt-md row justify-end q-gutter-x-sm">
+                <q-btn label="Close" color="orange" @click="onDialogHide" />
+                <q-btn label="Apply" color="primary" @click="applyAction" />
             </div>
         </q-card>
     </q-dialog>

--- a/frontend/src/layouts/main-layout/footer/footer-component.vue
+++ b/frontend/src/layouts/main-layout/footer/footer-component.vue
@@ -1,21 +1,16 @@
 <template>
-    <div class="text-placeholder">
-        <q-toolbar>
-            <q-toolbar
-                class="flex text-center justify-between"
-                style="font-size: 12px"
-            >
-                <div class="flex" style="gap: 8px">
-                    <span>
-                        © {{ year }} ETH Zürich - Robotic Systems Lab (RSL)
-                    </span>
-                    <footer-separator />
+    <footer class="app-footer text-placeholder">
+        <div class="app-footer__inner">
+            <div class="app-footer__group">
+                <span>© {{ year }} ETH Zürich - Robotic Systems Lab (RSL)</span>
+                <footer-separator class="gt-xs" />
+                <span class="app-footer__build">
                     <footer-build-info />
-                </div>
-                <footer-status-page-link />
-            </q-toolbar>
-        </q-toolbar>
-    </div>
+                </span>
+            </div>
+            <footer-status-page-link />
+        </div>
+    </footer>
 </template>
 
 <script setup lang="ts">
@@ -25,3 +20,49 @@ import FooterStatusPageLink from './footer-status-page-link.vue';
 
 const year = new Date().getFullYear();
 </script>
+
+<style scoped>
+.app-footer {
+    border-top: 1px solid #e0e0e0;
+    font-size: 12px;
+    margin: 24px calc(-1 * var(--page-gutter)) 0;
+    padding: 12px var(--page-gutter);
+}
+
+.app-footer__inner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px 16px;
+}
+
+.app-footer__group,
+.app-footer__build {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px 8px;
+}
+
+@media (max-width: 599px) {
+    .app-footer {
+        padding: 16px var(--page-gutter);
+        text-align: center;
+    }
+
+    .app-footer__inner {
+        flex-direction: column;
+        justify-content: center;
+    }
+
+    .app-footer__group {
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    .app-footer__build {
+        justify-content: center;
+    }
+}
+</style>

--- a/frontend/src/layouts/main-layout/header/bread-crumb-navigation.vue
+++ b/frontend/src/layouts/main-layout/header/bread-crumb-navigation.vue
@@ -1,10 +1,13 @@
 <template>
-    <div class="bg-default text-grey-8" style="margin: 0 -24px; z-index: 999">
+    <div
+        class="bg-default text-grey-8"
+        style="margin: 0 calc(-1 * var(--page-gutter)); z-index: 999"
+    >
         <q-separator />
 
         <div
-            class="height-xl flex column justify-center q-px-lg"
-            style="overflow-x: auto"
+            class="height-xl flex column justify-center scroll-x-nowrap"
+            style="padding: 0 var(--page-gutter)"
         >
             <q-breadcrumbs
                 gutter="xs"

--- a/frontend/src/layouts/main-layout/header/header-component.vue
+++ b/frontend/src/layouts/main-layout/header/header-component.vue
@@ -1,17 +1,25 @@
 <template>
-    <q-header class="bg-default text-grey-8 q-px-lg">
-        <q-toolbar class="q-pa-none height-xxl">
+    <q-header
+        class="bg-default text-grey-8"
+        style="padding: 0 var(--page-gutter)"
+    >
+        <q-toolbar class="q-pa-none height-xxl no-wrap">
             <q-toolbar-title
                 shrink
                 class="q-pa-none"
                 @click="navigateBackToHome"
             >
-                <kleinkram-logo class="q-pr-lg" />
+                <kleinkram-logo
+                    :class="$q.screen.gt.xs ? 'q-pr-lg' : 'q-pr-sm'"
+                />
             </q-toolbar-title>
 
             <q-separator vertical />
 
-            <header-tabs :main-menu="mainMenu" class="q-ml-lg" />
+            <header-tabs
+                :main-menu="mainMenu"
+                :class="$q.screen.gt.xs ? 'q-ml-lg' : 'q-ml-xs'"
+            />
 
             <q-space />
 
@@ -24,6 +32,7 @@
 </template>
 
 <script setup lang="ts">
+import { useQuasar } from 'quasar';
 import KleinkramLogo from 'src/components/images/kleinkram-logo.vue';
 import ROUTES from 'src/router/routes';
 import { useRouter } from 'vue-router';
@@ -32,6 +41,7 @@ import HeaderRightMenu from './header-right-menu.vue';
 import HeaderTabs, { MainMenu } from './header-tabs.vue';
 
 const $router = useRouter();
+const $q = useQuasar();
 
 const mainMenu: MainMenu[] = [
     {

--- a/frontend/src/layouts/main-layout/header/header-create-button.vue
+++ b/frontend/src/layouts/main-layout/header/header-create-button.vue
@@ -5,7 +5,8 @@
             class="q-mx-xs"
             style="height: 36px; display: inline-flex"
         />
-        <span class="q-mr-md"> New </span>
+        <span v-if="$q.screen.gt.xs" class="q-mr-md"> New </span>
+        <span v-else class="q-mr-xs" />
     </div>
     <q-separator vertical class="separator" />
     <q-icon
@@ -19,6 +20,12 @@
         class="q-my-sm"
     />
 </template>
+
+<script setup lang="ts">
+import { useQuasar } from 'quasar';
+
+const $q = useQuasar();
+</script>
 
 <style scoped>
 .separator {

--- a/frontend/src/layouts/main-layout/header/header-right-menu.vue
+++ b/frontend/src/layouts/main-layout/header/header-right-menu.vue
@@ -7,7 +7,14 @@
         <div v-else class="flex row justify-end" style="height: 56px">
             <header-create-menu />
 
-            <div style="margin: auto 10px auto 30px" @click="showOverlay">
+            <div
+                :style="{
+                    margin: $q.screen.gt.xs
+                        ? 'auto 10px auto 30px'
+                        : 'auto 0 auto 8px',
+                }"
+                @click="showOverlay"
+            >
                 <q-btn round flat color="grey-8" icon="sym_o_export_notes">
                     <q-tooltip>Processing Uploads</q-tooltip>
                     <q-linear-progress
@@ -19,10 +26,18 @@
                     />
                     <q-menu
                         v-model="isOverlayVisible"
-                        :offset="[110, 20]"
-                        style="width: 400px; overflow: hidden"
+                        :offset="$q.screen.gt.xs ? [110, 20] : [0, 20]"
+                        :style="{
+                            width: $q.screen.gt.xs ? '400px' : '100vw',
+                            maxWidth: '100vw',
+                            overflow: 'hidden',
+                        }"
                     >
-                        <div style="width: 400px">
+                        <div
+                            :style="{
+                                width: $q.screen.gt.xs ? '400px' : '100%',
+                            }"
+                        >
                             <q-card-section
                                 style="
                                     padding-bottom: 5px;
@@ -143,11 +158,14 @@
 <script setup lang="ts">
 import { useQueryClient } from '@tanstack/vue-query';
 import DocumentationIcon from 'components/documentation-icon.vue';
+import { useQuasar } from 'quasar';
 import { useIsUploading, useUser } from 'src/hooks/query-hooks';
 import ROUTES from 'src/router/routes';
 import { computed, inject, ref, watch } from 'vue';
 import HeaderCreateMenu from './header-create-menu.vue';
 import HeaderProfileMenu from './header-profile-menu.vue';
+
+const $q = useQuasar();
 
 const isUploading = useIsUploading();
 const { data: user } = useUser();

--- a/frontend/src/layouts/main-layout/header/header-tabs.vue
+++ b/frontend/src/layouts/main-layout/header/header-tabs.vue
@@ -5,8 +5,9 @@
             key="menu"
             no-caps
             class="q-py-none q-px-sm q-mx-sm text-secondary"
-            label="Menu"
+            :label="$q.screen.gt.xs ? 'Menu' : undefined"
             icon="sym_o_menu"
+            aria-label="Menu"
         >
             <q-menu auto-close style="width: 280px">
                 <q-list>

--- a/frontend/src/pages/access-group-details-page.vue
+++ b/frontend/src/pages/access-group-details-page.vue
@@ -1,19 +1,27 @@
 <template>
     <title-section :title="accessGroup?.name">
         <template #title>
-            <div class="row items-center q-gutter-x-sm">
+            <div class="row items-center no-wrap q-gutter-x-sm">
                 <q-avatar
                     v-if="personal"
-                    size="48px"
+                    :size="$q.screen.xs ? '36px' : '48px'"
                     color="blue-1"
                     text-color="primary"
                 >
                     <q-icon name="sym_o_person" />
                 </q-avatar>
-                <q-avatar v-else size="48px" color="grey-2" text-color="grey-8">
+                <q-avatar
+                    v-else
+                    :size="$q.screen.xs ? '36px' : '48px'"
+                    color="grey-2"
+                    text-color="grey-8"
+                >
                     <q-icon name="sym_o_group" />
                 </q-avatar>
-                <div class="column q-ml-sm">
+                <div
+                    class="col column items-start q-ml-sm"
+                    style="min-width: 0"
+                >
                     <h1 class="text-h5 text-md-h3 q-ma-none ellipsis">
                         {{ accessGroup?.name ?? 'Loading...' }}
                     </h1>
@@ -26,16 +34,17 @@
                         text-color="primary"
                         size="sm"
                         class="q-ma-none q-mt-xs"
+                        style="max-width: 100%"
                     >
-                        <div class="row items-center">
+                        <div class="row items-center no-wrap">
                             <q-icon
                                 name="sym_o_info"
                                 size="16px"
                                 class="q-mr-sm"
                             />
                             <span
-                                class="text-weight-regular"
-                                style="font-size: 13px"
+                                class="text-weight-regular ellipsis"
+                                style="font-size: 13px; min-width: 0"
                             >
                                 Email:
                                 <span class="text-weight-bold"
@@ -82,13 +91,13 @@
 
     <q-tab-panels v-model="tab" class="q-mt-lg" style="background: transparent">
         <q-tab-panel name="projects">
-            <div class="flex justify-between items-center q-mb-lg">
+            <div class="flex justify-between items-center q-mb-lg ag-toolbar">
                 <div />
-                <button-group>
+                <button-group class="ag-toolbar__actions">
                     <app-search-bar
                         v-model="search"
                         placeholder="Search"
-                        class="q-mr-sm"
+                        class="q-mr-sm ag-toolbar__search"
                     />
                     <app-refresh-button @click="refetchOnClick" />
                     <app-create-button
@@ -107,11 +116,127 @@
                 separator="none"
                 :rows="projectRows"
                 :columns="projectCols as any"
+                :grid="$q.screen.xs"
                 selection="multiple"
                 row-key="uuid"
                 :filter="search"
                 binary-state-sort
             >
+                <!-- phones: one tappable card per project -->
+                <template v-if="$q.screen.xs" #item="props">
+                    <div class="col-12 q-pa-xs">
+                        <q-card
+                            flat
+                            bordered
+                            class="ag-card"
+                            :class="{ 'ag-card--selected': props.selected }"
+                            @click="() => rowClick(props.row.uuid)"
+                        >
+                            <q-card-section class="q-px-md q-py-sm">
+                                <div class="row items-center no-wrap">
+                                    <q-checkbox
+                                        v-model="props.selected"
+                                        color="grey-8"
+                                        dense
+                                        class="q-mr-md"
+                                        aria-label="Select project"
+                                        @click.stop
+                                    />
+                                    <div
+                                        class="col column"
+                                        style="min-width: 0"
+                                    >
+                                        <div
+                                            class="text-weight-medium ellipsis"
+                                        >
+                                            {{ props.row.name }}
+                                        </div>
+                                        <div
+                                            class="text-caption text-grey-7 ellipsis"
+                                        >
+                                            {{ props.row.description }}
+                                        </div>
+                                    </div>
+                                    <q-btn
+                                        flat
+                                        round
+                                        dense
+                                        icon="sym_o_more_vert"
+                                        unelevated
+                                        color="primary"
+                                        class="cursor-pointer"
+                                        aria-label="Project actions"
+                                        @click.stop
+                                    >
+                                        <q-menu auto-close>
+                                            <q-list>
+                                                <q-item
+                                                    v-ripple
+                                                    style="width: 180px"
+                                                    clickable
+                                                    @click="
+                                                        () =>
+                                                            rowClick(
+                                                                props.row.uuid,
+                                                            )
+                                                    "
+                                                >
+                                                    <q-item-section>
+                                                        View Project Details
+                                                    </q-item-section>
+                                                </q-item>
+
+                                                <change-project-rights-dialog-opener
+                                                    :project-uuid="
+                                                        props.row.uuid
+                                                    "
+                                                    :project-access-uuid="
+                                                        props.row
+                                                            .project_access_uuid
+                                                    "
+                                                >
+                                                    <q-item v-ripple clickable>
+                                                        <q-item-section>
+                                                            Change rights
+                                                        </q-item-section>
+                                                    </q-item>
+                                                </change-project-rights-dialog-opener>
+                                                <RemoveProjectDialogOpener
+                                                    v-if="accessGroup"
+                                                    :access-group="accessGroup"
+                                                    :project-u-u-i-d="
+                                                        props.row.uuid
+                                                    "
+                                                >
+                                                    <q-item v-ripple clickable>
+                                                        <q-item-section>
+                                                            Remove
+                                                        </q-item-section>
+                                                    </q-item>
+                                                </RemoveProjectDialogOpener>
+                                            </q-list>
+                                        </q-menu>
+                                    </q-btn>
+                                </div>
+                                <div class="q-mt-sm">
+                                    <q-chip
+                                        dense
+                                        square
+                                        size="sm"
+                                        color="grey-2"
+                                        text-color="grey-9"
+                                        class="q-ma-none"
+                                    >
+                                        {{
+                                            AccessGroupRights[props.row.rights]
+                                        }}
+                                    </q-chip>
+                                </div>
+                            </q-card-section>
+                        </q-card>
+                    </div>
+                </template>
+
                 <template #no-data>
                     <div class="full-width row flex-center q-pa-xl text-grey-8">
                         <div class="text-center">
@@ -197,14 +322,14 @@
         <q-tab-panel v-if="!personal" name="members">
             <div
                 v-if="selectedUsers.length === 0"
-                class="flex justify-between items-center q-mb-lg"
+                class="flex justify-between items-center q-mb-lg ag-toolbar"
             >
                 <div />
-                <button-group>
+                <button-group class="ag-toolbar__actions">
                     <app-search-bar
                         v-model="search"
                         placeholder="Search"
-                        class="q-mr-sm"
+                        class="q-mr-sm ag-toolbar__search"
                     />
                     <app-refresh-button @click="refetchOnClick" />
 
@@ -216,7 +341,11 @@
                     </DialogOpenerAddUser>
                 </button-group>
             </div>
-            <div v-else class="q-py-lg" style="background: #0f62fe">
+            <div
+                v-else
+                class="q-py-lg selection-banner"
+                style="background: #0f62fe"
+            >
                 <ButtonGroupOverlay>
                     <template #start>
                         <div style="margin: 0; font-size: 14pt; color: white">
@@ -255,7 +384,8 @@
                 v-model:pagination="pagination2"
                 v-model:selected="selectedUsers"
                 :rows="accessGroup?.memberships || []"
-                :columns="userCols as any"
+                :columns="activeUserCols as any"
+                :grid="$q.screen.xs"
                 selection="multiple"
                 row-key="uuid"
                 :filter="search"
@@ -263,6 +393,148 @@
                 flat
                 bordered
             >
+                <!-- phones: one card per member -->
+                <template v-if="$q.screen.xs" #item="props">
+                    <div class="col-12 q-pa-xs">
+                        <q-card
+                            flat
+                            bordered
+                            class="ag-card"
+                            :class="{ 'ag-card--selected': props.selected }"
+                        >
+                            <q-card-section class="q-px-md q-py-sm">
+                                <div class="row items-center no-wrap">
+                                    <q-checkbox
+                                        v-model="props.selected"
+                                        color="grey-8"
+                                        dense
+                                        class="q-mr-md"
+                                        aria-label="Select member"
+                                    />
+                                    <div
+                                        class="col column"
+                                        style="min-width: 0"
+                                    >
+                                        <div
+                                            class="text-weight-medium ellipsis"
+                                        >
+                                            {{ props.row.user.name }}
+                                        </div>
+                                        <div
+                                            class="text-caption text-grey-7 ellipsis"
+                                        >
+                                            {{ props.row.user.email ?? 'N/A' }}
+                                        </div>
+                                    </div>
+                                    <q-btn
+                                        flat
+                                        round
+                                        dense
+                                        icon="sym_o_more_vert"
+                                        unelevated
+                                        color="primary"
+                                        class="cursor-pointer"
+                                        aria-label="Member actions"
+                                        @click.stop
+                                    >
+                                        <q-menu auto-close>
+                                            <q-list>
+                                                <q-item
+                                                    v-ripple
+                                                    clickable
+                                                    :disable="
+                                                        !currentUserCanEdit
+                                                    "
+                                                    @click="
+                                                        () =>
+                                                            toggleUserRole(
+                                                                props.row,
+                                                            )
+                                                    "
+                                                >
+                                                    <q-item-section>
+                                                        {{
+                                                            props.row
+                                                                .canEditGroup
+                                                                ? 'Demote to Member'
+                                                                : 'Promote to Owner'
+                                                        }}
+                                                    </q-item-section>
+                                                </q-item>
+                                                <q-item
+                                                    v-ripple
+                                                    clickable
+                                                    :disable="
+                                                        !currentUserCanEdit
+                                                    "
+                                                    @click="
+                                                        () =>
+                                                            removeSingleUser(
+                                                                props.row.user
+                                                                    .uuid,
+                                                            )
+                                                    "
+                                                >
+                                                    <q-item-section>
+                                                        Remove
+                                                    </q-item-section>
+                                                </q-item>
+                                            </q-list>
+                                        </q-menu>
+                                    </q-btn>
+                                </div>
+                                <div
+                                    class="row items-center q-gutter-x-sm q-mt-sm"
+                                >
+                                    <app-status-chip
+                                        :expiration-date="
+                                            props.row.expirationDate
+                                        "
+                                    />
+                                    <q-chip
+                                        dense
+                                        square
+                                        size="sm"
+                                        color="grey-2"
+                                        text-color="grey-9"
+                                        class="q-ma-none"
+                                    >
+                                        {{
+                                            props.row.canEditGroup
+                                                ? 'Owner'
+                                                : 'Member'
+                                        }}
+                                    </q-chip>
+                                </div>
+                                <q-btn
+                                    flat
+                                    dense
+                                    no-caps
+                                    size="sm"
+                                    class="button-border q-mt-sm full-width"
+                                    :class="
+                                        isExpired(props.row.expirationDate)
+                                            ? 'text-negative'
+                                            : 'text-grey-9'
+                                    "
+                                    :disable="!currentUserCanEdit"
+                                    icon="sym_o_date_range"
+                                    :label="
+                                        props.row.expirationDate
+                                            ? `Valid until ${new Date(
+                                                  props.row.expirationDate,
+                                              ).toDateString()}`
+                                            : 'Valid forever'
+                                    "
+                                    @click="
+                                        () => openSetExpirationDialog(props.row)
+                                    "
+                                />
+                            </q-card-section>
+                        </q-card>
+                    </div>
+                </template>
+
                 <template #no-data>
                     <div class="full-width row flex-center q-pa-xl text-grey-8">
                         <div class="text-center">
@@ -422,8 +694,9 @@
             <q-table
                 flat
                 bordered
+                :wrap-cells="$q.screen.xs"
                 :rows="auditLogs?.data || []"
-                :columns="auditLogCols as any"
+                :columns="activeAuditLogCols as any"
                 row-key="uuid"
                 :pagination="{
                     rowsPerPage: 50,
@@ -449,6 +722,14 @@
                 <template #body-cell-createdAt="props">
                     <q-td :props="props">
                         {{ formatDate(new Date(props.row.createdAt), true) }}
+                        <!-- phones: actor and type columns are folded in here -->
+                        <div
+                            v-if="$q.screen.xs"
+                            class="text-caption text-grey-7"
+                        >
+                            {{ props.row.actor?.name ?? 'System' }} &middot;
+                            {{ props.row.type }}
+                        </div>
                     </q-td>
                 </template>
                 <template #body-cell-actor="props">
@@ -945,6 +1226,12 @@ const userCols = [
     },
 ];
 
+// the email column is dropped on tablets, on phones the table is replaced by
+// a card list that shows the email below the name
+const activeUserCols = computed(() =>
+    $q.screen.sm ? userCols.filter((col) => col.name !== 'email') : userCols,
+);
+
 const rowClick = async (_uuid: string): Promise<void> => {
     await router.push({
         name: ROUTES.MISSIONS.routeName,
@@ -988,5 +1275,57 @@ const auditLogCols = [
         field: 'details',
     },
 ];
+
+// on phones only the timestamp and the details fit; the actor and the action
+// type are rendered below the timestamp instead
+const activeAuditLogCols = computed(() =>
+    $q.screen.xs
+        ? auditLogCols.filter(
+              (col) => col.name === 'createdAt' || col.name === 'details',
+          )
+        : auditLogCols,
+);
 </script>
-<style scoped></style>
+<style scoped>
+.button-border {
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+}
+
+.ag-card--selected {
+    background-color: #e7efff;
+}
+
+/* below 1024px the toolbars stack: search on its own row, buttons below */
+@media (max-width: 1023px) {
+    .ag-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+
+    .ag-toolbar__actions {
+        flex-wrap: wrap;
+    }
+
+    .ag-toolbar__search {
+        flex: 1 0 100%;
+        margin-right: 0;
+    }
+
+    .ag-toolbar :deep(.q-btn) {
+        min-height: 40px;
+        min-width: 40px;
+    }
+}
+
+@media (max-width: 599px) {
+    .selection-banner :deep(.q-ml-lg) {
+        margin-left: 12px;
+    }
+
+    .selection-banner :deep(.q-pr-lg) {
+        padding-right: 12px;
+    }
+}
+</style>

--- a/frontend/src/pages/access-groups-page.vue
+++ b/frontend/src/pages/access-groups-page.vue
@@ -158,26 +158,19 @@
                                     <div class="text-weight-medium ellipsis">
                                         {{ props.row.name }}
                                     </div>
+                                    <!-- The search endpoint does not expose user
+                                         emails, so personal groups show no caption -->
                                     <div
+                                        v-if="tab !== 'users'"
                                         class="text-caption text-grey-7 ellipsis"
                                     >
-                                        <template v-if="tab === 'users'">
-                                            {{
-                                                props.row.memberships[0]?.user
-                                                    .email ?? '-'
-                                            }}
-                                        </template>
-                                        <template v-else>
-                                            {{ props.row.creator?.name ?? '-' }}
-                                            &middot;
-                                            {{
-                                                formatDate(
-                                                    new Date(
-                                                        props.row.createdAt,
-                                                    ),
-                                                )
-                                            }}
-                                        </template>
+                                        {{ props.row.creator?.name ?? '-' }}
+                                        &middot;
+                                        {{
+                                            formatDate(
+                                                new Date(props.row.createdAt),
+                                            )
+                                        }}
                                     </div>
                                 </div>
                                 <q-btn

--- a/frontend/src/pages/access-groups-page.vue
+++ b/frontend/src/pages/access-groups-page.vue
@@ -15,11 +15,11 @@
     </title-section>
 
     <div class="q-my-lg">
-        <div class="flex justify-between items-center">
-            <button-group>
+        <div class="flex justify-between items-center ag-toolbar">
+            <button-group class="ag-toolbar__filters">
                 <div
                     v-if="tab === 'groups'"
-                    class="self-stretch flex items-center"
+                    class="self-stretch flex items-center scroll-x-nowrap"
                 >
                     <q-btn-toggle
                         v-model="prefilter"
@@ -36,9 +36,10 @@
                 </div>
             </button-group>
 
-            <button-group>
+            <button-group class="ag-toolbar__actions">
                 <app-search-bar
                     v-model="filterOptions.search"
+                    class="ag-toolbar__search"
                     :placeholder="
                         tab === 'groups' ? 'Search Groups' : 'Search Users'
                     "
@@ -81,7 +82,8 @@
             flat
             bordered
             wrap-cells
-            virtual-scroll
+            :virtual-scroll="!$q.screen.xs"
+            :grid="$q.screen.xs"
             separator="none"
             :rows="accessGroupsTable"
             :columns="activeColumns as any"
@@ -90,6 +92,175 @@
             row-key="uuid"
             @row-click="rowClick"
         >
+            <!-- phones: the table header is replaced by an explicit sort menu -->
+            <template v-if="$q.screen.xs" #top>
+                <q-btn
+                    flat
+                    dense
+                    no-caps
+                    class="button-border q-px-sm"
+                    icon="sym_o_swap_vert"
+                    :label="sortLabel"
+                    aria-label="Change sorting"
+                >
+                    <q-menu auto-close>
+                        <q-list>
+                            <q-item
+                                v-for="column in sortableColumns"
+                                :key="column.name"
+                                v-ripple
+                                clickable
+                                @click="() => setSort(column.name)"
+                            >
+                                <q-item-section>
+                                    {{ column.label }}
+                                </q-item-section>
+                                <q-item-section
+                                    v-if="pagination.sortBy === column.name"
+                                    side
+                                >
+                                    <q-icon
+                                        :name="
+                                            pagination.descending
+                                                ? 'sym_o_arrow_downward'
+                                                : 'sym_o_arrow_upward'
+                                        "
+                                        size="18px"
+                                    />
+                                </q-item-section>
+                            </q-item>
+                        </q-list>
+                    </q-menu>
+                </q-btn>
+            </template>
+
+            <!-- phones: one tappable card per access group -->
+            <template v-if="$q.screen.xs" #item="props">
+                <div class="col-12 q-pa-xs">
+                    <q-card
+                        flat
+                        bordered
+                        class="ag-card"
+                        :class="{ 'ag-card--selected': props.selected }"
+                        @click="() => rowClick(undefined, props.row)"
+                    >
+                        <q-card-section class="q-px-md q-py-sm">
+                            <div class="row items-center no-wrap">
+                                <q-checkbox
+                                    v-model="props.selected"
+                                    color="grey-8"
+                                    dense
+                                    class="q-mr-md"
+                                    aria-label="Select access group"
+                                    @click.stop
+                                />
+                                <div class="col column" style="min-width: 0">
+                                    <div class="text-weight-medium ellipsis">
+                                        {{ props.row.name }}
+                                    </div>
+                                    <div
+                                        class="text-caption text-grey-7 ellipsis"
+                                    >
+                                        <template v-if="tab === 'users'">
+                                            {{
+                                                props.row.memberships[0]?.user
+                                                    .email ?? '-'
+                                            }}
+                                        </template>
+                                        <template v-else>
+                                            {{ props.row.creator?.name ?? '-' }}
+                                            &middot;
+                                            {{
+                                                formatDate(
+                                                    new Date(
+                                                        props.row.createdAt,
+                                                    ),
+                                                )
+                                            }}
+                                        </template>
+                                    </div>
+                                </div>
+                                <q-btn
+                                    flat
+                                    round
+                                    dense
+                                    icon="sym_o_more_vert"
+                                    unelevated
+                                    color="primary"
+                                    class="cursor-pointer"
+                                    aria-label="Access group actions"
+                                    @click.stop
+                                >
+                                    <q-menu auto-close>
+                                        <q-list>
+                                            <q-item
+                                                v-ripple
+                                                clickable
+                                                @click="
+                                                    () =>
+                                                        rowClick(
+                                                            undefined,
+                                                            props.row,
+                                                        )
+                                                "
+                                            >
+                                                <q-item-section>
+                                                    View Details
+                                                </q-item-section>
+                                            </q-item>
+                                            <q-item v-ripple clickable disabled>
+                                                <q-item-section>
+                                                    Edit
+                                                </q-item-section>
+                                            </q-item>
+                                            <DeleteAccessGroup
+                                                :access-group="props.row"
+                                            >
+                                                <q-item v-ripple clickable>
+                                                    <q-item-section>
+                                                        Delete
+                                                    </q-item-section>
+                                                </q-item>
+                                            </DeleteAccessGroup>
+                                        </q-list>
+                                    </q-menu>
+                                </q-btn>
+                            </div>
+                            <div class="row items-center q-gutter-x-sm q-mt-sm">
+                                <app-status-chip
+                                    v-if="tab === 'users'"
+                                    :expiration-date="
+                                        props.row.memberships[0]?.expirationDate
+                                    "
+                                />
+                                <q-chip
+                                    v-else
+                                    dense
+                                    square
+                                    size="sm"
+                                    color="grey-2"
+                                    text-color="grey-9"
+                                    class="q-ma-none"
+                                >
+                                    {{ props.row.memberships.length }} members
+                                </q-chip>
+                                <q-chip
+                                    dense
+                                    square
+                                    size="sm"
+                                    color="grey-2"
+                                    text-color="grey-9"
+                                    class="q-ma-none"
+                                >
+                                    {{ props.row.projectAccesses.length }}
+                                    projects
+                                </q-chip>
+                            </div>
+                        </q-card-section>
+                    </q-card>
+                </div>
+            </template>
+
             <template #body-selection="props">
                 <q-checkbox
                     v-model="props.selected"
@@ -174,19 +345,38 @@ import AppRefreshButton from 'components/common/app-refresh-button.vue';
 import AppSearchBar from 'components/common/app-search-bar.vue';
 import AppStatusChip from 'components/common/app-status-chip.vue';
 import TitleSection from 'components/title-section.vue';
-import { QTable } from 'quasar';
+import { QTable, useQuasar } from 'quasar';
 import ROUTES from 'src/router/routes';
 import { searchAccessGroups } from 'src/services/queries/access';
 import { useRoute, useRouter } from 'vue-router';
 
+interface AccessGroupColumn {
+    name: string;
+    required?: boolean;
+    label: string;
+    align: string;
+    field?: (row: AccessGroupDto) => string;
+    format?: (value: string) => string;
+    sortable?: boolean;
+    style?: string;
+}
+
+const $q = useQuasar();
 const $router = useRouter();
 const route = useRoute();
 const tab = ref((route.query.tab as string) || 'groups');
 
-const prefilterOptions = [
-    { label: 'Custom Groups', value: AccessGroupType.CUSTOM },
-    { label: 'Affiliation Groups', value: AccessGroupType.AFFILIATION },
-];
+// the long labels do not fit next to each other on a phone
+const prefilterOptions = computed(() => [
+    {
+        label: $q.screen.xs ? 'Custom' : 'Custom Groups',
+        value: AccessGroupType.CUSTOM,
+    },
+    {
+        label: $q.screen.xs ? 'Affiliation' : 'Affiliation Groups',
+        value: AccessGroupType.AFFILIATION,
+    },
+]);
 const prefilter = ref<AccessGroupType>(AccessGroupType.CUSTOM);
 
 const selectedAccessGroups: Ref<ProjectWithMissionsDto[]> = ref([]);
@@ -290,7 +480,7 @@ async function rowClick(event: any, row: AccessGroupDto) {
     });
 }
 
-const usersColumns = [
+const usersColumns: AccessGroupColumn[] = [
     {
         name: 'Name',
         required: true,
@@ -346,7 +536,7 @@ const usersColumns = [
     },
 ];
 
-const accessGroupsColumns = [
+const accessGroupsColumns: AccessGroupColumn[] = [
     {
         name: 'Access Group',
         required: true,
@@ -407,9 +597,77 @@ const accessGroupsColumns = [
     },
 ];
 
-const activeColumns = computed(() => {
-    return tab.value === 'users' ? usersColumns : accessGroupsColumns;
-});
+const allColumns = computed(() =>
+    tab.value === 'users' ? usersColumns : accessGroupsColumns,
+);
+
+// secondary columns are dropped on tablet-sized screens, on phones the table
+// is replaced by a card list and the columns are only used for sorting
+const secondaryColumns = computed(() =>
+    tab.value === 'users'
+        ? new Set(['Projects'])
+        : new Set(['Creator', 'createdAt']),
+);
+
+const activeColumns = computed(() =>
+    $q.screen.sm
+        ? allColumns.value.filter(
+              (column) => !secondaryColumns.value.has(column.name),
+          )
+        : allColumns.value,
+);
+
+const sortableColumns = computed(() =>
+    allColumns.value.filter((column) => column.sortable),
+);
+
+const sortLabel = computed(
+    () =>
+        sortableColumns.value.find(
+            (column) => column.name === pagination.value.sortBy,
+        )?.label ?? 'Sort',
+);
+
+const setSort = (columnName: string): void => {
+    if (pagination.value.sortBy === columnName) {
+        pagination.value.descending = !pagination.value.descending;
+    } else {
+        pagination.value.sortBy = columnName;
+        pagination.value.descending = false;
+    }
+};
 </script>
 
-<style scoped></style>
+<style scoped>
+.button-border {
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+}
+
+.ag-card--selected {
+    background-color: #e7efff;
+}
+
+/* below 1024px the toolbar stacks: search on its own row, buttons below */
+@media (max-width: 1023px) {
+    .ag-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+
+    .ag-toolbar__actions {
+        order: -1;
+        flex-wrap: wrap;
+    }
+
+    .ag-toolbar__search {
+        flex: 1 0 100%;
+    }
+
+    .ag-toolbar :deep(.q-btn) {
+        min-height: 40px;
+        min-width: 40px;
+    }
+}
+</style>

--- a/frontend/src/pages/action-details-page.vue
+++ b/frontend/src/pages/action-details-page.vue
@@ -63,9 +63,11 @@
                     class="button-border"
                     flat
                     icon="sym_o_arrow_back"
-                    label="Back to Actions"
+                    :label="$q.screen.xs ? 'Back' : 'Back to Actions'"
                     @click="navigateBackToActions"
-                />
+                >
+                    <q-tooltip>Back to Actions</q-tooltip>
+                </q-btn>
                 <q-btn
                     class="button-border"
                     flat
@@ -172,15 +174,28 @@
                 >
             </div>
 
-            <div class="row justify-between items-center q-mb-md">
-                <div class="row q-gutter-x-md items-center">
+            <div
+                class="q-mb-md"
+                :class="
+                    $q.screen.xs
+                        ? 'column q-gutter-y-sm'
+                        : 'row justify-between items-center'
+                "
+            >
+                <div
+                    :class="
+                        $q.screen.xs
+                            ? 'column q-gutter-y-sm'
+                            : 'row q-gutter-x-md items-center'
+                    "
+                >
                     <q-input
                         v-model="logsSearch"
                         dense
                         outlined
                         placeholder="Search logs..."
                         debounce="300"
-                        style="width: 200px"
+                        :style="$q.screen.xs ? undefined : 'width: 200px'"
                     >
                         <template #append>
                             <q-icon name="sym_o_search" />
@@ -193,17 +208,24 @@
                         dense
                         outlined
                         label="Level"
-                        style="width: 120px"
+                        :style="$q.screen.xs ? undefined : 'width: 120px'"
                         emit-value
                         map-options
                     />
 
-                    <div v-if="logs?.count" class="text-caption q-ml-md">
+                    <div
+                        v-if="logs?.count"
+                        class="text-caption"
+                        :class="$q.screen.xs ? '' : 'q-ml-md'"
+                    >
                         Showing {{ logs.data.length }} of {{ logs.count }} lines
                     </div>
                 </div>
 
-                <div class="q-gutter-x-sm">
+                <div
+                    class="q-gutter-x-sm"
+                    :class="$q.screen.xs ? 'row justify-end' : ''"
+                >
                     <q-btn
                         v-if="(logs?.count || 0) > (logs?.data.length || 0)"
                         flat
@@ -222,26 +244,20 @@
             </div>
 
             <q-card
-                class="q-pa-lg"
+                :class="$q.screen.xs ? 'q-pa-sm' : 'q-pa-lg'"
                 style="background-color: #f4f4f4"
                 flat
                 bordered
             >
-                <q-card-section class="flex column q-pa-none">
+                <q-card-section class="flex column q-pa-none log-output">
                     <div
                         v-for="(log, index) in logs?.data"
                         :id="`log-line-${index}`"
                         :key="log.timestamp"
-                        class="flex justify-start q-pb-xs"
+                        class="flex justify-start q-pb-xs log-line"
                         :class="{
                             'bg-orange-1': index === highlightedLogIndex,
                         }"
-                        style="
-                            font-family: monospace;
-                            color: #222222;
-                            font-size: 0.8em;
-                            transition: background-color 3s ease-out;
-                        "
                     >
                         <template v-if="log.type == 'stdout'">
                             <span
@@ -258,9 +274,7 @@
                                 [{{ log.type }}]
                             </span>
 
-                            <span
-                                style="margin-left: -250px; padding-left: 250px"
-                            >
+                            <span class="log-line__message">
                                 {{ log.message.replaceAll(' ', '\u00a0') }}
                             </span>
                         </template>
@@ -281,11 +295,8 @@
                             </span>
 
                             <span
-                                style="
-                                    margin-left: -250px;
-                                    padding-left: 250px;
-                                    color: #ff3c3c;
-                                "
+                                class="log-line__message"
+                                style="color: #ff3c3c"
                             >
                                 {{ log.message.replaceAll(' ', '\u00a0') }}
                             </span>
@@ -312,30 +323,27 @@
 
             <h2 class="text-h5 q-mb-sm text-grey-9">Called Endpoints</h2>
             <q-card
-                class="q-pa-lg"
+                :class="$q.screen.xs ? 'q-pa-sm' : 'q-pa-lg'"
                 style="background-color: #f4f4f4"
                 flat
                 bordered
             >
-                <div
-                    v-for="log in action?.auditLogs"
-                    :key="log.url"
-                    class="flex justify-start q-pb-xs"
-                    style="
-                        font-family: monospace;
-                        color: #222222;
-                        font-size: 0.8em;
-                    "
-                >
-                    <span
-                        class="q-pr-sm"
-                        style="user-select: none; color: #525252"
-                        >{{ log.method }}</span
+                <div class="log-output">
+                    <div
+                        v-for="log in action?.auditLogs"
+                        :key="log.url"
+                        class="flex justify-start q-pb-xs log-line"
                     >
+                        <span
+                            class="q-pr-sm"
+                            style="user-select: none; color: #525252"
+                            >{{ log.method }}</span
+                        >
 
-                    <span>
-                        {{ log.url }}
-                    </span>
+                        <span>
+                            {{ log.url }}
+                        </span>
+                    </div>
                 </div>
             </q-card>
         </q-tab-panel>
@@ -565,6 +573,37 @@ const navigateBackToActions = async (): Promise<void> => {
 };
 </script>
 
-<style>
-/* Styles removed as table is no longer used */
+<style scoped>
+/*
+ * Log and audit-log output must scroll inside its own box, so that a long
+ * line never widens the page (which would make the whole page scroll
+ * horizontally on a phone).
+ */
+.log-output {
+    overflow-x: auto;
+}
+
+.log-line {
+    font-family: monospace;
+    color: #222222;
+    font-size: 0.8em;
+    transition: background-color 3s ease-out;
+    flex-wrap: nowrap;
+    width: max-content;
+    min-width: 100%;
+}
+
+/* Hanging indent so that wrapped output lines up after the timestamp */
+.log-line__message {
+    margin-left: -250px;
+    padding-left: 250px;
+}
+
+/* There is no room for a 250px indent on small screens */
+@media (max-width: 1023px) {
+    .log-line__message {
+        margin-left: 0;
+        padding-left: 0;
+    }
+}
 </style>

--- a/frontend/src/pages/data-table-page.vue
+++ b/frontend/src/pages/data-table-page.vue
@@ -3,6 +3,49 @@
 
     <FilesFilter :use-filter="filterHook" />
 
+    <!--
+        The card list has no column headers, so phones get an explicit sort
+        control and a hint about how many rows are currently selected.
+    -->
+    <div v-if="isPhone" class="row items-center justify-between q-mb-sm">
+        <q-btn-dropdown
+            flat
+            dense
+            no-caps
+            class="text-grey-8"
+            icon="sym_o_swap_vert"
+            :label="`Sort: ${activeSortLabel}`"
+            aria-label="Change sorting"
+        >
+            <q-list>
+                <q-item
+                    v-for="option in sortOptions"
+                    :key="option.value"
+                    v-close-popup
+                    clickable
+                    @click="() => toggleSort(option.value)"
+                >
+                    <q-item-section>{{ option.label }}</q-item-section>
+                    <q-item-section side>
+                        <q-icon
+                            v-if="pagination.sortBy === option.value"
+                            :name="
+                                pagination.descending
+                                    ? 'sym_o_arrow_downward'
+                                    : 'sym_o_arrow_upward'
+                            "
+                            size="18px"
+                        />
+                    </q-item-section>
+                </q-item>
+            </q-list>
+        </q-btn-dropdown>
+
+        <span v-if="selected.length > 0" class="text-caption text-grey-7">
+            {{ selected.length }} selected
+        </span>
+    </div>
+
     <q-table
         ref="tableReference"
         v-model:pagination="pagination"
@@ -12,11 +55,15 @@
         separator="none"
         :rows-per-page-options="[5, 10, 20, 50, 100]"
         :rows="data"
-        :columns="columns as QTableColumn<FileWithTopicDto>[]"
+        :columns="visibleColumns as QTableColumn<FileWithTopicDto>[]"
         row-key="uuid"
         :loading="loading"
         selection="multiple"
         binary-state-sort
+        :grid="isPhone"
+        :wrap-cells="isCompact"
+        :rows-per-page-label="isPhone ? 'Rows' : undefined"
+        :class="{ 'files-table--grid': isPhone }"
         @row-click="onRowClick"
         @request="setPagination"
     >
@@ -79,6 +126,107 @@
                 </q-btn>
             </q-td>
         </template>
+        <template #item="props">
+            <div class="col-12 file-card-wrapper">
+                <q-card
+                    flat
+                    bordered
+                    class="file-card"
+                    :class="{ 'file-card--selected': props.selected }"
+                    @click="() => onRowClick(undefined, props.row)"
+                >
+                    <div class="q-pa-sm">
+                        <div class="row items-center no-wrap">
+                            <q-checkbox
+                                v-model="props.selected"
+                                dense
+                                color="grey-8"
+                                class="q-mr-sm"
+                                :aria-label="`Select ${props.row.filename}`"
+                                @click.stop
+                            />
+                            <q-icon
+                                :name="getIcon(props.row.state)"
+                                :color="getColorFileState(props.row.state)"
+                                size="20px"
+                                class="q-mr-sm"
+                                :aria-label="getTooltip(props.row.state)"
+                            >
+                                <q-tooltip>
+                                    {{ getTooltip(props.row.state) }}
+                                </q-tooltip>
+                            </q-icon>
+                            <div class="col file-card__name">
+                                {{ props.row.filename }}
+                            </div>
+                            <q-btn
+                                flat
+                                round
+                                dense
+                                icon="sym_o_more_vert"
+                                unelevated
+                                color="primary"
+                                class="cursor-pointer"
+                                aria-label="File actions"
+                                @click.stop
+                            >
+                                <q-menu auto-close>
+                                    <q-list>
+                                        <edit-file-dialog-opener
+                                            :file="props.row"
+                                        >
+                                            <q-item v-ripple clickable>
+                                                <q-item-section>
+                                                    Edit File
+                                                </q-item-section>
+                                            </q-item>
+                                        </edit-file-dialog-opener>
+                                        <q-item
+                                            v-ripple
+                                            clickable
+                                            @click="
+                                                () =>
+                                                    onRowClick(
+                                                        undefined,
+                                                        props.row,
+                                                    )
+                                            "
+                                        >
+                                            <q-item-section>
+                                                View File
+                                            </q-item-section>
+                                        </q-item>
+                                        <q-item v-ripple clickable>
+                                            <q-item-section>
+                                                <DeleteFileDialogOpener
+                                                    :file="props.row"
+                                                >
+                                                    Delete File
+                                                </DeleteFileDialogOpener>
+                                            </q-item-section>
+                                        </q-item>
+                                    </q-list>
+                                </q-menu>
+                            </q-btn>
+                        </div>
+
+                        <div class="file-card__meta text-caption text-grey-7">
+                            {{ props.row.mission.project.name }} /
+                            {{ props.row.mission.name }}
+                        </div>
+                        <div
+                            class="row items-center q-gutter-x-sm text-caption text-grey-7"
+                        >
+                            <span>{{ formatSize(props.row.size) }}</span>
+                            <span aria-hidden="true">&middot;</span>
+                            <span>
+                                {{ formatDate(new Date(props.row.createdAt)) }}
+                            </span>
+                        </div>
+                    </div>
+                </q-card>
+            </div>
+        </template>
         <template #no-data>
             <TableEmptyState
                 :is-empty="
@@ -110,7 +258,7 @@ import EditFileDialogOpener from 'components/button-wrapper/edit-file-dialog-ope
 import TableEmptyState from 'components/common/table-empty-state.vue';
 import FilesFilter from 'components/files/files-filter.vue';
 import TitleSection from 'components/title-section.vue';
-import { QTable, QTableColumn } from 'quasar';
+import { QTable, QTableColumn, useQuasar } from 'quasar';
 import { useFileFilter } from 'src/composables/use-file-filter';
 import { useHandler } from 'src/hooks/query-hooks';
 import ROUTES from 'src/router/routes';
@@ -122,12 +270,42 @@ import { computed, Ref, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
 const $router = useRouter();
+const $q = useQuasar();
 const tableReference: Ref<QTable | undefined> = ref(undefined);
 const handler = useHandler();
 handler.value.sortBy = 'file.createdAt';
 handler.value.descending = true;
 const loading = ref(false);
-const selected = ref([]);
+const selected = ref<FileWithTopicDto[]>([]);
+
+/**
+ * Phones render the files as tappable cards, tablets keep the table but drop
+ * the secondary columns so that it fits without horizontal scrolling.
+ */
+const isPhone = computed(() => $q.screen.xs);
+const isCompact = computed(() => $q.screen.lt.md);
+
+const sortOptions = [
+    { label: 'File name', value: 'file.filename' },
+    { label: 'Health', value: 'state' },
+    { label: 'Recording date', value: 'file.date' },
+    { label: 'Creation date', value: 'file.createdAt' },
+    { label: 'Size', value: 'file.size' },
+];
+
+const activeSortLabel = computed(
+    () =>
+        sortOptions.find((option) => option.value === handler.value.sortBy)
+            ?.label ?? 'Creation date',
+);
+
+function toggleSort(name: string): void {
+    handler.value.setDescending(
+        handler.value.sortBy === name ? !handler.value.descending : false,
+    );
+    handler.value.setSort(name);
+    handler.value.setPage(1);
+}
 
 const filterHook = useFileFilter();
 const {
@@ -313,6 +491,25 @@ const columns = [
     },
 ];
 
+/**
+ * Below 1024px only the essentials are shown: project, recording date and
+ * creator are dropped so that the remaining columns fit the viewport.
+ */
+const COMPACT_COLUMN_NAMES = new Set([
+    'state',
+    'mission.name',
+    'file.filename',
+    'file.createdAt',
+    'file.size',
+    'action',
+]);
+
+const visibleColumns = computed(() =>
+    isCompact.value
+        ? columns.filter((column) => COMPACT_COLUMN_NAMES.has(column.name))
+        : columns,
+);
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const onRowClick = async (_: any, row: FileWithTopicDto): Promise<void> => {
     await $router.push({
@@ -326,3 +523,57 @@ const onRowClick = async (_: any, row: FileWithTopicDto): Promise<void> => {
     });
 };
 </script>
+
+<style scoped>
+.file-card-wrapper {
+    padding: 4px 0;
+}
+
+.file-card {
+    border-radius: 4px;
+}
+
+.file-card--selected {
+    background-color: #e7efff;
+}
+
+.file-card__name {
+    min-width: 0;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 20px;
+    overflow: hidden;
+    word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.file-card__meta {
+    margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* The card list is a plain column, no inner scroll container */
+.files-table--grid :deep(.q-table__grid-content) {
+    margin: 0;
+}
+
+/*
+ * The global stylesheet already lets the pagination bar wrap on phones; it
+ * only needs slightly smaller text and finger-sized page buttons here.
+ */
+@media (max-width: 599px) {
+    :deep(.q-table__bottom) {
+        column-gap: 8px;
+        font-size: 12px;
+    }
+
+    :deep(.q-table__bottom .q-btn) {
+        min-height: 36px;
+        min-width: 36px;
+    }
+}
+</style>

--- a/frontend/src/pages/error-403-page.vue
+++ b/frontend/src/pages/error-403-page.vue
@@ -1,18 +1,33 @@
 <template>
-    <q-page class="flex flex-center bg-grey-2">
+    <q-page class="flex flex-center bg-grey-2 q-py-md">
         <q-card class="q-pa-md shadow-2 my_card" bordered>
             <q-card-section class="text-center">
-                <div class="text-grey-9 text-h2 text-weight-bold">
+                <div
+                    class="text-grey-9 text-weight-bold"
+                    :class="$q.screen.xs ? 'text-h4' : 'text-h2'"
+                >
                     403 Error
                 </div>
-                <div v-if="message" class="text-grey-8 text-h5">
+                <div
+                    v-if="message"
+                    class="text-grey-8"
+                    :class="$q.screen.xs ? 'text-subtitle1' : 'text-h5'"
+                >
                     {{ message }}
                 </div>
-                <div v-else class="text-grey-8 text-h5">
+                <div
+                    v-else
+                    class="text-grey-8"
+                    :class="$q.screen.xs ? 'text-subtitle1' : 'text-h5'"
+                >
                     You are not authorized to access this page.
                 </div>
 
-                <div v-if="projectUuid" class="text-grey-8 text-h6 q-mt-lg">
+                <div
+                    v-if="projectUuid"
+                    class="text-grey-8 q-mt-lg project-uuid"
+                    :class="$q.screen.xs ? 'text-subtitle2' : 'text-h6'"
+                >
                     Project UUID:<br />
                     {{ projectUuid }}
                 </div>
@@ -23,7 +38,7 @@
                     Do you want to go back?
                     <a
                         href="/dashboard"
-                        class="text-dark text-weight-bold"
+                        class="text-dark text-weight-bold back-link"
                         style="text-decoration: none"
                     >
                         Back to Dashboard.
@@ -39,3 +54,23 @@ const urlParameters = new URLSearchParams(globalThis.location.search);
 const message = urlParameters.get('message');
 const projectUuid = urlParameters.get('projectUuid');
 </script>
+
+<style scoped>
+/* A UUID is a single long token; let it wrap instead of widening the card */
+.project-uuid {
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 599px) {
+    .my_card {
+        width: 100%;
+    }
+
+    /* Comfortable touch target for the only link on the page */
+    .back-link {
+        display: inline-block;
+        min-height: 40px;
+        line-height: 40px;
+    }
+}
+</style>

--- a/frontend/src/pages/error-404-page.vue
+++ b/frontend/src/pages/error-404-page.vue
@@ -1,11 +1,17 @@
 <template>
-    <q-page class="flex flex-center bg-grey-2">
+    <q-page class="flex flex-center bg-grey-2 q-py-md">
         <q-card class="q-pa-md shadow-2 my_card" bordered>
             <q-card-section class="text-center">
-                <div class="text-grey-9 text-h2 text-weight-bold">
+                <div
+                    class="text-grey-9 text-weight-bold"
+                    :class="$q.screen.xs ? 'text-h4' : 'text-h2'"
+                >
                     404 Error
                 </div>
-                <div class="text-grey-8 text-h5">
+                <div
+                    class="text-grey-8"
+                    :class="$q.screen.xs ? 'text-subtitle1' : 'text-h5'"
+                >
                     The page you are looking <br />for does not exist.
                 </div>
             </q-card-section>
@@ -15,7 +21,7 @@
                     Do you want to go back?
                     <a
                         href="/"
-                        class="text-dark text-weight-bold"
+                        class="text-dark text-weight-bold back-link"
                         style="text-decoration: none"
                         >Back to Home.</a
                     >
@@ -26,3 +32,18 @@
 </template>
 
 <script setup lang="ts"></script>
+
+<style scoped>
+@media (max-width: 599px) {
+    .my_card {
+        width: 100%;
+    }
+
+    /* Comfortable touch target for the only link on the page */
+    .back-link {
+        display: inline-block;
+        min-height: 40px;
+        line-height: 40px;
+    }
+}
+</style>

--- a/frontend/src/pages/files-explorer-page.vue
+++ b/frontend/src/pages/files-explorer-page.vue
@@ -1,7 +1,12 @@
 <template>
     <div>
         <title-section :title="mission?.name">
-            <template v-if="mission?.tags" #titleAppend>
+            <!--
+                On phones the chip does not fit next to the (already
+                ellipsized) mission name, so it is rendered underneath the
+                title instead of beside it.
+            -->
+            <template v-if="mission?.tags" #[metadataChipSlot]>
                 <div class="q-shrink">
                     <q-btn
                         unelevated
@@ -196,7 +201,7 @@ import MissionActions from 'components/explorer-page/mission-actions.vue';
 import MissionFiles from 'components/explorer-page/mission-files.vue';
 import MissionMetadataDrawer from 'components/explorer-page/mission-metadata-drawer.vue';
 import TitleSection from 'components/title-section.vue';
-import { copyToClipboard, Notify } from 'quasar';
+import { copyToClipboard, Notify, useQuasar } from 'quasar';
 import {
     registerNoPermissionErrorHandler,
     useMission,
@@ -207,9 +212,18 @@ import { useRoute, useRouter } from 'vue-router';
 
 const $router = useRouter();
 const $route = useRoute();
+const $q = useQuasar();
 
 const missionUuid = useMissionUUID();
 const isMetadataDrawerOpen = ref(false);
+
+/**
+ * The metadata chip sits next to the title on wider screens and moves below
+ * it on phones, where the title row has no room left.
+ */
+const metadataChipSlot = computed<'subtitle' | 'titleAppend'>(() =>
+    $q.screen.xs ? 'subtitle' : 'titleAppend',
+);
 
 const openMetadataDrawer = () => {
     isMetadataDrawerOpen.value = true;

--- a/frontend/src/pages/index-page.vue
+++ b/frontend/src/pages/index-page.vue
@@ -1,8 +1,16 @@
 <template>
     <div class="flex flex-center">
-        <div class="q-pa-lg">
-            <div class="text-h3 text-center">Kleinkram</div>
-            <div class="text-h5 text-center">
+        <div :class="$q.screen.xs ? 'q-pa-md' : 'q-pa-lg'" class="index-hero">
+            <div
+                class="text-center"
+                :class="$q.screen.xs ? 'text-h4' : 'text-h3'"
+            >
+                Kleinkram
+            </div>
+            <div
+                class="text-center"
+                :class="$q.screen.xs ? 'text-subtitle1' : 'text-h5'"
+            >
                 A web-based tool for managing ROS bags
             </div>
             <q-img src="/rsl.png" class="q-mt-md" />
@@ -12,8 +20,7 @@
 
 <script setup lang="ts"></script>
 <style scoped>
-.styled-bullet-list {
-    list-style-type: disc; /* Bullet style */
-    margin-left: 20px; /* Indent items to allow space for bullets */
+.index-hero {
+    max-width: 100%;
 }
 </style>

--- a/frontend/src/pages/landing-page.vue
+++ b/frontend/src/pages/landing-page.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="fixed-center text-center">
+    <div class="fixed-center text-center q-px-md landing-status">
         <q-spinner color="primary" size="3em" />
         <div class="q-mt-md text-h6">Login Successful</div>
         <div class="text-subtitle2 text-grey">Redirecting...</div>
@@ -17,4 +17,9 @@ onMounted(async () => {
     await $router.push({ name: ROUTES.DASHBOARD.routeName });
 });
 </script>
-<style scoped></style>
+<style scoped>
+/* Keep the centered status text inside the viewport on narrow screens */
+.landing-status {
+    max-width: 100vw;
+}
+</style>

--- a/frontend/src/pages/login-page.vue
+++ b/frontend/src/pages/login-page.vue
@@ -1,55 +1,16 @@
 <template>
-    <div class="flex flex-center bg-grey-2" style="height: calc(100vh - 50px)">
-        <div
-            style="
-                border-radius: 0;
-                display: grid;
-                grid-template-columns: 48px 460px 48px;
-                grid-template-rows: 48px 460px 48px;
-            "
-        >
-            <div
-                style="
-                    border-bottom: 1px solid #e0e0e0;
-                    border-right: 1px solid #e0e0e0;
-                "
-            />
-            <div style="border-bottom: 1px solid #e0e0e0" />
-            <div
-                style="
-                    border-bottom: 1px solid #e0e0e0;
-                    border-left: 1px solid #e0e0e0;
-                "
-            />
+    <div class="login-page flex flex-center bg-grey-2">
+        <div class="login-frame">
+            <div class="login-frame-cell login-frame-cell--top-left" />
+            <div class="login-frame-cell login-frame-cell--top-center" />
+            <div class="login-frame-cell login-frame-cell--top-right" />
 
-            <div style="border-right: 1px solid #e0e0e0" />
-            <div
-                style="
-                    background: white;
-                    display: flex;
-                    padding: 48px;
-                    justify-content: center;
-                    align-items: center;
-                    text-align: center;
-                "
-            >
+            <div class="login-frame-cell login-frame-cell--middle-left" />
+            <div class="login-card">
                 <div style="width: 100%">
-                    <img
-                        src="/logoRSL.png"
-                        style="height: 28px; margin-bottom: 48px"
-                    />
+                    <img src="/logoRSL.png" class="login-logo" />
 
-                    <h1
-                        style="
-                            font-size: 28px;
-                            font-weight: 400;
-                            margin-bottom: 48px;
-                            margin-top: 0;
-                            line-height: 36px;
-                        "
-                    >
-                        Login to Kleinkram
-                    </h1>
+                    <h1 class="login-title">Login to Kleinkram</h1>
 
                     <!-- Loading state -->
                     <div
@@ -83,7 +44,7 @@
                             label="Retry Connection"
                             color="warning"
                             flat
-                            class="q-mt-sm full-width"
+                            class="q-mt-sm full-width login-button"
                             @click="handleRefetchProviders"
                         />
                     </div>
@@ -92,7 +53,7 @@
                     <template v-else>
                         <template v-if="availableProviders?.fakeOauth">
                             <q-btn
-                                class="button-border full-width"
+                                class="button-border full-width login-button"
                                 flat
                                 outline
                                 size="md"
@@ -103,7 +64,7 @@
 
                         <q-btn
                             v-if="availableProviders?.google"
-                            class="button-border full-width"
+                            class="button-border full-width login-button"
                             flat
                             outline
                             size="md"
@@ -113,7 +74,7 @@
 
                         <q-btn
                             v-if="availableProviders?.github"
-                            class="button-border full-width q-mt-md"
+                            class="button-border full-width q-mt-md login-button"
                             flat
                             outline
                             size="md"
@@ -129,21 +90,11 @@
                     </div>
                 </div>
             </div>
-            <div style="border-left: 1px solid #e0e0e0" />
+            <div class="login-frame-cell login-frame-cell--middle-right" />
 
-            <div
-                style="
-                    border-top: 1px solid #e0e0e0;
-                    border-right: 1px solid #e0e0e0;
-                "
-            />
-            <div style="border-top: 1px solid #e0e0e0" />
-            <div
-                style="
-                    border-top: 1px solid #e0e0e0;
-                    border-left: 1px solid #e0e0e0;
-                "
-            />
+            <div class="login-frame-cell login-frame-cell--bottom-left" />
+            <div class="login-frame-cell login-frame-cell--bottom-center" />
+            <div class="login-frame-cell login-frame-cell--bottom-right" />
         </div>
     </div>
 </template>
@@ -211,3 +162,116 @@ const handleRefetchProviders = () => {
     void refetchProviders();
 };
 </script>
+
+<style scoped>
+/*
+ * The login card sits inside a decorative 3x3 frame. On desktop the frame is
+ * exactly 48px + 460px + 48px wide (unchanged); on narrow viewports the middle
+ * column shrinks so the page never scrolls horizontally.
+ */
+.login-page {
+    height: calc(100vh - 50px);
+}
+
+.login-frame {
+    border-radius: 0;
+    display: grid;
+    grid-template-columns: 48px minmax(0, 460px) 48px;
+    grid-template-rows: 48px minmax(460px, auto) 48px;
+    width: 100%;
+    max-width: 556px;
+}
+
+.login-frame-cell--top-left {
+    border-bottom: 1px solid #e0e0e0;
+    border-right: 1px solid #e0e0e0;
+}
+
+.login-frame-cell--top-center {
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.login-frame-cell--top-right {
+    border-bottom: 1px solid #e0e0e0;
+    border-left: 1px solid #e0e0e0;
+}
+
+.login-frame-cell--middle-left {
+    border-right: 1px solid #e0e0e0;
+}
+
+.login-frame-cell--middle-right {
+    border-left: 1px solid #e0e0e0;
+}
+
+.login-frame-cell--bottom-left {
+    border-top: 1px solid #e0e0e0;
+    border-right: 1px solid #e0e0e0;
+}
+
+.login-frame-cell--bottom-center {
+    border-top: 1px solid #e0e0e0;
+}
+
+.login-frame-cell--bottom-right {
+    border-top: 1px solid #e0e0e0;
+    border-left: 1px solid #e0e0e0;
+}
+
+.login-card {
+    align-items: center;
+    background: white;
+    display: flex;
+    justify-content: center;
+    padding: 48px;
+    text-align: center;
+}
+
+.login-logo {
+    height: 28px;
+    margin-bottom: 48px;
+    max-width: 100%;
+}
+
+.login-title {
+    font-size: 28px;
+    font-weight: 400;
+    line-height: 36px;
+    margin-bottom: 48px;
+    margin-top: 0;
+}
+
+/* Comfortable touch targets on touch-sized viewports */
+@media (max-width: 1023px) {
+    .login-button {
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 599px) {
+    .login-page {
+        height: auto;
+        min-height: calc(100vh - 50px);
+        padding: 24px 0;
+    }
+
+    .login-frame {
+        grid-template-columns: 16px minmax(0, 1fr) 16px;
+        grid-template-rows: 16px auto 16px;
+    }
+
+    .login-card {
+        padding: 32px 20px;
+    }
+
+    .login-logo {
+        margin-bottom: 32px;
+    }
+
+    .login-title {
+        font-size: 24px;
+        line-height: 32px;
+        margin-bottom: 32px;
+    }
+}
+</style>

--- a/frontend/src/pages/missions-explorer-page.vue
+++ b/frontend/src/pages/missions-explorer-page.vue
@@ -16,20 +16,28 @@
                         <q-btn
                             class="button-border"
                             flat
-                            style="height: 100%"
+                            style="height: 100%; min-height: 40px"
                             color="primary"
                             icon="sym_o_sell"
-                            label="Enforce Metadata"
+                            :label="
+                                $q.screen.xs ? undefined : 'Enforce Metadata'
+                            "
+                            aria-label="Enforce Metadata"
                             :disable="!projectUuid"
-                        />
+                        >
+                            <q-tooltip v-if="$q.screen.xs">
+                                Enforce Metadata
+                            </q-tooltip>
+                        </q-btn>
                     </ConfigureTagsDialogOpener>
 
                     <q-btn
                         icon="sym_o_more_vert"
                         class="button-border"
                         flat
-                        style="height: 100%"
+                        style="height: 100%; min-height: 40px; min-width: 40px"
                         color="primary"
+                        aria-label="More Actions"
                     >
                         <q-tooltip> More Actions</q-tooltip>
 
@@ -115,35 +123,49 @@
         <div>
             <div
                 v-if="selectedMissions.length === 0"
-                class="q-my-lg flex justify-between items-center"
+                class="missions-toolbar"
+                :class="$q.screen.xs ? 'q-my-md' : 'q-my-lg'"
             >
-                <h2 class="text-h4 q-mb-xs">
-                    All Missions of {{ project?.name }}
+                <h2 class="text-h4 q-mb-xs missions-toolbar__title">
+                    {{ missionsHeading }}
                 </h2>
 
-                <button-group>
+                <div class="missions-toolbar__search">
                     <app-search-bar
                         v-model="search"
                         placeholder="Search by Mission Name"
                     />
+                </div>
 
+                <div class="missions-toolbar__actions">
                     <app-refresh-button @click="refresh" />
                     <UploadMissionFolder :project-uuid="projectUuid">
                         <q-btn
                             flat
-                            style="height: 100%"
+                            style="height: 100%; min-height: 40px"
                             color="icon-secondary"
                             class="button-border"
                             icon="sym_o_drive_folder_upload"
-                        />
+                            aria-label="Create Mission from Folder"
+                        >
+                            <q-tooltip>Create Mission from Folder</q-tooltip>
+                        </q-btn>
                     </UploadMissionFolder>
                     <create-mission-dialog-opener :project-uuid="projectUuid">
-                        <app-create-button label="Create Mission" />
+                        <app-create-button
+                            :label="$q.screen.xs ? 'Create' : 'Create Mission'"
+                            aria-label="Create Mission"
+                        />
                     </create-mission-dialog-opener>
-                </button-group>
+                </div>
             </div>
-            <div v-else class="q-py-lg" style="background: #0f62fe">
-                <ButtonGroupOverlay>
+            <div
+                v-else
+                class="missions-selection"
+                :class="$q.screen.xs ? 'q-py-md' : 'q-py-lg'"
+                style="background: #0f62fe"
+            >
+                <ButtonGroupOverlay class="missions-selection__bar">
                     <template #start>
                         <div style="margin: 0; font-size: 14pt; color: white">
                             {{ selectedMissions.length }}
@@ -158,7 +180,7 @@
                     <template #end>
                         <KleinDownloadMissions
                             :missions="selectedMissions"
-                            style="max-width: 400px"
+                            class="missions-selection__cli"
                         />
                         <q-btn
                             flat
@@ -204,6 +226,7 @@
                             padding="6px"
                             icon="sym_o_close"
                             color="white"
+                            aria-label="Clear selection"
                             @click="deselect"
                         />
                     </template>
@@ -213,14 +236,16 @@
             <div>
                 <Suspense>
                     <template #fallback>
-                        <div style="width: 550px; height: 67px">
+                        <div
+                            style="width: 100%; max-width: 550px; height: 67px"
+                        >
                             <q-skeleton
                                 class="q-mr-md q-mb-sm q-mt-sm"
-                                style="width: 300px; height: 20px"
+                                style="max-width: 300px; height: 20px"
                             />
                             <q-skeleton
                                 class="q-mr-md"
-                                style="width: 200px; height: 18px"
+                                style="max-width: 200px; height: 18px"
                             />
                         </div>
                     </template>
@@ -272,6 +297,17 @@ const { data: project, isLoadingError, error } = useProjectQuery(projectUuid);
 const createAction = ref(false);
 
 registerNoPermissionErrorHandler(isLoadingError, projectUuid, 'project', error);
+
+/**
+ * Repeating a (potentially long) project name in the section heading wastes
+ * the little horizontal space a phone has, the title section right above
+ * already shows it.
+ */
+const missionsHeading = computed(() =>
+    $q.screen.lt.md
+        ? 'Missions'
+        : `All Missions of ${project.value?.name ?? ''}`,
+);
 
 const onClose = (): void => {
     createAction.value = false;
@@ -330,3 +366,92 @@ const copyProjectUuidToClipboard = async (): Promise<void> => {
     await copyToClipboard(projectUuid.value ?? '');
 };
 </script>
+
+<style scoped>
+/*
+ * Desktop keeps the original single row: heading on the left, search and the
+ * action buttons on the right.
+ */
+.missions-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.missions-toolbar__title {
+    margin-right: auto;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.missions-toolbar__actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.missions-selection__cli {
+    max-width: 400px;
+}
+
+/*
+ * Below 1024px the heading, the search field and the buttons each get their
+ * own row and the buttons keep comfortable touch targets.
+ */
+@media (max-width: 1023px) {
+    .missions-toolbar {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .missions-toolbar__title {
+        flex: 1 0 100%;
+        margin-right: 0;
+
+        /* `text-h4` is far too large on a phone; fall back to a h6 scale */
+        font-size: 1.25rem;
+        font-weight: 500;
+        line-height: 1.75rem;
+        letter-spacing: 0.0125em;
+    }
+
+    .missions-toolbar__search {
+        flex: 1 0 100%;
+        min-width: 0;
+    }
+
+    .missions-toolbar__actions {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .missions-toolbar__actions :deep(.q-btn) {
+        min-height: 40px;
+        min-width: 40px;
+    }
+
+    .missions-toolbar__search :deep(.q-field .q-field__control),
+    .missions-toolbar__search :deep(.q-field .q-field__marginal) {
+        height: 40px;
+        min-height: 40px;
+    }
+
+    /*
+     * The selection bar stacks: the counter above the wrapped actions. The
+     * horizontal inset moves from margin/padding-left to symmetric padding so
+     * a full-width row cannot push the page into horizontal scrolling.
+     */
+    .missions-selection__bar :deep(.q-ml-lg),
+    .missions-selection__bar :deep(.q-pr-lg) {
+        flex: 1 0 100%;
+        margin-left: 0;
+        padding-left: 16px;
+        padding-right: 16px;
+    }
+
+    .missions-selection__cli {
+        flex: 1 0 100%;
+        max-width: 100%;
+    }
+}
+</style>

--- a/frontend/src/pages/projects-explorer-page.vue
+++ b/frontend/src/pages/projects-explorer-page.vue
@@ -1,7 +1,7 @@
 <template>
     <title-section title="Projects" />
 
-    <div class="q-my-lg">
+    <div :class="$q.screen.xs ? 'q-my-md' : 'q-my-lg'">
         <project-list-filter-options v-model="myProjects" />
 
         <div style="padding-top: 10px">

--- a/frontend/src/services/decoding-strategies/mcap-strategy.ts
+++ b/frontend/src/services/decoding-strategies/mcap-strategy.ts
@@ -10,11 +10,12 @@ import { coarseToFineOrder, LogMessage, ReadOptions } from './utilities';
 
 /** Identity of a message record, used to drop duplicates from overlapping chunks */
 const messageIdentity = (message: {
+    channelId: number;
     logTime: bigint;
     publishTime: bigint;
     sequence: number;
 }): string =>
-    `${String(message.logTime)}:${String(message.publishTime)}:${String(message.sequence)}`;
+    `${String(message.channelId)}:${String(message.logTime)}:${String(message.publishTime)}:${String(message.sequence)}`;
 
 export class McapStrategy extends DecodingStrategy {
     private reader: McapIndexedReader | null = null;


### PR DESCRIPTION
## Summary
Makes every page usable on phones (< 600px) and tablets (600–1023px) while keeping desktop (≥ 1024px) rendering unchanged.

**Foundation**
- `--page-gutter` CSS variable shared by header, breadcrumbs, title section, footer and page container, so full-bleed sections no longer overflow the viewport on phones.
- Compact header (icon-only menu and create button on phones, full-width upload popup), title-section buttons wrap below the title, tabs and breadcrumbs scroll horizontally, stacked and centered footer.
- Global phone rules: tighter table cells, full-width dialogs, wrapping pagination and chips.

**Pages**
- Projects, missions, mission files, datatable, upload queue, API keys, access groups and members, action executions, triggers, running actions: card lists on phones with a sort control, reduced columns on tablets, stacked toolbars.
- File page: wrapping title, stacked metadata, wrapping CLI command, compact topic table (datatype as caption), full-width message previews.
- Dashboard: panels stack, recent projects become a list, worker rows truncate. Also fixes a bug where the worker icon click passed the mouse event as the worker id.
- Actions: drawers are full-screen overlays on phones, forms single-column, log output scrolls inside its box.
- Login, error, index and landing pages scale down; the login frame had a fixed 556px grid that overflowed phones.
- Shared components: responsive bulk-action bar, 40px touch targets for search, create and refresh, accessible names on icon-only buttons.

**Desktop-visible changes (intentional, minor)**
- Dashboard shows 2 instead of 3 columns between 800 and 1023px.
- Container margin between 600 and 999px is 16px instead of 10px.
- Very long group names in the access-group header now truncate.

## Notes
- `title-section.vue` uses `text-md-h3`, which needs Quasar's `cssAddon` to have any effect. It is not enabled, so the title renders at `text-h5` on desktop today. Left unchanged to avoid a desktop change; worth a separate decision.

## Test plan
- [ ] Open each page at 375px, 768px and 1280px width; no horizontal page scrolling at any width.
- [ ] Project, mission, file and datatable lists: cards on phones, sort control works, selection and bulk actions work, pagination fits.
- [ ] File page: metadata, buttons and CLI box fit; topic table shows expand, topic and count; previews use full width.
- [ ] Upload dialog and other dialogs fill the phone width.
- [ ] Desktop pages look as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXQGxpkpiP2DL3T3cyQDoD