### PR TITLE
feat: allow sorting the projects table by mission count

### DIFF
--- a/backend/src/services/project.service.ts
+++ b/backend/src/services/project.service.ts
@@ -64,6 +64,13 @@ import { ConfigService } from '@nestjs/config';
  */
 const PROJECT_SIZE_SORT_ALIAS = 'project_total_size';
 
+/**
+ * Alias of the computed column holding the number of missions of a project, see
+ * {@link ProjectService._addMissionCountForSorting}. Same reasoning as
+ * {@link PROJECT_SIZE_SORT_ALIAS}.
+ */
+const PROJECT_MISSION_COUNT_SORT_ALIAS = 'project_mission_count';
+
 const FIND_MANY_SORT_KEYS = {
     projectName: 'project.name',
     description: 'project.description',
@@ -73,6 +80,7 @@ const FIND_MANY_SORT_KEYS = {
     creator: 'creator.name',
     rights: 'projectAccessView.rights',
     size: PROJECT_SIZE_SORT_ALIAS,
+    nrOfMissions: PROJECT_MISSION_COUNT_SORT_ALIAS,
 };
 
 @Injectable()
@@ -197,6 +205,32 @@ export class ProjectService {
         );
     }
 
+    /**
+     * Adds the number of (non-deleted) missions of a project as a computed
+     * column, so that the database can sort by it.
+     *
+     * The count is not stored on the project and `_getMissionCounts` only
+     * fetches it for the rows of the current page, which is too late for
+     * sorting.
+     */
+    private _addMissionCountForSorting(
+        query: SelectQueryBuilder<ProjectEntity>,
+    ): SelectQueryBuilder<ProjectEntity> {
+        // Correlated for the same reason as the size aggregate, see
+        // `_addProjectSizeForSorting`.
+        const missionCount = this.projectRepository.manager
+            .createQueryBuilder()
+            .select('COUNT(countMission.uuid)')
+            .from(MissionEntity, 'countMission')
+            .where('"countMission"."projectUuid" = "project"."uuid"')
+            .andWhere('countMission.deletedAt IS NULL');
+
+        return query.addSelect(
+            `(${missionCount.getQuery()})`,
+            PROJECT_MISSION_COUNT_SORT_ALIAS,
+        );
+    }
+
     async findMany(
         projectUuids: string[],
         projectPatterns: string[],
@@ -236,13 +270,18 @@ export class ProjectService {
             query = this._addProjectSizeForSorting(query);
         }
 
+        if (sortBy === 'nrOfMissions') {
+            query = this._addMissionCountForSorting(query);
+        }
+
         if (sortBy !== undefined) {
             query = addSort(query, FIND_MANY_SORT_KEYS, sortBy, sortOrder);
 
             // Stable tie-breaker: rows that compare equal on the sort column
-            // (projects of the same size, most notably the empty ones) would
-            // otherwise be free to swap places between two requests, which
-            // duplicates and drops rows across LIMIT/OFFSET pages.
+            // (projects of the same size or mission count, most notably the
+            // empty ones) would otherwise be free to swap places between two
+            // requests, which duplicates and drops rows across LIMIT/OFFSET
+            // pages.
             query.addOrderBy('project.uuid', 'ASC');
         }
 

--- a/backend/tests/functional/api-query-parameters.test.ts
+++ b/backend/tests/functional/api-query-parameters.test.ts
@@ -225,6 +225,89 @@ describe('Comprehensive API Query Parameters Tests', () => {
         expect(pagedUuids.slice(2)).toEqual([projectUuid, biggerProjectUuid]);
     });
 
+    test('should sort projects by mission count (sortBy=nrOfMissions)', async () => {
+        // The setup project holds a single mission
+        const { user, projectUuid } = await setupTestEnvironment(
+            'proj-missions@kleinkram.dev',
+            'Project Mission Count User',
+        );
+
+        // A second project, holding two missions
+        const busyProjectUuid = await createProjectUsingPost(
+            {
+                name: 'busy_project',
+                description: 'holds two missions',
+                requiredTags: [],
+            },
+            user,
+        );
+        for (const name of ['busy_mission_a', 'busy_mission_b']) {
+            await createMissionUsingPost(
+                {
+                    name,
+                    projectUUID: busyProjectUuid,
+                    tags: {},
+                    ignoreTags: true,
+                },
+                user,
+            );
+        }
+
+        const fetchSorted = async (
+            sortOrder: string,
+            take = 10,
+            skip = 0,
+        ): Promise<{ uuid: string; missionCount: number }[]> => {
+            const response = await fetch(
+                `${DEFAULT_URL}/projects?take=${String(take)}&skip=${String(skip)}&sortBy=nrOfMissions&sortOrder=${sortOrder}`,
+                {
+                    method: 'GET',
+                    headers: getAuthHeaders(user),
+                },
+            );
+            expect(response.status).toBe(200);
+            const json = (await response.json()) as {
+                data: { uuid: string; missionCount: number }[];
+            };
+            return json.data;
+        };
+
+        const ascending = await fetchSorted('asc');
+        expect(ascending.map((project) => project.uuid)).toEqual([
+            projectUuid,
+            busyProjectUuid,
+        ]);
+        expect(ascending.map((project) => project.missionCount)).toEqual([
+            1, 2,
+        ]);
+
+        const descending = await fetchSorted('desc');
+        expect(descending.map((project) => project.uuid)).toEqual([
+            busyProjectUuid,
+            projectUuid,
+        ]);
+        expect(descending.map((project) => project.missionCount)).toEqual([
+            2, 1,
+        ]);
+
+        // Two more projects without any mission, so that half the projects tie
+        // at a count of zero: paging has to stay stable despite the tie.
+        for (const name of ['empty_project_a', 'empty_project_b']) {
+            await createProjectUsingPost(
+                { name, description: 'no missions', requiredTags: [] },
+                user,
+            );
+        }
+
+        const pagedUuids = [
+            ...(await fetchSorted('asc', 2, 0)),
+            ...(await fetchSorted('asc', 2, 2)),
+        ].map((project) => project.uuid);
+        expect(pagedUuids).toHaveLength(4);
+        expect(new Set(pagedUuids).size).toBe(4);
+        expect(pagedUuids.slice(2)).toEqual([projectUuid, busyProjectUuid]);
+    });
+
     test('should support all mission query parameters (take, skip, sortBy, sortDirection, projectUuid, uuid, missionUuids, missionPatterns, minimal)', async () => {
         const { user, projectUuid, missionUuid } = await setupTestEnvironment(
             'mission-params@kleinkram.dev',

--- a/frontend/src/components/explorer-page/explorer-page-table-columns.ts
+++ b/frontend/src/components/explorer-page/explorer-page-table-columns.ts
@@ -79,6 +79,7 @@ export const explorerPageTableColumns: ProjectColumnType[] = [
         style: 'min-width: 100px',
         field: (row: ProjectWithMissionCountDto) => row.missionCount,
         format: (value: number) => value.toString(),
+        sortable: true,
     },
     {
         name: 'size',


### PR DESCRIPTION
Follow-up to #2416, which made the `Size` column of the `/projects` list sortable. The `# Missions` column had the same problem and is now sortable too.

## Why it did not work

A project's mission count is not stored on the project. `ProjectService.findMany` fetched it with `_getMissionCounts`, a separate aggregate query run over the rows of the current page — which is after `LIMIT`/`OFFSET`, and so too late for the database to order by it.

## What changed

- **backend** — `findMany` adds the count as a computed column when `sortBy=nrOfMissions`, and `nrOfMissions` joins the allow-list of sort keys. The subquery is correlated, mirroring `_addProjectSizeForSorting`, so the aggregate is only evaluated for the projects that survive the access constraints and filters, and not at all for the count query. Soft-deleted missions are excluded, matching what `_getMissionCounts` reports in the response.
- **frontend** — the `# Missions` column is marked `sortable`. The existing uuid tie-breaker already keeps paging stable across projects with equal counts.

## Verification

- New functional test `should sort projects by mission count (sortBy=nrOfMissions)`, mirroring the size test: ascending/descending order, the `missionCount` values, and stable paging across a tie at zero.
- Ran the real `ProjectService.findMany` against a seeded postgres to confirm the generated SQL: ordering is correct in both directions, a project whose only mission is soft-deleted sorts as zero, and paging through a three-way tie returned 6 rows with 6 unique uuids (no drops or duplicates).
- `eslint` and `tsc -b` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)